### PR TITLE
[GUISliderControl] support for range selection / seeking wasn't working in video player

### DIFF
--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -792,6 +792,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
 
   CStdString altLabel;
   CStdString strLabel2;
+  CStdString action;
 
   int focusPosition = 0;
   int scrollTime = 200;
@@ -1111,6 +1112,8 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
   GetString(pControlNode, "scrollsuffix", labelInfo.scrollSuffix);
   spinInfo.scrollSuffix = labelInfo.scrollSuffix;
 
+  XMLUtils::GetString(pControlNode, "action", action);
+
   /////////////////////////////////////////////////////////////////////////////
   // Instantiate a new control using the properties gathered above
   //
@@ -1294,6 +1297,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
       textureBar, textureNib, textureNibFocus, SPIN_CONTROL_TYPE_TEXT, orientation);
 
     ((CGUISliderControl *)control)->SetInfo(singleInfo);
+    ((CGUISliderControl *)control)->SetAction(action);
   }
   else if (type == CGUIControl::GUICONTROL_SETTINGS_SLIDER)
   {

--- a/xbmc/guilib/GUISliderControl.cpp
+++ b/xbmc/guilib/GUISliderControl.cpp
@@ -32,19 +32,26 @@ static const SliderAction actions[] = {
 CGUISliderControl::CGUISliderControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& backGroundTexture, const CTextureInfo& nibTexture, const CTextureInfo& nibTextureFocus, int iType, ORIENTATION orientation)
     : CGUIControl(parentID, controlID, posX, posY, width, height)
     , m_guiBackground(posX, posY, width, height, backGroundTexture)
-    , m_guiMid(posX, posY, width, height, nibTexture)
-    , m_guiMidFocus(posX, posY, width, height, nibTextureFocus)
+    , m_guiSelectorLower(posX, posY, width, height, nibTexture)
+    , m_guiSelectorUpper(posX, posY, width, height, nibTexture)
+    , m_guiSelectorLowerFocus(posX, posY, width, height, nibTextureFocus)
+    , m_guiSelectorUpperFocus(posX, posY, width, height, nibTextureFocus)
 {
   m_iType = iType;
-  m_iPercent = 0;
+  m_rangeSelection = false;
+  m_currentSelector = RangeSelectorLower; // use lower selector by default
+  m_iPercent[0] = 0;
+  m_iPercent[1] = 100;
   m_iStart = 0;
   m_iEnd = 100;
   m_iInterval = 1;
   m_fStart = 0.0f;
   m_fEnd = 1.0f;
   m_fInterval = 0.1f;
-  m_iValue = 0;
-  m_fValue = 0.0;
+  m_iValue[0] = m_iStart;
+  m_iValue[1] = m_iEnd;
+  m_fValue[0] = m_fStart;
+  m_fValue[1] = m_fEnd;
   ControlType = GUICONTROL_SLIDER;
   m_orientation = orientation;
   m_iInfoCode = 0;
@@ -63,23 +70,37 @@ void CGUISliderControl::Render()
   if (m_action && (!m_dragging || m_action->fireOnDrag))
     infoCode = m_action->infoCode;
   if (infoCode)
-    SetIntValue(g_infoManager.GetInt(infoCode));
+  {
+    int val = g_infoManager.GetInt(infoCode);
+    if (val)
+      SetIntValue(val);
+  }
+
+  float fScale;
+  if (m_orientation == HORIZONTAL)
+    fScale = m_height == 0 ? 1.0f : m_height / m_guiBackground.GetTextureHeight();
+  else
+    fScale = m_width == 0 ? 1.0f : m_width / m_guiBackground.GetTextureWidth();
 
   m_guiBackground.SetHeight(m_height);
   m_guiBackground.SetWidth(m_width);
   m_guiBackground.Render();
 
+  CGUITexture &nibLower = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorLower) ? m_guiSelectorLowerFocus : m_guiSelectorLower;
+  RenderSelector(nibLower, fScale, RangeSelectorLower);
+  if (m_rangeSelection)
+  {
+    CGUITexture &nibUpper = (m_bHasFocus && !IsDisabled() && m_currentSelector == RangeSelectorUpper) ? m_guiSelectorUpperFocus : m_guiSelectorUpper;
+    RenderSelector(nibUpper, fScale, RangeSelectorUpper);
+  }
+
+  CGUIControl::Render();
+}
+
+void CGUISliderControl::RenderSelector(CGUITexture &nib, float fScale, RangeSelector selector)
+{
   // we render the nib centered at the appropriate percentage, except where the nib
   // would overflow the background image
-  CGUITexture &nib = (m_bHasFocus && !IsDisabled()) ? m_guiMidFocus : m_guiMid;
-
-  float fScale = 1.0f;
-
-  if (m_orientation == HORIZONTAL && m_guiBackground.GetTextureHeight() != 0)
-    fScale = m_height / m_guiBackground.GetTextureHeight();
-  else if (m_width != 0 && nib.GetTextureWidth() != 0)
-    fScale = m_width / nib.GetTextureWidth();
-  
   if (m_orientation == HORIZONTAL)
   {
     nib.SetHeight(nib.GetTextureHeight() * fScale);
@@ -90,14 +111,15 @@ void CGUISliderControl::Render()
     nib.SetWidth(nib.GetTextureWidth() * fScale);
     nib.SetHeight(nib.GetWidth() * 2);
   }
-  CAspectRatio ratio(CAspectRatio::AR_KEEP); ratio.align = ASPECT_ALIGN_LEFT | ASPECT_ALIGNY_CENTER;
+  CAspectRatio ratio(CAspectRatio::AR_KEEP);
+  ratio.align = ASPECT_ALIGN_LEFT | ASPECT_ALIGNY_CENTER;
   nib.SetAspectRatio(ratio);
   CRect rect = nib.GetRenderRect();
 
   float offset;
   if (m_orientation == HORIZONTAL)
   {
-    offset = GetProportion() * m_width - rect.Width() / 2;
+    offset = GetProportion(selector) * m_width - rect.Width() / 2;
     if (offset > m_width - rect.Width())
       offset = m_width - rect.Width();
     if (offset < 0)
@@ -106,7 +128,7 @@ void CGUISliderControl::Render()
   }
   else
   {
-    offset = GetProportion() * m_height - rect.Height() / 2;
+    offset = GetProportion(selector) * m_height - rect.Height() / 2;
     if (offset > m_height - rect.Height())
       offset = m_height - rect.Height();
     if (offset < 0)
@@ -114,8 +136,6 @@ void CGUISliderControl::Render()
     nib.SetPosition(m_guiBackground.GetXPosition(), m_guiBackground.GetYPosition() + m_guiBackground.GetHeight() - offset - ((nib.GetHeight() - rect.Height()) / 2 + rect.Height()));
   }
   nib.Render();
-
-  CGUIControl::Render();
 }
 
 bool CGUISliderControl::OnMessage(CGUIMessage& message)
