### PR TITLE
[skin] add option to debug skin

### DIFF
--- a/skin/Confluence Lite/skin.xml
+++ b/skin/Confluence Lite/skin.xml
@@ -4,6 +4,7 @@
 	<defaultthemename>Textures.xpr</defaultthemename>
 	<version>2.11</version>
 	<effectslowdown>.75</effectslowdown>
+  <debugging>false</debugging>
 	<credits>
 		<skinname>Confluence Lite</skinname>
 		<name>Confluence skin by Jezz_X, Team XBMC</name>

--- a/xbmc/Application.h
+++ b/xbmc/Application.h
@@ -55,6 +55,7 @@ class CCdgParser;
 class CApplicationMessenger;
 class CProfile;
 class CSplash;
+class CGUITextLayout;
 
 class CApplication : public CXBApplicationEx, public IPlayerCallback, public IMsgTargetCallback
 {
@@ -249,6 +250,8 @@ protected:
   int m_iPlaySpeed;
   int m_currentStackPosition;
   int m_nextPlaylistItem;
+
+  CGUITextLayout *m_debugLayout;
 
   static LONG WINAPI UnhandledExceptionFilter(struct _EXCEPTION_POINTERS *ExceptionInfo);
 

--- a/xbmc/guilib/SkinInfo.cpp
+++ b/xbmc/guilib/SkinInfo.cpp
@@ -38,28 +38,31 @@ CSkinInfo g_SkinInfo; // global
 
 CSkinInfo::CSkinInfo()
 {
-  m_DefaultResolution = PAL_4x3;
-  m_DefaultResolutionWide = INVALID;
-  m_strBaseDir = "";
-  m_iNumCreditLines = 0;
-  m_effectsSlowDown = 1.0f;
-  m_onlyAnimateToHome = true;
-  m_Version = 1.0;
-  m_skinzoom = 1.0f;
-  m_bLegacy = false;
+  SetDefaults();
 }
 
 CSkinInfo::~CSkinInfo()
 {}
 
-void CSkinInfo::Load(const CStdString& strSkinDir, bool loadIncludes)
+void CSkinInfo::SetDefaults()
 {
-  m_strBaseDir = strSkinDir;
+  m_strBaseDir = "";
   m_DefaultResolution = PAL_4x3;
   m_DefaultResolutionWide = INVALID;
   m_effectsSlowDown = 1.0f;
-  m_skinzoom = 1.0f;
   m_Version = 1.0;
+  m_debugging = false;
+  m_onlyAnimateToHome = true;
+  m_iNumCreditLines = 0;
+  m_skinzoom = 1.0f;
+  m_bLegacy = false;
+}
+
+void CSkinInfo::Load(const CStdString& strSkinDir, bool loadIncludes)
+{
+  SetDefaults();
+  m_strBaseDir = strSkinDir;
+
   // Load from skin.xml
   TiXmlDocument xmlDoc;
   CStdString strFile = m_strBaseDir + "\\skin.xml";
@@ -77,6 +80,7 @@ void CSkinInfo::Load(const CStdString& strSkinDir, bool loadIncludes)
 
       XMLUtils::GetDouble(root, "version", m_Version);
       XMLUtils::GetFloat(root, "effectslowdown", m_effectsSlowDown);
+      XMLUtils::GetBoolean(root, "debugging", m_debugging);
       XMLUtils::GetFloat(root, "zoom", m_skinzoom);
 
       // get the legacy parameter to tweak the control behaviour for old skins such as PM3

--- a/xbmc/guilib/SkinInfo.h
+++ b/xbmc/guilib/SkinInfo.h
@@ -65,6 +65,11 @@ public:
   CStdString GetBaseDir() const;
   double GetVersion() const { return m_Version; };
 
+  /*! \brief Return whether skin debugging is enabled
+   \return true if skin debugging (set via <debugging>true</debugging> in skin.xml) is enabled.
+   */
+  bool IsDebugging() const { return m_debugging; };
+
   /*! \brief Get the id of the first window to load
    The first window is generally Startup.xml unless it doesn't exist or if the skinner
    has specified which start windows they support and the user is going to somewhere other
@@ -118,6 +123,7 @@ protected:
    */
   CStdString GetDirFromRes(RESOLUTION res) const;
 
+  void SetDefaults();
   void LoadIncludes();
   bool LoadStartupWindows(const TiXmlElement *startup);
   bool IsWide(RESOLUTION res) const;
@@ -134,6 +140,7 @@ protected:
 
   std::vector<CStartupWindow> m_startupWindows;
   bool m_onlyAnimateToHome;
+  bool m_debugging;
 
   float m_skinzoom;
 


### PR DESCRIPTION
This PR adds option to render skin debug info when Debugging is enabled. If enabled you will see:

- Currently opened Window and XML file for that Window
- Name and ID of current focused control
- Coordinates of mouse pointer location

Skinners can toggle this debug info by adding code down below to skin.xml:
`<debugging>true|false</debugging>`