### PR TITLE
[guilib] Added support for defining <width> and <height> in percent

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -208,7 +208,7 @@ bool CGUIControlFactory::GetDimension(const TiXmlNode *pRootNode, const char* st
     if (!min) min = 1;
     return true;
   }
-  value = (float)atof(pNode->FirstChild()->Value());
+  value = ParsePosition(pNode->FirstChild()->Value(), parentSize);
   return true;
 }
 


### PR DESCRIPTION
- This is backport of [13f8d3c](https://github.com/xbmc/xbmc/commit/13f8d3c596278172b9ea869c12a0c4fe22ddfdb8) commit

Now you can define width and height as percent of screen's width and height. Example:

```
<control type="grouplist">
    <description>Group list which width is 120% of screen's width</description>
    <width>120%</width>
   <height>60%</height>
</control>
```