@@ -131,7 +151,8 @@ bool CGUISliderControl::OnMessage(CGUIMessage& message)
 
     case GUI_MSG_LABEL_RESET:
       {
-        SetPercentage(0);
+        SetPercentage(0, RangeSelectorLower);
+        SetPercentage(100, RangeSelectorUpper);
         return true;
       }
       break;
@@ -146,7 +167,6 @@ bool CGUISliderControl::OnAction(const CAction &action)
   switch ( action.GetID() )
   {
   case ACTION_MOVE_LEFT:
-    //case ACTION_OSD_SHOW_VALUE_MIN:
     if (m_orientation == HORIZONTAL)
     {
       Move(-1);
@@ -155,7 +175,6 @@ bool CGUISliderControl::OnAction(const CAction &action)
     break;
 
   case ACTION_MOVE_RIGHT:
-    //case ACTION_OSD_SHOW_VALUE_PLUS:
     if (m_orientation == HORIZONTAL)
     {
       Move(1);
@@ -178,6 +197,12 @@ bool CGUISliderControl::OnAction(const CAction &action)
       return true;
     }
     break;
+
+  case ACTION_SELECT_ITEM:
+    // switch between the two sliders
+    SwitchRangeSelector();
+    return true;
+
   default:
     break;
   }
@@ -186,26 +211,62 @@ bool CGUISliderControl::OnAction(const CAction &action)
 
 void CGUISliderControl::Move(int iNumSteps)
 {
+  bool rangeSwap = false;
+
   switch (m_iType)
   {
   case SPIN_CONTROL_TYPE_FLOAT:
-    m_fValue += m_fInterval * iNumSteps;
-    if (m_fValue < m_fStart) m_fValue = m_fStart;
-    if (m_fValue > m_fEnd) m_fValue = m_fEnd;
-    break;
+    {
+      float &value = m_fValue[m_currentSelector];
+      value += m_fInterval * iNumSteps;
+      if (value < m_fStart) value = m_fStart;
+      if (value > m_fEnd) value = m_fEnd;
+      if (m_fValue[0] > m_fValue[1])
+      {
+        float valueLower = m_fValue[0];
+        m_fValue[0] = m_fValue[1];
+        m_fValue[1] = valueLower;
+        rangeSwap = true;
+      }
+      break;
+    }
 
   case SPIN_CONTROL_TYPE_INT:
-    m_iValue += iNumSteps;
-    if (m_iValue < m_iStart) m_iValue = m_iStart;
-    if (m_iValue > m_iEnd) m_iValue = m_iEnd;
-    break;
+    {
+      int &value = m_iValue[m_currentSelector];
+      value += m_iInterval * iNumSteps;
+      if (value < m_iStart) value = m_iStart;
+      if (value > m_iEnd) value = m_iEnd;
+      if (m_iValue[0] > m_iValue[1])
+      {
+        int valueLower = m_iValue[0];
+        m_iValue[0] = m_iValue[1];
+        m_iValue[1] = valueLower;
+        rangeSwap = true;
+      }
+      break;
+    }
 
   default:
-    m_iPercent += iNumSteps;
-    if (m_iPercent < 0) m_iPercent = 0;
-    if (m_iPercent > 100) m_iPercent = 100;
-    break;
+    {
+      int &value = m_iPercent[m_currentSelector];
+      value += m_iInterval * iNumSteps;
+      if (value < 0) value = 0;
+      if (value > 100) value = 100;
+      if (m_iPercent[0] > m_iPercent[1])
+      {
+        int valueLower = m_iPercent[0];
+        m_iPercent[0] = m_iPercent[1];
+        m_iPercent[1] = valueLower;
+        rangeSwap = true;
+      }
+      break;
+    }
   }
+
+  if (rangeSwap)
+    SwitchRangeSelector();
+
   SendClick();
 }
 
@@ -223,56 +284,130 @@ void CGUISliderControl::SendClick()
   }
 }
 
-void CGUISliderControl::SetPercentage(int iPercent)
+void CGUISliderControl::SetRangeSelection(bool rangeSelection)
+{
+  if (m_rangeSelection == rangeSelection)
+    return;
+
+  m_rangeSelection = rangeSelection;
+  SetRangeSelector(RangeSelectorLower);
+  SetInvalid();
+}
+
+void CGUISliderControl::SetRangeSelector(RangeSelector selector)
+{
+  if (m_currentSelector == selector)
+    return;
+
+  m_currentSelector = selector;
+  SetInvalid();
+}
+
+void CGUISliderControl::SwitchRangeSelector()
+{
+  if (m_currentSelector == RangeSelectorLower)
+    SetRangeSelector(RangeSelectorUpper);
+  else
+    SetRangeSelector(RangeSelectorLower);
+}
+
+void CGUISliderControl::SetPercentage(int iPercent, RangeSelector selector /* = RangeSelectorLower */)
 {
   if (iPercent > 100) iPercent = 100;
-  if (iPercent < 0) iPercent = 0;
-  m_iPercent = iPercent;
+  else if (iPercent < 0) iPercent = 0;
+
+  int iPercentLower = selector == RangeSelectorLower ? iPercent : m_iPercent[0];
+  int iPercentUpper = selector == RangeSelectorUpper ? iPercent : m_iPercent[1];
+
+  if (!m_rangeSelection || iPercentLower <= iPercentUpper)
+  {
+    m_iPercent[0] = iPercentLower;
+    m_iPercent[1] = iPercentUpper;
+  }
+  else
+  {
+    m_iPercent[0] = iPercentUpper;
+    m_iPercent[1] = iPercentLower;
+  }
 }
 
-int CGUISliderControl::GetPercentage() const
+int CGUISliderControl::GetPercentage(RangeSelector selector /* = RangeSelectorLower */) const
 {
-  return m_iPercent;
+  return m_iPercent[selector];
 }
 
-void CGUISliderControl::SetIntValue(int iValue)
+void CGUISliderControl::SetIntValue(int iValue, RangeSelector selector /* = RangeSelectorLower */)
 {
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    m_fValue = (float)iValue;
+    SetFloatValue((float)iValue);
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    m_iValue = iValue;
+  {
+    if (iValue > m_iEnd) iValue = m_iEnd;
+    else if (iValue < m_iStart) iValue = m_iStart;
+
+    int iValueLower = selector == RangeSelectorLower ? iValue : m_iValue[0];
+    int iValueUpper = selector == RangeSelectorUpper ? iValue : m_iValue[1];
+
+    if (!m_rangeSelection || iValueLower <= iValueUpper)
+    {
+      m_iValue[0] = iValueLower;
+      m_iValue[1] = iValueUpper;
+    }
+    else
+    {
+      m_iValue[0] = iValueUpper;
+      m_iValue[1] = iValueLower;
+    }
+  }
   else
     SetPercentage(iValue);
 }
 
-int CGUISliderControl::GetIntValue() const
+int CGUISliderControl::GetIntValue(RangeSelector selector /* = RangeSelectorLower */) const
 {
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    return (int)m_fValue;
+    return (int)m_fValue[selector];
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    return m_iValue;
+    return m_iValue[selector];
   else
-    return m_iPercent;
+    return m_iPercent[selector];
 }
 
-void CGUISliderControl::SetFloatValue(float fValue)
+void CGUISliderControl::SetFloatValue(float fValue, RangeSelector selector /* = RangeSelectorLower */)
 {
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    m_fValue = fValue;
+  {
+    if (fValue > m_fEnd) fValue = m_fEnd;
+    else if (fValue < m_fStart) fValue = m_fStart;
+
+    float fValueLower = selector == RangeSelectorLower ? fValue : m_fValue[0];
+    float fValueUpper = selector == RangeSelectorUpper ? fValue : m_fValue[1];
+
+    if (!m_rangeSelection || fValueLower <= fValueUpper)
+    {
+      m_fValue[0] = fValueLower;
+      m_fValue[1] = fValueUpper;
+    }
+    else
+    {
+      m_fValue[0] = fValueUpper;
+      m_fValue[1] = fValueLower;
+    }
+  }
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    m_iValue = (int)fValue;
+    SetIntValue((int)fValue);
   else
     SetPercentage((int)fValue);
 }
 
-float CGUISliderControl::GetFloatValue() const
+float CGUISliderControl::GetFloatValue(RangeSelector selector /* = RangeSelectorLower */) const
 {
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    return m_fValue;
+    return m_fValue[selector];
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    return (float)m_iValue;
+    return (float)m_iValue[selector];
   else
-    return (float)m_iPercent;
+    return (float)m_iPercent[selector];
 }
 
 void CGUISliderControl::SetIntInterval(int iInterval)
@@ -297,8 +432,8 @@ void CGUISliderControl::SetRange(int iStart, int iEnd)
     SetFloatRange((float)iStart,(float)iEnd);
   else
   {
-    m_iStart = iStart;
-    m_iEnd = iEnd;
+    m_iValue[0] = m_iStart = iStart;
+    m_iValue[1] = m_iEnd = iEnd;
   }
 }
 
@@ -308,8 +443,8 @@ void CGUISliderControl::SetFloatRange(float fStart, float fEnd)
     SetRange((int)fStart, (int)fEnd);
   else
   {
-    m_fStart = fStart;
-    m_fEnd = fEnd;
+    m_fValue[0] = m_fStart = fStart;
+    m_fValue[1] = m_fEnd = fEnd;
   }
 }
 
@@ -317,38 +452,47 @@ void CGUISliderControl::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
   m_guiBackground.FreeResources(immediately);
-  m_guiMid.FreeResources(immediately);
-  m_guiMidFocus.FreeResources(immediately);
+  m_guiSelectorLower.FreeResources(immediately);
+  m_guiSelectorUpper.FreeResources(immediately);
+  m_guiSelectorLowerFocus.FreeResources(immediately);
+  m_guiSelectorUpperFocus.FreeResources(immediately);
 }
 
 void CGUISliderControl::DynamicResourceAlloc(bool bOnOff)
 {
   CGUIControl::DynamicResourceAlloc(bOnOff);
   m_guiBackground.DynamicResourceAlloc(bOnOff);
-  m_guiMid.DynamicResourceAlloc(bOnOff);
-  m_guiMidFocus.DynamicResourceAlloc(bOnOff);
+  m_guiSelectorLower.DynamicResourceAlloc(bOnOff);
+  m_guiSelectorUpper.DynamicResourceAlloc(bOnOff);
+  m_guiSelectorLowerFocus.DynamicResourceAlloc(bOnOff);
+  m_guiSelectorUpperFocus.DynamicResourceAlloc(bOnOff);
 }
 
 void CGUISliderControl::PreAllocResources()
 {
   CGUIControl::PreAllocResources();
   m_guiBackground.PreAllocResources();
-  m_guiMid.PreAllocResources();
-  m_guiMidFocus.PreAllocResources();
+  m_guiSelectorLower.PreAllocResources();
+  m_guiSelectorUpper.PreAllocResources();
+  m_guiSelectorLowerFocus.PreAllocResources();
+  m_guiSelectorUpperFocus.PreAllocResources();
 }
 
 void CGUISliderControl::AllocResources()
 {
   CGUIControl::AllocResources();
   m_guiBackground.AllocResources();
-  m_guiMid.AllocResources();
-  m_guiMidFocus.AllocResources();
+  m_guiSelectorLower.AllocResources();
+  m_guiSelectorUpper.AllocResources();
+  m_guiSelectorLowerFocus.AllocResources();
+  m_guiSelectorUpperFocus.AllocResources();
 }
 
 bool CGUISliderControl::HitTest(const CPoint &point) const
 {
   if (m_guiBackground.HitTest(point)) return true;
-  if (m_guiMid.HitTest(point)) return true;
+  if (m_guiSelectorLower.HitTest(point)) return true;
+  if (m_rangeSelection && m_guiSelectorUpper.HitTest(point)) return true;
   return false;
 }
 
@@ -361,27 +505,49 @@ void CGUISliderControl::SetFromPosition(const CPoint &point)
     fPercent = (point.y - m_guiBackground.GetYPosition()) / m_guiBackground.GetHeight();
   if (fPercent < 0) fPercent = 0;
   if (fPercent > 1) fPercent = 1;
+
+  RangeSelector selector = RangeSelectorLower;
   switch (m_iType)
   {
   case SPIN_CONTROL_TYPE_FLOAT:
-    m_fValue = m_fStart + (m_fEnd - m_fStart) * fPercent;
-    break;
+    {
+      float fValue = m_fStart + (m_fEnd - m_fStart) * fPercent;
+      if (m_rangeSelection && fValue >= m_fValue[1])
+        selector = RangeSelectorUpper;
+
+      SetFloatValue(fValue, selector);
+      break;
+    }
 
   case SPIN_CONTROL_TYPE_INT:
-    m_iValue = (int)(m_iStart + (float)(m_iEnd - m_iStart) * fPercent + 0.49f);
-    break;
+    {
+      int iValue = (int)(m_iStart + (float)(m_iEnd - m_iStart) * fPercent + 0.49f);
+      if (m_rangeSelection && iValue >= m_iValue[1])
+        selector = RangeSelectorUpper;
+
+      SetIntValue(iValue, selector);
+      break;
+    }
 
   default:
-    m_iPercent = (int)(fPercent * 100 + 0.49f);
-    break;
+    {
+      int iValue = (int)(fPercent * 100 + 0.49f);
+      if (m_rangeSelection && iValue >= m_iPercent[1])
+        selector = RangeSelectorUpper;
+
+      SetPercentage(iValue, selector);
+      break;
+    }
   }
   SendClick();
 }
 
 bool CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEvent &event)
 {
+  m_dragging = false;
   if (event.m_id == ACTION_MOUSE_DRAG)
   {
+    m_dragging = true;
     if (event.m_state == 1)
     { // grab exclusive access
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, GetID(), GetParentID());
@@ -389,6 +555,7 @@ bool CGUISliderControl::OnMouseEvent(const CPoint &point, const CMouseEvent &eve
     }
     else if (event.m_state == 3)
     { // release exclusive access
+      m_dragging = false;
       CGUIMessage msg(GUI_MSG_EXCLUSIVE_MOUSE, 0, GetParentID());
       SendWindowMessage(msg);
     }
@@ -424,11 +591,26 @@ CStdString CGUISliderControl::GetDescription() const
     return m_textValue;
   CStdString description;
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    description.Format("%2.2f", m_fValue);
+  {
+    if (m_rangeSelection)
+      description.Format("[%2.2f, %2.2f]", m_fValue[0], m_fValue[1]);
+    else
+      description.Format("%2.2f", m_fValue[0]);
+  }
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    description.Format("%i", m_iValue);
+  {
+    if (m_rangeSelection)
+      description.Format("[%i, %i]", m_iValue[0], m_iValue[1]);
+    else
+      description.Format("%i", m_iValue);
+  }
   else
-    description.Format("%i%%", m_iPercent);
+  {
+    if (m_rangeSelection)
+      description.Format("[%i%%, %i%%]", m_iPercent[0], m_iPercent[1]);
+    else
+      description.Format("%i%%", m_iPercent[0]);
+  }
   return description;
 }
 
@@ -436,17 +618,19 @@ void CGUISliderControl::UpdateColors()
 {
   CGUIControl::UpdateColors();
   m_guiBackground.SetDiffuseColor(m_diffuseColor);
-  m_guiMid.SetDiffuseColor(m_diffuseColor);
-  m_guiMidFocus.SetDiffuseColor(m_diffuseColor);
+  m_guiSelectorLower.SetDiffuseColor(m_diffuseColor);
+  m_guiSelectorUpper.SetDiffuseColor(m_diffuseColor);
+  m_guiSelectorLowerFocus.SetDiffuseColor(m_diffuseColor);
+  m_guiSelectorUpperFocus.SetDiffuseColor(m_diffuseColor);
 }
 
-float CGUISliderControl::GetProportion() const
+float CGUISliderControl::GetProportion(RangeSelector selector /* = RangeSelectorLower */) const
 {
   if (m_iType == SPIN_CONTROL_TYPE_FLOAT)
-    return (m_fValue - m_fStart) / (m_fEnd - m_fStart);
+    return (GetFloatValue(selector) - m_fStart) / (m_fEnd - m_fStart);
   else if (m_iType == SPIN_CONTROL_TYPE_INT)
-    return (float)(m_iValue - m_iStart) / (float)(m_iEnd - m_iStart);
-  return 0.01f * m_iPercent;
+    return (float)(GetIntValue(selector) - m_iStart) / (float)(m_iEnd - m_iStart);
+  return 0.01f * GetPercentage(selector);
 }
 
 void CGUISliderControl::SetAction(const CStdString &action)

--- a/xbmc/guilib/GUISliderControl.h
+++ b/xbmc/guilib/GUISliderControl.h
@@ -51,6 +51,11 @@ class CGUISliderControl :
       public CGUIControl
 {
 public:
+  typedef enum {
+    RangeSelectorLower = 0,
+    RangeSelectorUpper = 1
+  } RangeSelector;
+
   CGUISliderControl(int parentID, int controlID, float posX, float posY, float width, float height, const CTextureInfo& backGroundTexture, const CTextureInfo& mibTexture, const CTextureInfo& nibTextureFocus, int iType, ORIENTATION orientation);
   virtual ~CGUISliderControl(void);
   virtual CGUISliderControl *Clone() const { return new CGUISliderControl(*this); };
@@ -64,13 +69,17 @@ public:
   virtual void SetRange(int iStart, int iEnd);
   virtual void SetFloatRange(float fStart, float fEnd);
   virtual bool OnMessage(CGUIMessage& message);
+  void RenderSelector(CGUITexture &nib, float fScale, RangeSelector selector);
+  void SetRangeSelection(bool rangeSelection);
+  void SetRangeSelector(RangeSelector selector);
+  void SwitchRangeSelector();
   void SetInfo(int iInfo);
-  void SetPercentage(int iPercent);
-  int GetPercentage() const;
-  void SetIntValue(int iValue);
-  int GetIntValue() const;
-  void SetFloatValue(float fValue);
-  float GetFloatValue() const;
+  void SetPercentage(int iPercent, RangeSelector selector = RangeSelectorLower);
+  int GetPercentage(RangeSelector selector = RangeSelectorLower) const;
+  void SetIntValue(int iValue, RangeSelector selector = RangeSelectorLower);
+  int GetIntValue(RangeSelector selector = RangeSelectorLower) const;
+  void SetFloatValue(float fValue, RangeSelector selector = RangeSelectorLower);
+  float GetFloatValue(RangeSelector selector = RangeSelectorLower) const;
   void SetIntInterval(int iInterval);
   void SetFloatInterval(float fInterval);
   void SetType(int iType) { m_iType = iType; };
@@ -86,25 +95,30 @@ protected:
   /*! \brief Get the current position of the slider as a proportion
    \return slider position in the range [0,1]
    */
-  float GetProportion() const;
+  float GetProportion(RangeSelector selector = RangeSelectorLower) const;
 
   /*! \brief Send a click message (and/or action) to the app in response to a slider move
    */
   void SendClick();
 
   CGUITexture m_guiBackground;
-  CGUITexture m_guiMid;
-  CGUITexture m_guiMidFocus;
+  CGUITexture m_guiSelectorLower;
+  CGUITexture m_guiSelectorUpper;
+  CGUITexture m_guiSelectorLowerFocus;
+  CGUITexture m_guiSelectorUpperFocus;
   int m_iType;
 
-  int m_iPercent;
+  bool m_rangeSelection;
+  RangeSelector m_currentSelector;
 
-  int m_iValue;
+  int m_iPercent[2];
+
+  int m_iValue[2];
   int m_iStart;
   int m_iInterval;
   int m_iEnd;
 
-  float m_fValue;
+  float m_fValue[2];
   float m_fStart;
   float m_fInterval;
   float m_fEnd;

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -593,6 +593,25 @@ int CBuiltins::Execute(const CStdString& execString)
       if (g_application.IsPlaying())
         g_application.m_pPlayer->Seek(true, false);
     }
+    else if (parameter.Left(14).Equals("seekpercentage"))
+    {
+      CStdString offset = "";
+      float offsetpercent;
+      if (parameter.size() == 14)
+        CLog::Log(LOGERROR,"PlayerControl(seekpercentage(n)) called with no argument");
+      else if (parameter.size() < 17) // arg must be at least "(N)"
+        CLog::Log(LOGERROR,"PlayerControl(seekpercentage(n)) called with invalid argument: \"%s\"", parameter.Mid(14).c_str());
+      else
+      {
+        // Don't bother checking the argument: an invalid arg will do seek(0)
+        offset = parameter.Mid(15).TrimRight(")");
+        offsetpercent = (float) atof(offset.c_str());
+        if (offsetpercent < 0 || offsetpercent > 100)
+          CLog::Log(LOGERROR,"PlayerControl(seekpercentage(n)) argument, %f, must be 0-100", offsetpercent);
+        else if (g_application.IsPlaying())
+          g_application.SeekPercentage(offsetpercent);
+      }
+    }
     else if( parameter.Equals("showvideomenu") )
     {
       if( g_application.IsPlaying() && g_application.m_pPlayer )


### PR DESCRIPTION
This PR adds support for Range Selection on Slider control. It's somehow part of [#1399](https://github.com/xbmc/xbmc/pull/1399)

Using slider control to seek video playback wasn't working and it's fixed in this PR.