### PR TITLE
Keep GUIControls alive after window deinit #1283

### DIFF
--- a/skin/Confluence Lite/720p/DialogSelect.xml
+++ b/skin/Confluence Lite/720p/DialogSelect.xml
@@ -207,6 +207,100 @@
 				</control>
 			</focusedlayout>
 		</control>
+	  <control type="list" id="6">
+			<posx>20</posx>
+			<posy>60</posy>
+			<width>550</width>
+			<height>520</height>
+			<onup>6</onup>
+			<ondown>6</ondown>
+			<onleft>5</onleft>
+			<onright>61</onright>
+			<pagecontrol>61</pagecontrol>
+			<scrolltime>200</scrolltime>
+			<itemlayout height="40" width="550">
+				<control type="image">
+					<posx>0</posx>
+					<posy>0</posy>
+					<width>550</width>
+					<height>41</height>
+					<texture border="0,2,0,2">MenuItemNF.png</texture>
+				</control>
+				<control type="image">
+					<posx>0</posx>
+					<posy>2</posy>
+					<width>40</width>
+					<height>36</height>
+					<texture>$INFO[Listitem.Icon]</texture>
+					<bordertexture border="3">black-back2.png</bordertexture>
+					<bordersize>2</bordersize>
+				</control>
+				<control type="label">
+					<posx>45</posx>
+					<posy>0</posy>
+					<width>485</width>
+					<height>40</height>
+					<font>font13</font>
+					<textcolor>grey2</textcolor>
+					<selectedcolor>selected</selectedcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>$INFO[ListItem.Label]</label>
+				</control>
+			</itemlayout>
+			<focusedlayout height="80" width="550">
+				<control type="image">
+					<posx>0</posx>
+					<posy>0</posy>
+					<width>550</width>
+					<height>81</height>
+					<texture border="0,2,0,2">MenuItemNF.png</texture>
+					<visible>!Control.HasFocus(6)</visible>
+					<include>VisibleFadeEffect</include>
+				</control>
+				<control type="image">
+					<posx>0</posx>
+					<posy>0</posy>
+					<width>550</width>
+					<height>81</height>
+					<texture border="0,2,0,2">MenuItemFO.png</texture>
+					<visible>Control.HasFocus(6)</visible>
+					<include>VisibleFadeEffect</include>
+				</control>
+				<control type="image">
+					<posx>0</posx>
+					<posy>2</posy>
+					<width>120</width>
+					<height>76</height>
+					<texture>$INFO[Listitem.Icon]</texture>
+					<bordertexture border="3">black-back2.png</bordertexture>
+					<bordersize>2</bordersize>
+				</control>
+				<control type="label">
+					<posx>130</posx>
+					<posy>0</posy>
+					<width>410</width>
+					<height>30</height>
+					<font>font13</font>
+					<textcolor>white</textcolor>
+					<selectedcolor>selected</selectedcolor>
+					<align>left</align>
+					<aligny>center</aligny>
+					<label>[B]$INFO[ListItem.Label][/B]</label>
+				</control>
+				<control type="textbox">
+					<posx>130</posx>
+					<posy>30</posy>
+					<width>410</width>
+					<height>50</height>
+					<font>font12</font>
+					<textcolor>grey</textcolor>
+					<selectedcolor>selected</selectedcolor>
+					<align>left</align>
+					<label>$INFO[ListItem.Label2]</label>
+				</control>
+			</focusedlayout>
+		</control>
 		<control type="scrollbar" id="61">
 			<posx>570</posx>
 			<posy>65</posy>

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -736,6 +736,7 @@ HRESULT CApplication::Create(HWND hWnd)
       wrmsr
     }
     m_128MBHack = true;
+    g_advancedSettings.m_guiKeepInMemory = true;
   }
 #endif
 

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -2134,6 +2134,7 @@ bool CApplication::LoadUserWindows()
         continue;
       }
       pWindow->SetVisibleCondition(visibleCondition, false);
+      pWindow->SetLoadType(CGUIWindow::KEEP_IN_MEMORY);
       g_windowManager.AddCustomWindow(pWindow);
     }
     CloseHandle(hFind);

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -4677,3 +4677,13 @@ CStdString CGUIInfoManager::GetSkinVariableString(int info,
 
   return "";
 }
+
+bool CGUIInfoManager::ConditionsChangedValues(const std::map<int, bool>& map)
+{
+  for (std::map<int, bool>::const_iterator it = map.begin() ; it != map.end() ; it++)
+  {
+    if (GetBoolValue(it->first) != it->second)
+      return true;
+  }
+  return false;
+}

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -710,6 +710,9 @@ public:
   int RegisterSkinVariableString(const INFO::CSkinVariableString* info);
   int TranslateSkinVariableString(const CStdString& name, int context);
   CStdString GetSkinVariableString(int info, bool preferImage = false, const CGUIListItem *item=NULL);
+
+  /// \brief iterates through boolean conditions and compares their stored values to current values. Returns true if any condition changed value.
+  bool ConditionsChangedValues(const std::map<int, bool>& map);
 protected:
   // routines for window retrieval
   bool CheckWindowCondition(CGUIWindow *window, int condition) const;

--- a/xbmc/GUIWindowMusicOverlay.cpp
+++ b/xbmc/GUIWindowMusicOverlay.cpp
@@ -29,6 +29,7 @@ CGUIWindowMusicOverlay::CGUIWindowMusicOverlay()
 {
   m_renderOrder = 0;
   m_visibleCondition = SKIN_HAS_MUSIC_OVERLAY;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowMusicOverlay::~CGUIWindowMusicOverlay()

--- a/xbmc/GUIWindowOSD.cpp
+++ b/xbmc/GUIWindowOSD.cpp
@@ -26,6 +26,7 @@
 CGUIWindowOSD::CGUIWindowOSD(void)
     : CGUIDialog(WINDOW_OSD, "VideoOSD.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowOSD::~CGUIWindowOSD(void)

--- a/xbmc/GUIWindowVideoOverlay.cpp
+++ b/xbmc/GUIWindowVideoOverlay.cpp
@@ -36,6 +36,7 @@ CGUIWindowVideoOverlay::CGUIWindowVideoOverlay()
 {
   m_renderOrder = 0;
   m_visibleCondition = SKIN_HAS_VIDEO_OVERLAY;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowVideoOverlay::~CGUIWindowVideoOverlay()

--- a/xbmc/dialogs/GUIDialogBoxBase.cpp
+++ b/xbmc/dialogs/GUIDialogBoxBase.cpp
@@ -18,16 +18,22 @@
  *
  */
 
+#include "Application.h"
 #include "dialogs/GUIDialogBoxBase.h"
 #include "GUIWindowManager.h"
 #include "LocalizeStrings.h"
 
 using namespace std;
 
+#define CONTROL_HEADING 1
+#define CONTROL_LINES_START 2
+#define CONTROL_CHOICES_START 10
+
 CGUIDialogBoxBase::CGUIDialogBoxBase(int id, const CStdString &xmlFile)
     : CGUIDialog(id, xmlFile)
 {
   m_bConfirmed = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogBoxBase::~CGUIDialogBoxBase(void)
@@ -56,45 +62,56 @@ bool CGUIDialogBoxBase::IsConfirmed() const
 
 void CGUIDialogBoxBase::SetHeading(const CVariant& heading)
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), 1);
-  msg.SetLabel(GetLocalized(heading));
-
-  if(OwningCriticalSection(g_graphicsContext))
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strHeading = GetLocalized(heading);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(1, m_strHeading);
 }
 
 void CGUIDialogBoxBase::SetLine(int iLine, const CVariant& line)
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), iLine + 2);
-  msg.SetLabel(GetLocalized(line));
+  if (iLine < 0 || iLine >= DIALOG_MAX_LINES)
+    return;
 
-  if(OwningCriticalSection(g_graphicsContext))
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strLines[iLine] = GetLocalized(line);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_LINES_START + iLine, m_strLines[iLine]);
 }
 
 void CGUIDialogBoxBase::SetChoice(int iButton, const CVariant &choice) // iButton == 0 for no, 1 for yes
 {
-  Initialize();
-  CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), 10+iButton);
-  msg.SetLabel(GetLocalized(choice));
+  if (iButton < 0 || iButton >= DIALOG_MAX_CHOICES)
+    return;
 
-  if(OwningCriticalSection(g_graphicsContext))
-    OnMessage(msg);
-  else
-    g_windowManager.SendThreadMessage(msg, GetID());
+  m_strChoices[iButton] = GetLocalized(choice);
+  if (IsActive())
+    SET_CONTROL_LABEL_THREAD_SAFE(CONTROL_CHOICES_START + iButton, m_strChoices[iButton]);
 }
 
 void CGUIDialogBoxBase::OnInitWindow()
 {
   // set focus to default
   m_lastControlID = m_defaultControl;
+
+  // set control labels
+  SET_CONTROL_LABEL(CONTROL_HEADING, m_strHeading);
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
+    SET_CONTROL_LABEL(CONTROL_LINES_START + i, m_strLines[i]);
+  for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
+    SET_CONTROL_LABEL(CONTROL_CHOICES_START + i, m_strChoices[i]);
+
   CGUIDialog::OnInitWindow();
+}
+
+void CGUIDialogBoxBase::OnDeinitWindow(int nextWindowID)
+{
+  // make sure we set default labels for heading, lines and choices
+  SetHeading(GetDefaultLabel(CONTROL_HEADING));
+  for (int i = 0 ; i < DIALOG_MAX_LINES ; ++i)
+    SetLine(i, GetDefaultLabel(CONTROL_LINES_START + i));
+  for (int i = 0 ; i < DIALOG_MAX_CHOICES ; ++i)
+    SetChoice(i, GetDefaultLabel(CONTROL_CHOICES_START + i));
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 CStdString CGUIDialogBoxBase::GetLocalized(const CVariant &var) const
@@ -104,4 +121,15 @@ CStdString CGUIDialogBoxBase::GetLocalized(const CVariant &var) const
   else if (var.isInteger() && var.asInteger())
     return g_localizeStrings.Get(var.asInteger());
   return "";
+}
+
+CStdString CGUIDialogBoxBase::GetDefaultLabel(int controlId) const
+{
+  int labelId = GetDefaultLabelID(controlId);
+  return labelId != -1 ? g_localizeStrings.Get(labelId) : "";
+}
+
+int CGUIDialogBoxBase::GetDefaultLabelID(int controlId) const
+{
+  return -1;
 }

--- a/xbmc/dialogs/GUIDialogBoxBase.h
+++ b/xbmc/dialogs/GUIDialogBoxBase.h
@@ -23,6 +23,9 @@
 #include "GUIDialog.h"
 #include "utils/Variant.h"
 
+#define DIALOG_MAX_LINES 3
+#define DIALOG_MAX_CHOICES 2
+
 class CGUIDialogBoxBase :
       public CGUIDialog
 {
@@ -35,6 +38,8 @@ public:
   void SetHeading(const CVariant &heading);
   void SetChoice(int iButton, const CVariant &choice);
 protected:
+  CStdString GetDefaultLabel(int controlId) const;
+  virtual int GetDefaultLabelID(int controlId) const;
   /*! \brief Get a localized string from a variant
    If the varaint is already a string we return directly, else if it's an integer we return the corresponding
    localized string.
@@ -43,5 +48,12 @@ protected:
   CStdString GetLocalized(const CVariant &var) const;
 
   virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
+
   bool m_bConfirmed;
+
+  // actual strings
+  std::string m_strHeading;
+  std::string m_strLines[DIALOG_MAX_LINES];
+  std::string m_strChoices[DIALOG_MAX_CHOICES];
 };

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -24,7 +24,7 @@
 CGUIDialogBusy::CGUIDialogBusy(void)
 : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml")
 {
-  m_loadType = LOAD_ON_DEMAND;
+  m_loadType = LOAD_EVERY_TIME;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -24,7 +24,7 @@
 CGUIDialogBusy::CGUIDialogBusy(void)
 : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml")
 {
-  m_loadOnDemand = true;
+  m_loadType = LOAD_ON_DEMAND;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)

--- a/xbmc/dialogs/GUIDialogButtonMenu.cpp
+++ b/xbmc/dialogs/GUIDialogButtonMenu.cpp
@@ -28,6 +28,7 @@
 CGUIDialogButtonMenu::CGUIDialogButtonMenu(int id, const CStdString &xmlFile)
 : CGUIDialog(id, xmlFile)
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogButtonMenu::~CGUIDialogButtonMenu(void)

--- a/xbmc/dialogs/GUIDialogContextMenu.cpp
+++ b/xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -67,9 +67,12 @@ void CContextButtons::Add(unsigned int button, int label)
   push_back(pair<unsigned int, CStdString>(button, g_localizeStrings.Get(label)));
 }
 
-CGUIDialogContextMenu::CGUIDialogContextMenu(void):CGUIDialog(WINDOW_DIALOG_CONTEXT_MENU, "DialogContextMenu.xml")
+CGUIDialogContextMenu::CGUIDialogContextMenu(void)
+  : CGUIDialog(WINDOW_DIALOG_CONTEXT_MENU, "DialogContextMenu.xml")
 {
   m_clickedButton = -1;
+  m_backgroundImageSize = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogContextMenu::~CGUIDialogContextMenu(void)
@@ -164,14 +167,14 @@ void CGUIDialogContextMenu::SetupButtons()
       if (pGroupList->GetOrientation() == VERTICAL)
       {
         // keep gap between bottom edges of grouplist and background image
-        float diff = pControl->GetHeight() - pGroupList->GetHeight();
+        float diff = m_backgroundImageSize - pGroupList->GetHeight();
         pGroupList->SetHeight(pGroupList->GetTotalSize());
         pControl->SetHeight(diff + pGroupList->GetHeight());
       }
       else
       {
         // keep gap between right edges of grouplist and background image
-        float diff = pControl->GetWidth() - pGroupList->GetWidth();
+        float diff = m_backgroundImageSize - pGroupList->GetWidth();
         pGroupList->SetWidth(pGroupList->GetTotalSize());
         pControl->SetWidth(diff + pGroupList->GetWidth());
       }
@@ -640,15 +643,39 @@ CMediaSource *CGUIDialogContextMenu::GetShare(const CStdString &type, const CFil
 
 void CGUIDialogContextMenu::OnWindowLoaded()
 {
+  m_coordX = m_posX;
+  m_coordY = m_posY;
+
+  const CGUIControlGroupList* pGroupList = NULL;
+  const CGUIControl* pControl = GetControl(GROUP_LIST);
+  if (pControl && pControl->GetControlType() == GUICONTROL_GROUPLIST)
+    pGroupList = (CGUIControlGroupList*)pControl;
+
+  pControl = (CGUIControl *)GetControl(BACKGROUND_IMAGE);
+  if (pControl && pGroupList)
+  {
+    if (pGroupList->GetOrientation() == VERTICAL)
+      m_backgroundImageSize = pControl->GetHeight();
+    else
+      m_backgroundImageSize = pControl->GetWidth();
+  }
+
   CGUIDialog::OnWindowLoaded();
-  SetInitialVisibility();
-  SetupButtons();
 }
 
-void CGUIDialogContextMenu::OnWindowUnload()
+void CGUIDialogContextMenu::OnDeinitWindow(int nextWindowID)
 {
+  //we can't be sure that controls are removed on window unload
+  //we have to remove them to be sure that they won't stay for next use of context menu
+  for (unsigned int i = 0; i < m_buttons.size(); i++)
+  {
+    const CGUIControl *control = GetControl(BUTTON_START + i);
+    if (control)
+      RemoveControl(control);
+  }
+
   m_buttons.clear();
-  CGUIDialog::OnWindowUnload();
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 CStdString CGUIDialogContextMenu::GetDefaultShareNameByType(const CStdString &strType)
@@ -717,7 +744,7 @@ int CGUIDialogContextMenu::ShowAndGetChoice(const CContextButtons &choices)
   {
     pMenu->m_buttons = choices;
     pMenu->Initialize();
-
+    pMenu->SetupButtons();
     pMenu->PositionAtCurrentFocus();
     pMenu->DoModal();
     return pMenu->m_clickedButton;
@@ -735,7 +762,7 @@ void CGUIDialogContextMenu::PositionAtCurrentFocus()
     {
       CPoint pos = focusedControl->GetRenderPosition() + CPoint(focusedControl->GetWidth() * 0.5f, focusedControl->GetHeight() * 0.5f)
                    + window->GetRenderPosition();
-      SetPosition(m_posX + pos.x - GetWidth() * 0.5f, m_posY + pos.y - GetHeight() * 0.5f);
+      SetPosition(m_coordX + pos.x - GetWidth() * 0.5f, m_coordY + pos.y - GetHeight() * 0.5f);
       return;
     }
   }

--- a/xbmc/dialogs/GUIDialogContextMenu.h
+++ b/xbmc/dialogs/GUIDialogContextMenu.h
@@ -156,13 +156,16 @@ protected:
   float GetHeight();
   virtual void OnInitWindow();
   virtual void OnWindowLoaded();
-  virtual void OnWindowUnload();
+  virtual void OnDeinitWindow(int nextWindowID);
   static CStdString GetDefaultShareNameByType(const CStdString &strType);
   static void SetDefault(const CStdString &strType, const CStdString &strDefault);
   static void ClearDefault(const CStdString &strType);
   static CMediaSource *GetShare(const CStdString &type, const CFileItem *item);
 
 private:
+  float m_coordX, m_coordY;
+  /// \brief Stored size of background image (height or width depending on grouplist orientation)
+  float m_backgroundImageSize;
   int m_clickedButton;
   CContextButtons m_buttons;
 };

--- a/xbmc/dialogs/GUIDialogFavourites.cpp
+++ b/xbmc/dialogs/GUIDialogFavourites.cpp
@@ -32,6 +32,7 @@ CGUIDialogFavourites::CGUIDialogFavourites(void)
     : CGUIDialog(WINDOW_DIALOG_FAVOURITES, "DialogFavourites.xml")
 {
   m_favourites = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFavourites::~CGUIDialogFavourites(void)

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -66,6 +66,7 @@ CGUIDialogFileBrowser::CGUIDialogFileBrowser()
   m_singleList = false;
   m_thumbLoader.SetObserver(this);
   m_flipEnabled = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFileBrowser::~CGUIDialogFileBrowser()

--- a/xbmc/dialogs/GUIDialogKaiToast.cpp
+++ b/xbmc/dialogs/GUIDialogKaiToast.cpp
@@ -36,7 +36,7 @@ CGUIDialogKaiToast::CGUIDialogKaiToast(void)
 : CGUIDialog(WINDOW_DIALOG_KAI_TOAST, "DialogKaiToast.xml")
 {
   m_defaultIcon = "";
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIDialogKaiToast::~CGUIDialogKaiToast(void)

--- a/xbmc/dialogs/GUIDialogKeyboard.cpp
+++ b/xbmc/dialogs/GUIDialogKeyboard.cpp
@@ -67,6 +67,7 @@ CGUIDialogKeyboard::CGUIDialogKeyboard(void)
   m_keyType = LOWER;
   m_strHeading = "";
   m_lastRemoteClickTime = 0;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogKeyboard::~CGUIDialogKeyboard(void)

--- a/xbmc/dialogs/GUIDialogMediaSource.cpp
+++ b/xbmc/dialogs/GUIDialogMediaSource.cpp
@@ -50,6 +50,7 @@ CGUIDialogMediaSource::CGUIDialogMediaSource(void)
     : CGUIDialog(WINDOW_DIALOG_MEDIA_SOURCE, "DialogMediaSource.xml")
 {
   m_paths =  new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMediaSource::~CGUIDialogMediaSource()
@@ -585,3 +586,11 @@ vector<CStdString> CGUIDialogMediaSource::GetPaths()
   return paths;
 }
 
+void CGUIDialogMediaSource::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // clear paths container
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_PATH, 0);
+  OnMessage(msg);
+}

--- a/xbmc/dialogs/GUIDialogMediaSource.h
+++ b/xbmc/dialogs/GUIDialogMediaSource.h
@@ -33,6 +33,7 @@ public:
   CGUIDialogMediaSource(void);
   virtual ~CGUIDialogMediaSource(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual void OnDeinitWindow(int nextWindowID);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
   static bool ShowAndAddMediaSource(const CStdString &type);

--- a/xbmc/dialogs/GUIDialogMuteBug.cpp
+++ b/xbmc/dialogs/GUIDialogMuteBug.cpp
@@ -30,7 +30,7 @@
 CGUIDialogMuteBug::CGUIDialogMuteBug(void)
     : CGUIDialog(WINDOW_DIALOG_MUTE_BUG, "DialogMuteBug.xml")
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIDialogMuteBug::~CGUIDialogMuteBug(void)

--- a/xbmc/dialogs/GUIDialogNumeric.cpp
+++ b/xbmc/dialogs/GUIDialogNumeric.cpp
@@ -48,6 +48,7 @@ CGUIDialogNumeric::CGUIDialogNumeric(void)
   m_integer = 0;
   memset(&m_datetime, 0, sizeof(SYSTEMTIME));
   m_dirty = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogNumeric::~CGUIDialogNumeric(void)

--- a/xbmc/dialogs/GUIDialogOK.cpp
+++ b/xbmc/dialogs/GUIDialogOK.cpp
@@ -62,3 +62,10 @@ void CGUIDialogOK::ShowAndGetInput(const CVariant &heading, const CVariant &line
   dialog->DoModal();
   return ;
 }
+
+int CGUIDialogOK::GetDefaultLabelID(int controlId) const
+{
+  if (controlId == ID_BUTTON_OK)
+    return 186;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
+}

--- a/xbmc/dialogs/GUIDialogOK.h
+++ b/xbmc/dialogs/GUIDialogOK.h
@@ -30,4 +30,6 @@ public:
   virtual ~CGUIDialogOK(void);
   virtual bool OnMessage(CGUIMessage& message);
   static void ShowAndGetInput(const CVariant &heading, const CVariant &line0, const CVariant &line1, const CVariant &line2);
+protected:
+  virtual int GetDefaultLabelID(int controlId) const;
 };

--- a/xbmc/dialogs/GUIDialogPlayerControls.cpp
+++ b/xbmc/dialogs/GUIDialogPlayerControls.cpp
@@ -24,6 +24,7 @@
 CGUIDialogPlayerControls::CGUIDialogPlayerControls(void)
     : CGUIDialog(WINDOW_DIALOG_PLAYER_CONTROLS, "PlayerControls.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogPlayerControls::~CGUIDialogPlayerControls(void)

--- a/xbmc/dialogs/GUIDialogProgress.cpp
+++ b/xbmc/dialogs/GUIDialogProgress.cpp
@@ -220,15 +220,9 @@ void CGUIDialogProgress::ShowProgressBar(bool bOnOff)
     g_windowManager.SendThreadMessage(msg, GetID());
 }
 
-void CGUIDialogProgress::SetHeading(const string& strLine)
+int CGUIDialogProgress::GetDefaultLabelID(int controlId) const
 {
-  m_strHeading = strLine;
-  CGUIDialogBoxBase::SetHeading(m_strHeading);
+  if (controlId == CONTROL_CANCEL_BUTTON)
+    return 222;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
 }
-
-void CGUIDialogProgress::SetHeading(int iString)
-{
-  m_strHeading = g_localizeStrings.Get(iString);
-  CGUIDialogBoxBase::SetHeading(m_strHeading);
-}
-

--- a/xbmc/dialogs/GUIDialogProgress.h
+++ b/xbmc/dialogs/GUIDialogProgress.h
@@ -41,8 +41,6 @@ public:
   void SetPercentage(int iPercentage);
   int GetPercentage() const { return m_percentage; };
   void ShowProgressBar(bool bOnOff);
-  void SetHeading(const std::string& strLine);
-  void SetHeading(int iString);             // for convenience to lookup in strings.xml
 
   // Implements IProgressCallback
   virtual void SetProgressMax(int iMax);
@@ -52,9 +50,10 @@ public:
   void SetCanCancel(bool bCanCancel);
 
 protected:
+  virtual int GetDefaultLabelID(int controlId) const;
+
   bool m_bCanCancel;
   bool m_bCanceled;
-  std::string m_strHeading;
 
   int  m_iCurrent;
   int  m_iMax;

--- a/xbmc/dialogs/GUIDialogSeekBar.cpp
+++ b/xbmc/dialogs/GUIDialogSeekBar.cpp
@@ -36,7 +36,7 @@ CGUIDialogSeekBar::CGUIDialogSeekBar(void)
 {
   m_fSeekPercentage = 0.0f;
   m_bRequireSeek = false;
-  m_loadOnDemand = false;    // the application class handles our resources
+  m_loadType = LOAD_ON_GUI_INIT;    // the application class handles our resources
 }
 
 CGUIDialogSeekBar::~CGUIDialogSeekBar(void)

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -37,6 +37,7 @@ CGUIDialogSelect::CGUIDialogSelect(void)
   m_vecListInternal = new CFileItemList;
   m_selectedItem = new CFileItem;
   m_vecList = m_vecListInternal;
+  m_iSelected = -1;
 }
 
 CGUIDialogSelect::~CGUIDialogSelect(void)
@@ -53,7 +54,10 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
     {
       CGUIDialog::OnMessage(message);
       m_viewControl.Reset();
-      Reset();
+      m_bButtonEnabled = false;
+      m_useDetails = false;
+      m_vecListInternal->Clear();
+      m_vecList = m_vecListInternal;
       return true;
     }
     break;
@@ -113,6 +117,8 @@ void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
   m_useDetails = false;
+  m_iSelected = -1;
+  m_selectedItem = NULL;
   m_vecListInternal->Clear();
   m_vecList = m_vecListInternal;
 }

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -27,11 +27,13 @@
 #define CONTROL_LIST          3
 #define CONTROL_NUMBEROFFILES 2
 #define CONTROL_BUTTON        5
+#define CONTROL_DETAILS       6
 
 CGUIDialogSelect::CGUIDialogSelect(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_SELECT, "DialogSelect.xml")
 {
   m_bButtonEnabled = false;
+  m_useDetails = false;
   m_vecListInternal = new CFileItemList;
   m_selectedItem = new CFileItem;
   m_vecList = m_vecListInternal;
@@ -50,6 +52,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIDialog::OnMessage(message);
+      m_viewControl.Reset();
       Reset();
       return true;
     }
@@ -60,23 +63,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       m_bButtonPressed = false;
       CGUIDialog::OnMessage(message);
       m_iSelected = -1;
-      CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_LIST, 0, 0, m_vecList);
-      g_windowManager.SendMessage(msg);
 
-      CStdString items;
-      items.Format("%i %s", m_vecList->Size(), g_localizeStrings.Get(127).c_str());
-      SET_CONTROL_LABEL(CONTROL_NUMBEROFFILES, items);
-
-      if (m_bButtonEnabled)
-      {
-        CGUIMessage msg2(GUI_MSG_VISIBLE, GetID(), CONTROL_BUTTON);
-        g_windowManager.SendMessage(msg2);
-      }
-      else
-      {
-        CGUIMessage msg2(GUI_MSG_HIDDEN, GetID(), CONTROL_BUTTON);
-        g_windowManager.SendMessage(msg2);
-      }
       return true;
     }
     break;
@@ -85,14 +72,12 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_CLICKED:
     {
       int iControl = message.GetSenderId();
-      if (CONTROL_LIST == iControl)
+      if (m_viewControl.HasControl(CONTROL_LIST))
       {
         int iAction = message.GetParam1();
         if (ACTION_SELECT_ITEM == iAction || ACTION_MOUSE_LEFT_CLICK == iAction)
         {
-          CGUIMessage msg(GUI_MSG_ITEM_SELECTED, GetID(), iControl);
-          g_windowManager.SendMessage(msg);
-          m_iSelected = msg.GetParam1();
+          m_iSelected = m_viewControl.GetSelectedItem();
           if(m_iSelected >= 0 && m_iSelected < (int)m_vecList->Size())
           {
             *m_selectedItem = *m_vecList->Get(m_iSelected);
@@ -110,6 +95,15 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
       }
     }
     break;
+  case GUI_MSG_SETFOCUS:
+    {
+      if (m_viewControl.HasControl(message.GetControlId()) && m_viewControl.GetCurrentControl() != message.GetControlId())
+      {
+        m_viewControl.SetFocused();
+        return true;
+      }
+    }
+    break;
   }
 
   return CGUIDialog::OnMessage(message);
@@ -118,6 +112,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
 void CGUIDialogSelect::Reset()
 {
   m_bButtonEnabled = false;
+  m_useDetails = false;
   m_vecListInternal->Clear();
   m_vecList = m_vecListInternal;
 }
@@ -191,3 +186,45 @@ void CGUIDialogSelect::SetSelected(int iSelected)
   m_iSelected = iSelected;
 }
 
+void CGUIDialogSelect::SetUseDetails(bool useDetails)
+{
+  m_useDetails = useDetails;
+}
+
+CGUIControl *CGUIDialogSelect::GetFirstFocusableControl(int id)
+{
+  if (m_viewControl.HasControl(id))
+    id = m_viewControl.GetCurrentControl();
+  return CGUIDialogBoxBase::GetFirstFocusableControl(id);
+}
+
+void CGUIDialogSelect::OnWindowLoaded()
+{
+  CGUIDialogBoxBase::OnWindowLoaded();
+  m_viewControl.Reset();
+  m_viewControl.SetParentWindow(GetID());
+  m_viewControl.AddView(GetControl(CONTROL_LIST));
+  m_viewControl.AddView(GetControl(CONTROL_DETAILS));
+}
+
+void CGUIDialogSelect::OnInitWindow()
+{
+  m_viewControl.SetItems(*m_vecList);
+  m_viewControl.SetCurrentView(m_useDetails ? CONTROL_DETAILS : CONTROL_LIST);
+
+  CStdString items;
+  items.Format("%i %s", m_vecList->Size(), g_localizeStrings.Get(127).c_str());
+  SET_CONTROL_LABEL(CONTROL_NUMBEROFFILES, items);
+
+  if (m_bButtonEnabled)
+  {
+    CGUIMessage msg2(GUI_MSG_VISIBLE, GetID(), CONTROL_BUTTON);
+    g_windowManager.SendMessage(msg2);
+  }
+  else
+  {
+    CGUIMessage msg2(GUI_MSG_HIDDEN, GetID(), CONTROL_BUTTON);
+    g_windowManager.SendMessage(msg2);
+  }
+  CGUIDialogBoxBase::OnInitWindow();
+}

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -38,6 +38,7 @@ CGUIDialogSelect::CGUIDialogSelect(void)
   m_selectedItem = new CFileItem;
   m_vecList = m_vecListInternal;
   m_iSelected = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSelect::~CGUIDialogSelect(void)
@@ -53,7 +54,7 @@ bool CGUIDialogSelect::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIDialog::OnMessage(message);
-      m_viewControl.Reset();
+      m_viewControl.Clear();
       m_bButtonEnabled = false;
       m_useDetails = false;
       m_vecListInternal->Clear();
@@ -232,4 +233,10 @@ void CGUIDialogSelect::OnInitWindow()
     g_windowManager.SendMessage(msg2);
   }
   CGUIDialogBoxBase::OnInitWindow();
+}
+
+void CGUIDialogSelect::OnWindowUnload()
+{
+  CGUIDialog::OnWindowUnload();
+  m_viewControl.Reset();
 }

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -118,7 +118,6 @@ void CGUIDialogSelect::Reset()
   m_bButtonEnabled = false;
   m_useDetails = false;
   m_iSelected = -1;
-  m_selectedItem = NULL;
   m_vecListInternal->Clear();
   m_vecList = m_vecListInternal;
 }

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -53,6 +53,7 @@ protected:
   virtual CGUIControl *CGUIDialogSelect::GetFirstFocusableControl(int id);
   virtual void OnWindowLoaded();
   virtual void OnInitWindow();
+  virtual void OnWindowUnload();
 
   bool m_bButtonEnabled;
   bool m_bButtonPressed;

--- a/xbmc/dialogs/GUIDialogSelect.h
+++ b/xbmc/dialogs/GUIDialogSelect.h
@@ -22,6 +22,7 @@
 
 #include "dialogs/GUIDialogBoxBase.h"
 #include "GUIListItem.h"
+#include "GUIViewControl.h"
 
 class CFileItem;
 class CFileItemList;
@@ -47,12 +48,19 @@ public:
   bool IsButtonPressed();
   void Sort(bool bSortOrder = true);
   void SetSelected(int iSelected);
+  void SetUseDetails(bool useDetails);
 protected:
+  virtual CGUIControl *CGUIDialogSelect::GetFirstFocusableControl(int id);
+  virtual void OnWindowLoaded();
+  virtual void OnInitWindow();
+
   bool m_bButtonEnabled;
   bool m_bButtonPressed;
   int m_iSelected;
+  bool m_useDetails;
 
   CFileItem* m_selectedItem;
   CFileItemList* m_vecListInternal;
   CFileItemList* m_vecList;
+  CGUIViewControl m_viewControl;
 };

--- a/xbmc/dialogs/GUIDialogSlider.cpp
+++ b/xbmc/dialogs/GUIDialogSlider.cpp
@@ -32,6 +32,7 @@ CGUIDialogSlider::CGUIDialogSlider(void)
 {
   m_callback = NULL;
   m_callbackData = NULL;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSlider::~CGUIDialogSlider(void)
@@ -62,6 +63,10 @@ bool CGUIDialogSlider::OnMessage(CGUIMessage& message)
         SET_CONTROL_LABEL(CONTROL_LABEL, slider->GetDescription());
       }
     }
+    break;
+  case GUI_MSG_WINDOW_DEINIT:
+    m_callback = NULL;
+    m_callbackData = NULL;
     break;
   }
   return CGUIDialog::OnMessage(message);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -70,6 +70,7 @@ CGUIDialogSmartPlaylistEditor::CGUIDialogSmartPlaylistEditor(void)
 {
   m_cancelled = false;
   m_ruleLabels = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSmartPlaylistEditor::~CGUIDialogSmartPlaylistEditor()
@@ -118,21 +119,6 @@ bool CGUIDialogSmartPlaylistEditor::OnMessage(CGUIMessage& message)
       else
         return CGUIDialog::OnMessage(message);
       return true;
-    }
-    break;
-  case GUI_MSG_WINDOW_INIT:
-    {
-      m_cancelled = false;
-      UpdateButtons();
-    }
-    break;
-  case GUI_MSG_WINDOW_DEINIT:
-    {
-      CGUIDialog::OnMessage(message);
-      // clear the rule list
-      CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
-      OnMessage(msg);
-      m_ruleLabels->Clear();
     }
     break;
   case GUI_MSG_FOCUSED:
@@ -345,6 +331,13 @@ void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
     msg.SetLabel(label);
     OnMessage(msg);
   }
+}
+
+void CGUIDialogSmartPlaylistEditor::OnInitWindow()
+{
+  m_cancelled = false;
+  UpdateButtons();
+
   SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_LIMIT, m_playlist.m_limit);
 
   vector<PLAYLIST_TYPE> allowedTypes;
@@ -390,6 +383,16 @@ void CGUIDialogSmartPlaylistEditor::OnWindowLoaded()
 
   SendMessage(GUI_MSG_ITEM_SELECT, CONTROL_TYPE, type);
   m_playlist.SetType(ConvertType(type));
+
+  CGUIDialog::OnInitWindow();
+}
+
+void CGUIDialogSmartPlaylistEditor::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+  CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_RULE_LIST);
+  OnMessage(msg);
+  m_ruleLabels->Clear();
 }
 
 CGUIDialogSmartPlaylistEditor::PLAYLIST_TYPE CGUIDialogSmartPlaylistEditor::ConvertType(const CStdString &type)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.h
@@ -36,6 +36,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnWindowLoaded();
+  virtual void OnInitWindow();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool EditPlaylist(const CStdString &path, const CStdString &type = "");
   static bool NewPlaylist(const CStdString &type);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -43,6 +43,7 @@ CGUIDialogSmartPlaylistRule::CGUIDialogSmartPlaylistRule(void)
     : CGUIDialog(WINDOW_DIALOG_SMART_PLAYLIST_RULE, "SmartPlaylistRule.xml")
 {
   m_cancelled = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSmartPlaylistRule::~CGUIDialogSmartPlaylistRule()
@@ -338,10 +339,17 @@ void CGUIDialogSmartPlaylistRule::AddOperatorLabel(CSmartPlaylistRule::SEARCH_OP
   OnMessage(select);
 }
 
+void CGUIDialogSmartPlaylistRule::OnWindowLoaded()
+{
+  CGUIWindow::OnWindowLoaded();
+  ChangeButtonToEdit(CONTROL_VALUE, true); // true for single label
+}
+
 void CGUIDialogSmartPlaylistRule::OnInitWindow()
 {
-  ChangeButtonToEdit(CONTROL_VALUE, true); // true for single label
   CGUIDialog::OnInitWindow();
+
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_FIELD);
   // add the fields to the field spincontrol
   vector<CSmartPlaylistRule::DATABASE_FIELD> fields = CSmartPlaylistRule::GetFields(m_type);
   for (unsigned int i = 0; i < fields.size(); i++)
@@ -351,6 +359,16 @@ void CGUIDialogSmartPlaylistRule::OnInitWindow()
     OnMessage(msg);
   }
   UpdateButtons();
+}
+
+void CGUIDialogSmartPlaylistRule::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // reset field spincontrolex
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_FIELD);
+  // reset operator spincontrolex
+  SendMessage(GUI_MSG_LABEL_RESET, CONTROL_OPERATOR);
 }
 
 bool CGUIDialogSmartPlaylistRule::EditRule(CSmartPlaylistRule &rule, const CStdString& type)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.h
@@ -32,6 +32,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
+  virtual void OnWindowLoaded();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool EditRule(CSmartPlaylistRule &rule, const CStdString& type="songs");
 

--- a/xbmc/dialogs/GUIDialogTextViewer.cpp
+++ b/xbmc/dialogs/GUIDialogTextViewer.cpp
@@ -26,7 +26,9 @@
 
 CGUIDialogTextViewer::CGUIDialogTextViewer(void)
     : CGUIDialog(WINDOW_DIALOG_TEXT_VIEWER, "DialogTextViewer.xml")
-{}
+{
+  m_loadType = KEEP_IN_MEMORY;
+}
 
 CGUIDialogTextViewer::~CGUIDialogTextViewer(void)
 {}
@@ -78,3 +80,14 @@ void CGUIDialogTextViewer::SetHeading()
   OnMessage(msg);
 }
 
+void CGUIDialogTextViewer::OnDeinitWindow(int nextWindowID)
+{
+  CGUIDialog::OnDeinitWindow(nextWindowID);
+
+  // reset text area
+  CGUIMessage msgReset(GUI_MSG_LABEL_RESET, GetID(), CONTROL_TEXTAREA);
+  OnMessage(msgReset);
+
+  // reset heading
+  SET_CONTROL_LABEL(CONTROL_HEADING, "");
+}

--- a/xbmc/dialogs/GUIDialogTextViewer.h
+++ b/xbmc/dialogs/GUIDialogTextViewer.h
@@ -33,6 +33,8 @@ public:
   void SetText(const CStdString& strText) { m_strText = strText; }
   void SetHeading(const CStdString& strHeading) { m_strHeading = strHeading; }
 protected:
+  virtual void OnDeinitWindow(int nextWindowID);
+
   CStdString m_strText;
   CStdString m_strHeading;
 

--- a/xbmc/dialogs/GUIDialogVolumeBar.cpp
+++ b/xbmc/dialogs/GUIDialogVolumeBar.cpp
@@ -27,7 +27,7 @@
 CGUIDialogVolumeBar::CGUIDialogVolumeBar(void)
     : CGUIDialog(WINDOW_DIALOG_VOLUME_BAR, "DialogVolumeBar.xml")
 {
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIDialogVolumeBar::~CGUIDialogVolumeBar(void)

--- a/xbmc/dialogs/GUIDialogYesNo.cpp
+++ b/xbmc/dialogs/GUIDialogYesNo.cpp
@@ -21,6 +21,9 @@
 #include "dialogs/GUIDialogYesNo.h"
 #include "GUIWindowManager.h"
 
+#define CONTROL_NO_BUTTON 10
+#define CONTROL_YES_BUTTON 11
+
 CGUIDialogYesNo::CGUIDialogYesNo(void)
     : CGUIDialogBoxBase(WINDOW_DIALOG_YES_NO, "DialogYesNo.xml")
 {
@@ -41,13 +44,13 @@ bool CGUIDialogYesNo::OnMessage(CGUIMessage& message)
       int iAction = message.GetParam1();
       if (1 || ACTION_SELECT_ITEM == iAction)
       {
-        if (iControl == 10)
+        if (iControl == CONTROL_NO_BUTTON)
         {
           m_bConfirmed = false;
           Close();
           return true;
         }
-        if (iControl == 11)
+        if (iControl == CONTROL_YES_BUTTON)
         {
           m_bConfirmed = true;
           Close();
@@ -92,8 +95,12 @@ bool CGUIDialogYesNo::ShowAndGetInput(int heading, int line0, int line1, int lin
     dialog->SetAutoClose(autoCloseTime);
   if (iNoLabel != -1)
     dialog->SetChoice(0,iNoLabel);
+  else
+    dialog->SetChoice(0,106);
   if (iYesLabel != -1)
     dialog->SetChoice(1,iYesLabel);
+  else
+    dialog->SetChoice(1,107);
   dialog->m_bCanceled = false;
   dialog->DoModal();
   bCanceled = dialog->m_bCanceled;
@@ -120,3 +127,11 @@ bool CGUIDialogYesNo::ShowAndGetInput(const CStdString& heading, const CStdStrin
   return (dialog->IsConfirmed()) ? true : false;
 }
 
+int CGUIDialogYesNo::GetDefaultLabelID(int controlId) const
+{
+  if (controlId == CONTROL_NO_BUTTON)
+    return 106;
+  else if (controlId == CONTROL_YES_BUTTON)
+    return 107;
+  return CGUIDialogBoxBase::GetDefaultLabelID(controlId);
+}

--- a/xbmc/dialogs/GUIDialogYesNo.h
+++ b/xbmc/dialogs/GUIDialogYesNo.h
@@ -37,5 +37,7 @@ public:
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2);
   static bool ShowAndGetInput(const CStdString& heading, const CStdString& line0, const CStdString& line1, const CStdString& line2, bool &bCanceled);
 protected:
+  virtual int GetDefaultLabelID(int controlId) const;
+
   bool m_bCanceled;
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -784,6 +784,12 @@ void CGUIBaseContainer::UpdateStaticItems(bool refreshItems)
   }
 }
 
+void CGUIBaseContainer::SetInitialVisibility()
+{
+  UpdateStaticItems(true);
+  CGUIControl::SetInitialVisibility();
+}
+
 void CGUIBaseContainer::CalculateLayout()
 {
   CGUIListItemLayout *oldFocusedLayout = m_focusedLayout;
@@ -931,16 +937,17 @@ void CGUIBaseContainer::LoadContent(TiXmlElement *content)
     }
     item = item->NextSiblingElement("item");
   }
-  SetStaticContent(items);
+  SetStaticContent(items, false);
 }
 
-void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items)
+void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items, bool forceUpdate /* = true */)
 {
   m_staticContent = true;
   m_staticUpdateTime = 0;
   m_staticItems.clear();
   m_staticItems.assign(items.begin(), items.end());
-  UpdateStaticItems(true);
+  if (forceUpdate)
+    UpdateStaticItems(true);
 }
 
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -55,6 +55,7 @@ public:
   virtual void AllocResources();
   virtual void FreeResources(bool immediately = false);
   virtual void UpdateVisibility(const CGUIListItem *item = NULL);
+  virtual void SetInitialVisibility();
 
   virtual unsigned int GetRows() const;
 
@@ -81,7 +82,7 @@ public:
   virtual bool GetCondition(int condition, int data) const;
   CStdString GetLabel(int info) const;
 
-  void SetStaticContent(const std::vector<CGUIListItemPtr> &items);
+  void SetStaticContent(const std::vector<CGUIListItemPtr> &items, bool forceUpdate = true);
 
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus

--- a/xbmc/guilib/GUIIncludes.cpp
+++ b/xbmc/guilib/GUIIncludes.cpp
@@ -225,21 +225,21 @@ bool CGUIIncludes::HasIncludeFile(const CStdString &file) const
   return false;
 }
 
-void CGUIIncludes::ResolveIncludes(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   if (!node)
     return;
-  ResolveIncludesForNode(node);
+  ResolveIncludesForNode(node, xmlIncludeConditions);
 
   TiXmlElement *child = node->FirstChildElement();
   while (child)
   {
-    ResolveIncludes(child);
+    ResolveIncludes(child, xmlIncludeConditions);
     child = child->NextSiblingElement();
   }
 }
 
-void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
+void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
   // we have a node, find any <include file="fileName">tagName</include> tags and replace
   // recursively with their real includes
@@ -276,7 +276,11 @@ void CGUIIncludes::ResolveIncludesForNode(TiXmlElement *node)
     const char *condition = include->Attribute("condition");
     if (condition)
     { // check this condition
-      bool value = g_infoManager.GetBool(g_infoManager.TranslateString(condition));
+      int conditionID = g_infoManager.Register(condition);
+      bool value = g_infoManager.GetBoolValue(conditionID);
+
+      if (xmlIncludeConditions)
+        (*xmlIncludeConditions)[conditionID] = value;
 
       if (!value)
       {

--- a/xbmc/guilib/GUIIncludes.h
+++ b/xbmc/guilib/GUIIncludes.h
@@ -45,7 +45,7 @@ public:
    "bar" from the include file "foo".
    \param node an XML Element - all child elements are traversed.
    */
-  void ResolveIncludes(TiXmlElement *node);
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
   const INFO::CSkinVariableString* CreateSkinVariable(const CStdString& name, int context);
 
 private:
@@ -56,7 +56,7 @@ private:
     SINGLE_UNDEFINED_PARAM_RESOLVED
   };
 
-  void ResolveIncludesForNode(TiXmlElement *node);
+  void ResolveIncludesForNode(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
   typedef std::map<CStdString, CStdString> Params;
   static bool GetParameters(const TiXmlElement *include, const char *valueAttribute, Params& params);
   static void ResolveParametersForNode(TiXmlElement *node, const Params& params);

--- a/xbmc/guilib/GUIMessage.h
+++ b/xbmc/guilib/GUIMessage.h
@@ -168,6 +168,20 @@ do { \
 
 /*!
  \ingroup winmsg
+ \brief Set the label of the current control
+ */
+#define SET_CONTROL_LABEL_THREAD_SAFE(controlID,label) \
+{ \
+ CGUIMessage msg(GUI_MSG_LABEL_SET, GetID(), controlID); \
+ msg.SetLabel(label); \
+ if(g_application.IsCurrentThread()) \
+   OnMessage(msg); \
+ else \
+   g_windowManager.SendThreadMessage(msg, GetID()); \
+}
+
+/*!
+ \ingroup winmsg
  \brief Set the second label of the current control
  */
 #define SET_CONTROL_LABEL2(controlID,label) \

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -52,7 +52,7 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_isDialog = false;
   m_needsScaling = true;
   m_windowLoaded = false;
-  m_loadType = LOAD_ON_DEMAND;
+  m_loadType = LOAD_EVERY_TIME;
   m_renderOrder = 0;
   m_dynamicResourceAlloc = true;
   m_previousWindow = WINDOW_INVALID;
@@ -585,13 +585,29 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   LARGE_INTEGER start;
   QueryPerformanceCounter(&start);
 #endif
-  // load skin xml fil
-  CStdString xmlFile = GetProperty("xmlfile");
-  bool bHasPath=false;
-  if (xmlFile.Find("\\") > -1 || xmlFile.Find("/") > -1 )
-    bHasPath = true;
-  if (xmlFile.size() && (forceLoad || m_loadType == LOAD_ON_DEMAND || !m_windowLoaded))
-    Load(xmlFile,bHasPath);
+  // use forceLoad to determine if xml file needs loading
+  forceLoad |= (m_loadType == LOAD_EVERY_TIME);
+
+  // if window is loaded (not cleared before) and we aren't forced to load
+  // we will have to load it only if include conditions values were changed
+  if (m_windowLoaded && !forceLoad)
+    forceLoad = g_infoManager.ConditionsChangedValues(m_xmlIncludeConditions);
+
+  // if window is loaded and load is forced we have to free window resources first
+  if (m_windowLoaded && forceLoad)
+    FreeResources(true);
+
+  // load skin xml file only if we are forced to load or window isn't loaded yet
+  forceLoad |= !m_windowLoaded;
+  if (forceLoad)
+  {
+    CStdString xmlFile = GetProperty("xmlfile");
+    if (xmlFile.size())
+    {
+      bool bHasPath = xmlFile.Find("\\") > -1 || xmlFile.Find("/") > -1;
+      Load(xmlFile,bHasPath);
+    }
+  }
 
   LARGE_INTEGER slend;
   QueryPerformanceCounter(&slend);
@@ -611,7 +627,13 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   LARGE_INTEGER end, freq;
   QueryPerformanceCounter(&end);
   QueryPerformanceFrequency(&freq);
-  CLog::Log(LOGDEBUG,"Alloc resources: %.2fms (%.2f ms skin load, %.2f ms preload)", 1000.f * (end.QuadPart - start.QuadPart) / freq.QuadPart, 1000.f * (slend.QuadPart - start.QuadPart) / freq.QuadPart, 1000.f * (plend.QuadPart - slend.QuadPart) / freq.QuadPart);
+  if (forceLoad)
+    CLog::Log(LOGDEBUG,"Alloc resources: %.2fms (%.2f ms skin load, %.2f ms preload)", 1000.f * (end.QuadPart - start.QuadPart) / freq.QuadPart, 1000.f * (slend.QuadPart - start.QuadPart) / freq.QuadPart, 1000.f * (plend.QuadPart - slend.QuadPart) / freq.QuadPart);
+  else
+  {
+    CLog::Log(LOGDEBUG,"Window %s was already loaded", GetProperty("xmlfile").c_str());
+    CLog::Log(LOGDEBUG,"Alloc resources: %.2fm", 1000.f * (end - start) / freq);
+  }
 #endif
   m_bAllocated = true;
 }
@@ -622,7 +644,7 @@ void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
   CGUIControlGroup::FreeResources();
   //g_TextureManager.Dump();
   // unload the skin
-  if (m_loadType == LOAD_ON_DEMAND || forceUnload) ClearAll();
+  if (m_loadType == LOAD_EVERY_TIME || forceUnload) ClearAll();
 }
 
 void CGUIWindow::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -666,6 +666,9 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
 
 void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
 {
+  if (!g_advancedSettings.m_guiKeepInMemory && !forceUnload)
+    forceUnload = true;
+
   m_bAllocated = false;
   CGUIControlGroup::FreeResources();
   //g_TextureManager.Dump();

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -60,10 +60,13 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_manualRunActions = false;
   m_exclusiveMouseControl = 0;
   m_clearBackground = 0xff000000; // opaque black -> always clear
+  m_windowXMLRootElement = NULL;
 }
 
 CGUIWindow::~CGUIWindow(void)
-{}
+{
+  delete m_windowXMLRootElement;
+}
 
 bool CGUIWindow::Load(const CStdString& strFileName, bool bContainsPath)
 {
@@ -101,20 +104,29 @@ bool CGUIWindow::Load(const CStdString& strFileName, bool bContainsPath)
 
 bool CGUIWindow::LoadXML(const CStdString &strPath, const CStdString &strLowerPath)
 {
-  TiXmlDocument xmlDoc;
-  if ( !xmlDoc.LoadFile(strPath) && !xmlDoc.LoadFile(CStdString(strPath).ToLower()) && !xmlDoc.LoadFile(strLowerPath))
+  // load window xml if we don't have it stored yet
+  if (!m_windowXMLRootElement)
   {
-    CLog::Log(LOGERROR, "unable to load:%s, Line %d\n%s", strPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
-    SetID(WINDOW_INVALID);
-    return false;
+    TiXmlDocument xmlDoc;
+    if ( !xmlDoc.LoadFile(strPath) && !xmlDoc.LoadFile(CStdString(strPath).ToLower()) && !xmlDoc.LoadFile(strLowerPath))
+    {
+      CLog::Log(LOGERROR, "unable to load:%s, Line %d\n%s", strPath.c_str(), xmlDoc.ErrorRow(), xmlDoc.ErrorDesc());
+      SetID(WINDOW_INVALID);
+      return false;
+    }
+    m_windowXMLRootElement = (TiXmlElement*)xmlDoc.RootElement()->Clone();
   }
+  else
+    CLog::Log(LOGDEBUG, "Using already stored xml root node for %s", strPath.c_str());
 
-  return Load(xmlDoc);
+  return Load(m_windowXMLRootElement);
 }
 
-bool CGUIWindow::Load(TiXmlDocument &xmlDoc)
+bool CGUIWindow::Load(TiXmlElement* pRootElement)
 {
-  TiXmlElement* pRootElement = xmlDoc.RootElement();
+  if (!pRootElement)
+    return false;
+
   if (strcmpi(pRootElement->Value(), "window"))
   {
     CLog::Log(LOGERROR, "file : XML file doesnt contain <window>");
@@ -645,6 +657,11 @@ void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
   //g_TextureManager.Dump();
   // unload the skin
   if (m_loadType == LOAD_EVERY_TIME || forceUnload) ClearAll();
+  if (forceUnload)
+  {
+    delete m_windowXMLRootElement;
+    m_windowXMLRootElement = NULL;
+  }
 }
 
 void CGUIWindow::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -52,7 +52,7 @@ CGUIWindow::CGUIWindow(int id, const CStdString &xmlFile)
   m_isDialog = false;
   m_needsScaling = true;
   m_windowLoaded = false;
-  m_loadOnDemand = true;
+  m_loadType = LOAD_ON_DEMAND;
   m_renderOrder = 0;
   m_dynamicResourceAlloc = true;
   m_previousWindow = WINDOW_INVALID;
@@ -590,7 +590,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   bool bHasPath=false;
   if (xmlFile.Find("\\") > -1 || xmlFile.Find("/") > -1 )
     bHasPath = true;
-  if (xmlFile.size() && (forceLoad || m_loadOnDemand || !m_windowLoaded))
+  if (xmlFile.size() && (forceLoad || m_loadType == LOAD_ON_DEMAND || !m_windowLoaded))
     Load(xmlFile,bHasPath);
 
   LARGE_INTEGER slend;
@@ -622,7 +622,7 @@ void CGUIWindow::FreeResources(bool forceUnload /*= FALSE */)
   CGUIControlGroup::FreeResources();
   //g_TextureManager.Dump();
   // unload the skin
-  if (m_loadOnDemand || forceUnload) ClearAll();
+  if (m_loadType == LOAD_ON_DEMAND || forceUnload) ClearAll();
 }
 
 void CGUIWindow::DynamicResourceAlloc(bool bOnOff)

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -644,7 +644,7 @@ void CGUIWindow::AllocResources(bool forceLoad /*= FALSE */)
   else
   {
     CLog::Log(LOGDEBUG,"Window %s was already loaded", GetProperty("xmlfile").c_str());
-    CLog::Log(LOGDEBUG,"Alloc resources: %.2fm", 1000.f * (end - start) / freq);
+    CLog::Log(LOGDEBUG,"Alloc resources: %.2fm", 1000.f * (end.QuadPart - start.QuadPart) / freq.QuadPart);
   }
 #endif
   m_bAllocated = true;

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -125,8 +125,8 @@ bool CGUIWindow::Load(TiXmlDocument &xmlDoc)
   // be done with respect to the correct aspect ratio
   g_graphicsContext.SetScalingResolution(m_coordsRes, m_needsScaling);
 
-  // Resolve any includes that may be present
-  g_SkinInfo.ResolveIncludes(pRootElement);
+  // Resolve any includes that may be present and save conditions used to do it
+  g_SkinInfo.ResolveIncludes(pRootElement, &m_xmlIncludeConditions);
   // now load in the skin file
   SetDefaults();
 

--- a/xbmc/guilib/GUIWindow.cpp
+++ b/xbmc/guilib/GUIWindow.cpp
@@ -78,7 +78,21 @@ bool CGUIWindow::Load(const CStdString& strFileName, bool bContainsPath)
   start = CurrentHostCounter();
 #endif
   RESOLUTION resToUse = INVALID;
-  CLog::Log(LOGINFO, "Loading skin file: %s", strFileName.c_str());
+  const char* strLoadType;
+  switch (m_loadType)
+  {
+  case LOAD_ON_GUI_INIT:
+    strLoadType = "LOAD_ON_GUI_INIT";
+    break;
+  case KEEP_IN_MEMORY:
+    strLoadType = "KEEP_IN_MEMORY";
+    break;
+  case LOAD_EVERY_TIME:
+  default:
+    strLoadType = "LOAD_EVERY_TIME";
+    break;
+  }
+  CLog::Log(LOGINFO, "Loading skin file: %s, load type: %s", strFileName.c_str(), strLoadType);
   TiXmlDocument xmlDoc;
   // Find appropriate skin folder + resolution to load from
   CStdString strPath;

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -76,7 +76,7 @@ class CGUIWindow : public CGUIControlGroup
 {
 public:
   enum WINDOW_TYPE { WINDOW = 0, MODAL_DIALOG, MODELESS_DIALOG, BUTTON_MENU, SUB_MENU };
-  enum LOAD_TYPE { LOAD_ON_DEMAND, LOAD_ON_GUI_INIT};
+  enum LOAD_TYPE { LOAD_EVERY_TIME, LOAD_ON_GUI_INIT, KEEP_IN_MEMORY };
 
   CGUIWindow(int id, const CStdString &xmlFile);
   virtual ~CGUIWindow(void);

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -76,6 +76,7 @@ class CGUIWindow : public CGUIControlGroup
 {
 public:
   enum WINDOW_TYPE { WINDOW = 0, MODAL_DIALOG, MODELESS_DIALOG, BUTTON_MENU, SUB_MENU };
+  enum LOAD_TYPE { LOAD_ON_DEMAND, LOAD_ON_GUI_INIT};
 
   CGUIWindow(int id, const CStdString &xmlFile);
   virtual ~CGUIWindow(void);
@@ -138,8 +139,8 @@ public:
   virtual bool IsActive() const;
   void SetCoordsRes(RESOLUTION res) { m_coordsRes = res; };
   RESOLUTION GetCoordsRes() const { return m_coordsRes; };
-  void LoadOnDemand(bool loadOnDemand) { m_loadOnDemand = loadOnDemand; };
-  bool GetLoadOnDemand() { return m_loadOnDemand; }
+  void SetLoadType(LOAD_TYPE loadType) { m_loadType = loadType; };
+  LOAD_TYPE GetLoadType() { return m_loadType; } const
   int GetRenderOrder() { return m_renderOrder; };
   virtual void SetInitialVisibility();
 
@@ -253,7 +254,7 @@ protected:
   RESOLUTION m_coordsRes; // resolution that the window coordinates are in.
   bool m_needsScaling;
   bool m_windowLoaded;  // true if the window's xml file has been loaded
-  bool m_loadOnDemand;  // true if the window should be loaded only as needed
+  LOAD_TYPE m_loadType;
   bool m_isDialog;      // true if we have a dialog, false otherwise.
   bool m_dynamicResourceAlloc;
   CGUIInfoColor m_clearBackground; // colour to clear the window

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -212,7 +212,7 @@ public:
 protected:
   virtual bool OnMouseEvent(const CPoint &point, const CMouseEvent &event);
   virtual bool LoadXML(const CStdString& strPath, const CStdString &strLowerPath);  ///< Loads from the given file
-  bool Load(TiXmlDocument &xmlDoc);                 ///< Loads from the given XML document
+  bool Load(TiXmlElement *pRootElement);                 ///< Loads from the given XML root element
   virtual void LoadAdditionalTags(TiXmlElement *root) {}; ///< Load additional information from the XML document
 
   virtual void SetDefaults();
@@ -289,6 +289,8 @@ protected:
   CGUIAction m_loadActions;
   CGUIAction m_unloadActions;
   
+  TiXmlElement* m_windowXMLRootElement;
+
   bool m_manualRunActions;
 
   int m_exclusiveMouseControl; ///< \brief id of child control that wishes to receive all mouse events \sa GUI_MSG_EXCLUSIVE_MOUSE

--- a/xbmc/guilib/GUIWindow.h
+++ b/xbmc/guilib/GUIWindow.h
@@ -291,6 +291,9 @@ protected:
   bool m_manualRunActions;
 
   int m_exclusiveMouseControl; ///< \brief id of child control that wishes to receive all mouse events \sa GUI_MSG_EXCLUSIVE_MOUSE
+
+private:
+  std::map<int, bool> m_xmlIncludeConditions; ///< \brief used to store conditions used to resolve includes for this window
 };
 
 #endif

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -784,7 +784,7 @@ void CGUIWindowManager::LoadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (!pWindow ->GetLoadOnDemand())
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
     {
       pWindow->FreeResources(true);
       pWindow->Initialize();
@@ -798,7 +798,7 @@ void CGUIWindowManager::UnloadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (!pWindow->GetLoadOnDemand())
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
     {
       pWindow->FreeResources(true);
     }

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -784,7 +784,8 @@ void CGUIWindowManager::LoadNotOnDemandWindows()
   for (WindowMap::iterator it = m_mapWindows.begin(); it != m_mapWindows.end(); it++)
   {
     CGUIWindow *pWindow = (*it).second;
-    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT)
+    if (pWindow->GetLoadType() == CGUIWindow::LOAD_ON_GUI_INIT ||
+        pWindow->GetLoadType() == CGUIWindow::KEEP_IN_MEMORY)
     {
       pWindow->FreeResources(true);
       pWindow->Initialize();

--- a/xbmc/guilib/SkinInfo.cpp
+++ b/xbmc/guilib/SkinInfo.cpp
@@ -262,9 +262,12 @@ void CSkinInfo::LoadIncludes()
   m_includes.LoadIncludes(includesPath);
 }
 
-void CSkinInfo::ResolveIncludes(TiXmlElement *node)
+void CSkinInfo::ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions /* = NULL */)
 {
-  m_includes.ResolveIncludes(node);
+  if(xmlIncludeConditions)
+    xmlIncludeConditions->clear();
+
+  m_includes.ResolveIncludes(node, xmlIncludeConditions);
 }
 
 int CSkinInfo::GetStartWindow() const

--- a/xbmc/guilib/SkinInfo.h
+++ b/xbmc/guilib/SkinInfo.h
@@ -90,7 +90,7 @@ public:
    */
   static RESOLUTION TranslateResolution(const CStdString &res, RESOLUTION def);
 
-  void ResolveIncludes(TiXmlElement *node);
+  void ResolveIncludes(TiXmlElement *node, std::map<int, bool>* xmlIncludeConditions = NULL);
 
   float GetEffectsSlowdown() const { return m_effectsSlowDown; };
 

--- a/xbmc/lib/libPython/xbmcmodule/GUIPythonWindow.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/GUIPythonWindow.cpp
@@ -34,7 +34,7 @@ CGUIPythonWindow::CGUIPythonWindow(int id)
 {
   pCallbackWindow = NULL;
   m_actionEvent = CreateEvent(NULL, true, false, NULL);
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIPythonWindow::~CGUIPythonWindow(void)

--- a/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowDialog.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowDialog.cpp
@@ -26,7 +26,7 @@ CGUIPythonWindowDialog::CGUIPythonWindowDialog(int id)
 :CGUIPythonWindow(id)
 {
   m_bRunning = false;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIPythonWindowDialog::~CGUIPythonWindowDialog(void)

--- a/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXML.cpp
@@ -52,7 +52,7 @@ CGUIPythonWindowXML::CGUIPythonWindowXML(int id, CStdString strXML, CStdString s
 {
   pCallbackWindow = NULL;
   m_actionEvent = CreateEvent(NULL, true, false, NULL);
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_coordsRes = PAL_4x3;
   m_scriptPath = strFallBackPath;
 }

--- a/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXML.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXML.cpp
@@ -351,7 +351,7 @@ bool CGUIPythonWindowXML::LoadXML(const CStdString &strPath, const CStdString &s
   if (xmlDoc.Error())
     return false;
 
-  return Load(xmlDoc);
+  return Load(xmlDoc.RootElement());
 }
 
 void CGUIPythonWindowXML::FreeResources(bool forceUnLoad /*= FALSE */)

--- a/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXMLDialog.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/GUIPythonWindowXMLDialog.cpp
@@ -26,7 +26,7 @@ CGUIPythonWindowXMLDialog::CGUIPythonWindowXMLDialog(int id, CStdString strXML, 
 : CGUIPythonWindowXML(id,strXML,strFallBackPath)
 {
   m_bRunning = false;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
 }
 
 CGUIPythonWindowXMLDialog::~CGUIPythonWindowXMLDialog(void)

--- a/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicInfo.cpp
@@ -67,6 +67,7 @@ CGUIWindowMusicInfo::CGUIWindowMusicInfo(void)
 {
   m_bRefresh = false;
   m_albumSongs = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowMusicInfo::~CGUIWindowMusicInfo(void)

--- a/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicOSD.cpp
@@ -32,6 +32,7 @@ CGUIDialogMusicOSD::CGUIDialogMusicOSD(void)
     : CGUIDialog(WINDOW_DIALOG_MUSIC_OSD, "MusicOSD.xml")
 {
   m_pVisualisation = NULL;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicOSD::~CGUIDialogMusicOSD(void)

--- a/xbmc/music/dialogs/GUIDialogMusicScan.cpp
+++ b/xbmc/music/dialogs/GUIDialogMusicScan.cpp
@@ -39,6 +39,7 @@ CGUIDialogMusicScan::CGUIDialogMusicScan(void)
 : CGUIDialog(WINDOW_DIALOG_MUSIC_SCAN, "DialogMusicScan.xml")
 {
   m_musicInfoScanner.SetObserver(this);
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogMusicScan::~CGUIDialogMusicScan(void)

--- a/xbmc/music/dialogs/GUIDialogSongInfo.cpp
+++ b/xbmc/music/dialogs/GUIDialogSongInfo.cpp
@@ -49,6 +49,7 @@ CGUIDialogSongInfo::CGUIDialogSongInfo(void)
   m_cancelled = false;
   m_needsUpdate = false;
   m_startRating = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSongInfo::~CGUIDialogSongInfo(void)

--- a/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
+++ b/xbmc/music/dialogs/GUIDialogVisualisationPresetList.cpp
@@ -35,6 +35,7 @@ CGUIDialogVisualisationPresetList::CGUIDialogVisualisationPresetList(void)
 {
   m_currentPreset = 0;
   m_vecPresets = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVisualisationPresetList::~CGUIDialogVisualisationPresetList(void)

--- a/xbmc/music/windows/GUIWindowVisualisation.cpp
+++ b/xbmc/music/windows/GUIWindowVisualisation.cpp
@@ -48,6 +48,7 @@ CGUIWindowVisualisation::CGUIWindowVisualisation(void)
   m_dwInitTimer = 0;
   m_dwLockedTimer = 0;
   m_bShowPreset = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowVisualisation::~CGUIWindowVisualisation(void)

--- a/xbmc/network/GUIDialogNetworkSetup.cpp
+++ b/xbmc/network/GUIDialogNetworkSetup.cpp
@@ -44,6 +44,7 @@ CGUIDialogNetworkSetup::CGUIDialogNetworkSetup(void)
 {
   m_protocol = NET_PROTOCOL_SMB;
   m_confirmed = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogNetworkSetup::~CGUIDialogNetworkSetup()
@@ -107,7 +108,7 @@ bool CGUIDialogNetworkSetup::ShowAndGetNetworkAddress(CStdString &path)
   return dialog->IsConfirmed();
 }
 
-void CGUIDialogNetworkSetup::OnInitWindow()
+void CGUIDialogNetworkSetup::OnWindowLoaded()
 {
   // replace our buttons with edits
   ChangeButtonToEdit(CONTROL_SERVER_ADDRESS);
@@ -116,6 +117,11 @@ void CGUIDialogNetworkSetup::OnInitWindow()
   ChangeButtonToEdit(CONTROL_PORT_NUMBER);
   ChangeButtonToEdit(CONTROL_PASSWORD);
 
+  CGUIDialog::OnWindowLoaded();
+}
+
+void CGUIDialogNetworkSetup::OnInitWindow()
+{
   // start as unconfirmed
   m_confirmed = false;
 
@@ -141,6 +147,16 @@ void CGUIDialogNetworkSetup::OnInitWindow()
 
   pSpin->SetValue(m_protocol);
   OnProtocolChange();
+}
+
+void CGUIDialogNetworkSetup::OnDeinitWindow(int nextWindowID)
+{
+  // clear protocol spinner
+  CGUISpinControlEx *pSpin = (CGUISpinControlEx *)GetControl(CONTROL_PROTOCOL);
+  if (pSpin)
+    pSpin->Clear();
+
+  CGUIDialog::OnDeinitWindow(nextWindowID);
 }
 
 void CGUIDialogNetworkSetup::OnServerBrowse()

--- a/xbmc/network/GUIDialogNetworkSetup.h
+++ b/xbmc/network/GUIDialogNetworkSetup.h
@@ -43,6 +43,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnBack(int actionID);
   virtual void OnInitWindow();
+  virtual void OnWindowLoaded();
+  virtual void OnDeinitWindow(int nextWindowID);
 
   static bool ShowAndGetNetworkAddress(CStdString &path);
 

--- a/xbmc/pictures/GUIDialogPictureInfo.cpp
+++ b/xbmc/pictures/GUIDialogPictureInfo.cpp
@@ -32,6 +32,7 @@ CGUIDialogPictureInfo::CGUIDialogPictureInfo(void)
     : CGUIDialog(WINDOW_DIALOG_PICTURE_INFO, "DialogPictureInfo.xml")
 {
   m_pictureInfo = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogPictureInfo::~CGUIDialogPictureInfo(void)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -82,7 +82,7 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
   virtual void Render();
-  virtual void FreeResources();
+  virtual void OnDeinitWindow(int nextWindowID);
   void OnLoadPic(int iPic, int iSlideNumber, LPDIRECT3DTEXTURE8 pTexture, int iWidth, int iHeight, int iOriginalWidth, int iOriginalHeight, int iRotate, bool bFullSize);
   int NumSlides() const;
   int CurrentSlide() const;

--- a/xbmc/settings/AdvancedSettings.cpp
+++ b/xbmc/settings/AdvancedSettings.cpp
@@ -215,6 +215,8 @@ CAdvancedSettings::CAdvancedSettings()
   m_bPythonVerbose = false;
 
   m_bgInfoLoaderMaxThreads = 1;
+
+  m_guiKeepInMemory = false;
 }
 
 bool CAdvancedSettings::Load()
@@ -695,6 +697,10 @@ bool CAdvancedSettings::Load()
 
   XMLUtils::GetInt(pRootElement, "bginfoloadermaxthreads", m_bgInfoLoaderMaxThreads);
   m_bgInfoLoaderMaxThreads = std::max(1, m_bgInfoLoaderMaxThreads);
+
+  pElement = pRootElement->FirstChildElement("gui");
+  if (pElement)
+    XMLUtils::GetBoolean(pElement, "keepinmemory", m_guiKeepInMemory);
 
   // load in the GUISettings overrides:
   g_guiSettings.LoadXML(pRootElement, true);  // true to hide the settings we read in

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -93,6 +93,8 @@ class CAdvancedSettings
     bool m_audioApplyDrc;
 
     float m_videoPlayCountMinimumPercent;
+    
+    bool m_guiKeepInMemory;
 
     unsigned int m_cacheMemBufferSize;
 

--- a/xbmc/settings/GUIDialogSettings.cpp
+++ b/xbmc/settings/GUIDialogSettings.cpp
@@ -48,6 +48,7 @@ CGUIDialogSettings::CGUIDialogSettings(int id, const char *xmlFile)
   m_pOriginalSlider = NULL;
   m_pOriginalSeparator = NULL;
   m_usePopupSliders = false;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogSettings::~CGUIDialogSettings(void)

--- a/xbmc/settings/GUIWindowSettings.cpp
+++ b/xbmc/settings/GUIWindowSettings.cpp
@@ -29,6 +29,7 @@
 CGUIWindowSettings::CGUIWindowSettings(void)
     : CGUIWindow(WINDOW_SETTINGS_MENU, "Settings.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowSettings::~CGUIWindowSettings(void)

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -109,6 +109,7 @@ using namespace XFILE;
 CGUIWindowSettingsCategory::CGUIWindowSettingsCategory(void)
     : CGUIWindow(WINDOW_SETTINGS_MYPICTURES, "SettingsCategory.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
   m_pOriginalSpin = NULL;
   m_pOriginalRadioButton = NULL;
   m_pOriginalButton = NULL;

--- a/xbmc/settings/GUIWindowSettingsProfile.cpp
+++ b/xbmc/settings/GUIWindowSettingsProfile.cpp
@@ -44,6 +44,7 @@ CGUIWindowSettingsProfile::CGUIWindowSettingsProfile(void)
     : CGUIWindow(WINDOW_SETTINGS_PROFILES, "SettingsProfile.xml")
 {
   m_listItems = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowSettingsProfile::~CGUIWindowSettingsProfile(void)

--- a/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogFullScreenInfo.cpp
@@ -23,6 +23,7 @@
 CGUIDialogFullScreenInfo::CGUIDialogFullScreenInfo(void)
     : CGUIDialog(WINDOW_DIALOG_FULLSCREEN_INFO, "DialogFullScreenInfo.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogFullScreenInfo::~CGUIDialogFullScreenInfo(void)

--- a/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoBookmarks.cpp
@@ -53,6 +53,7 @@ CGUIDialogVideoBookmarks::CGUIDialogVideoBookmarks()
     : CGUIDialog(WINDOW_DIALOG_VIDEO_BOOKMARKS, "VideoOSDBookmarks.xml")
 {
   m_vecItems = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoBookmarks::~CGUIDialogVideoBookmarks()

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -88,6 +88,7 @@ CGUIWindowVideoInfo::CGUIWindowVideoInfo(void)
   m_bRefresh = false;
   m_hasUpdatedThumb = false;
   m_castList = new CFileItemList;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowVideoInfo::~CGUIWindowVideoInfo(void)

--- a/xbmc/video/dialogs/GUIDialogVideoScan.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoScan.cpp
@@ -39,6 +39,7 @@ CGUIDialogVideoScan::CGUIDialogVideoScan(void)
 : CGUIDialog(WINDOW_DIALOG_VIDEO_SCAN, "DialogVideoScan.xml")
 {
   m_videoInfoScanner.SetObserver(this);
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIDialogVideoScan::~CGUIDialogVideoScan(void)
@@ -182,12 +183,17 @@ void CGUIDialogVideoScan::UpdateState()
       CGUIProgressControl* pProgressCtrl=(CGUIProgressControl*)GetControl(CONTROL_CURRENT_PROGRESS);
       if (pProgressCtrl) pProgressCtrl->SetPercentage(m_fCurrentPercentDone);
     }
+    else
+      SET_CONTROL_HIDDEN(CONTROL_CURRENT_PROGRESS);
+
     if (m_fPercentDone>-1.0f)
     {
       SET_CONTROL_VISIBLE(CONTROL_PROGRESS);
       CGUIProgressControl* pProgressCtrl=(CGUIProgressControl*)GetControl(CONTROL_PROGRESS);
       if (pProgressCtrl) pProgressCtrl->SetPercentage(m_fPercentDone);
     }
+    else
+      SET_CONTROL_HIDDEN(CONTROL_PROGRESS);
   }
   else
   {

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -149,7 +149,7 @@ void CGUIWindowFullScreen::UnloadDialog(unsigned int windowID)
   CGUIWindow *pWindow = g_windowManager.GetWindow(windowID);
   if (pWindow) {
     if (pWindow->GetLoadType() == LOAD_ON_GUI_INIT ||
-        pWindow->GetLoadType() == LOAD_ON_DEMAND)
+        pWindow->GetLoadType() == KEEP_IN_MEMORY)
     {
       pWindow->FreeResources(true);
     }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -148,7 +148,11 @@ void CGUIWindowFullScreen::UnloadDialog(unsigned int windowID)
 {
   CGUIWindow *pWindow = g_windowManager.GetWindow(windowID);
   if (pWindow) {
-    pWindow->FreeResources(pWindow->GetLoadOnDemand());
+    if (pWindow->GetLoadType() == LOAD_ON_GUI_INIT ||
+        pWindow->GetLoadType() == LOAD_ON_DEMAND)
+    {
+      pWindow->FreeResources(true);
+    }
   }
 }
 

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -152,7 +152,7 @@ void CGUIWindowFullScreen::UnloadDialog(unsigned int windowID)
     if (pWindow->GetLoadType() == LOAD_ON_GUI_INIT ||
         pWindow->GetLoadType() == KEEP_IN_MEMORY)
     {
-      pWindow->FreeResources(true);
+      pWindow->FreeResources(!g_advancedSettings.m_guiKeepInMemory);
     }
   }
 }

--- a/xbmc/video/windows/GUIWindowFullScreen.cpp
+++ b/xbmc/video/windows/GUIWindowFullScreen.cpp
@@ -111,6 +111,7 @@ CGUIWindowFullScreen::CGUIWindowFullScreen(void)
   m_bShowCurrentTime = false;
   m_subsLayout = NULL;
   m_sliderAction = 0;
+  m_loadType = KEEP_IN_MEMORY;
   // audio
   //  - language
   //  - volume
@@ -154,35 +155,6 @@ void CGUIWindowFullScreen::UnloadDialog(unsigned int windowID)
       pWindow->FreeResources(true);
     }
   }
-}
-
-void CGUIWindowFullScreen::AllocResources(bool forceLoad)
-{
-  CGUIWindow::AllocResources(forceLoad);
-  DynamicResourceAlloc(false);
-  PreloadDialog(WINDOW_OSD);
-  PreloadDialog(WINDOW_DIALOG_VIDEO_OSD_SETTINGS);
-  PreloadDialog(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
-  PreloadDialog(WINDOW_DIALOG_FULLSCREEN_INFO);
-  // No need to preload these here, as they're preloaded by our app
-//  PreloadDialog(WINDOW_DIALOG_SEEK_BAR);
-//  PreloadDialog(WINDOW_DIALOG_VOLUME_BAR);
-//  PreloadDialog(WINDOW_DIALOG_MUTE_BUG);
-}
-
-void CGUIWindowFullScreen::FreeResources(bool forceUnload)
-{
-  g_settings.Save();
-  DynamicResourceAlloc(true);
-  UnloadDialog(WINDOW_OSD);
-  UnloadDialog(WINDOW_DIALOG_VIDEO_OSD_SETTINGS);
-  UnloadDialog(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
-  UnloadDialog(WINDOW_DIALOG_FULLSCREEN_INFO);
-  // No need to unload these here, as they're preloaded by our app
-//  UnloadDialog(WINDOW_DIALOG_SEEK_BAR);
-//  UnloadDialog(WINDOW_DIALOG_VOLUME_BAR);
-//  UnloadDialog(WINDOW_DIALOG_MUTE_BUG);
-  CGUIWindow::FreeResources(forceUnload);
 }
 
 bool CGUIWindowFullScreen::OnAction(const CAction &action)
@@ -557,6 +529,11 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_INIT:
     {
+      PreloadDialog(WINDOW_OSD);
+      PreloadDialog(WINDOW_DIALOG_VIDEO_OSD_SETTINGS);
+      PreloadDialog(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
+      PreloadDialog(WINDOW_DIALOG_FULLSCREEN_INFO);
+
       // check whether we've come back here from a window during which time we've actually
       // stopped playing videos
       if (message.GetParam1() == WINDOW_INVALID && !g_application.IsPlayingVideo())
@@ -623,7 +600,10 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
     }
   case GUI_MSG_WINDOW_DEINIT:
     {
-      CGUIWindow::OnMessage(message);
+      UnloadDialog(WINDOW_OSD);
+      UnloadDialog(WINDOW_DIALOG_VIDEO_OSD_SETTINGS);
+      UnloadDialog(WINDOW_DIALOG_AUDIO_OSD_SETTINGS);
+      UnloadDialog(WINDOW_DIALOG_FULLSCREEN_INFO);
 
       CGUIDialogSlider *slider = (CGUIDialogSlider *)g_windowManager.GetWindow(WINDOW_DIALOG_SLIDER);
       if (slider) slider->Close(true);
@@ -632,7 +612,9 @@ bool CGUIWindowFullScreen::OnMessage(CGUIMessage& message)
       pDialog = (CGUIDialog *)g_windowManager.GetWindow(WINDOW_DIALOG_FULLSCREEN_INFO);
       if (pDialog) pDialog->Close(true);
 
-      FreeResources(true);
+      CGUIWindow::OnMessage(message);
+
+      g_settings.Save();
 
       CSingleLock lock (g_graphicsContext);
       CUtil::RestoreBrightnessContrastGamma();

--- a/xbmc/video/windows/GUIWindowFullScreen.h
+++ b/xbmc/video/windows/GUIWindowFullScreen.h
@@ -32,8 +32,6 @@ class CGUIWindowFullScreen :
 public:
   CGUIWindowFullScreen(void);
   virtual ~CGUIWindowFullScreen(void);
-  virtual void AllocResources(bool forceLoad = false);
-  virtual void FreeResources(bool forceUnLoad = false);
   virtual bool OnMessage(CGUIMessage& message);
   virtual bool OnAction(const CAction &action);
   virtual void Render();

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -66,6 +66,7 @@ using namespace std;
 CGUIMediaWindow::CGUIMediaWindow(int id, const char *xmlFile)
     : CGUIWindow(id, xmlFile)
 {
+  m_loadType = KEEP_IN_MEMORY;
   m_vecItems = new CFileItemList;
   m_unfilteredItems = new CFileItemList;
   m_vecItems->SetPath("?");

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -95,6 +95,7 @@ CGUIWindowFileManager::CGUIWindowFileManager(void)
   m_Directory[0]->m_bIsFolder = true;
   m_Directory[1]->m_bIsFolder = true;
   bCheckShareConnectivity = true;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowFileManager::~CGUIWindowFileManager(void)

--- a/xbmc/windows/GUIWindowHome.cpp
+++ b/xbmc/windows/GUIWindowHome.cpp
@@ -34,7 +34,7 @@ CGUIWindowHome::CGUIWindowHome(void) : CGUIWindow(WINDOW_HOME, "Home.xml"),
                                        m_cumulativeUpdateFlag(0)
 {
   m_updateRA = (Audio | Video | Totals);
-  
+  m_loadType = KEEP_IN_MEMORY;
   CAnnouncementManager::AddAnnouncer(this);
 }
 

--- a/xbmc/windows/GUIWindowLoginScreen.cpp
+++ b/xbmc/windows/GUIWindowLoginScreen.cpp
@@ -53,6 +53,7 @@ CGUIWindowLoginScreen::CGUIWindowLoginScreen(void)
   watch.StartZero();
   m_vecItems = new CFileItemList;
   m_iSelectedItem = -1;
+  m_loadType = KEEP_IN_MEMORY;
 }
 
 CGUIWindowLoginScreen::~CGUIWindowLoginScreen(void)

--- a/xbmc/windows/GUIWindowPointer.cpp
+++ b/xbmc/windows/GUIWindowPointer.cpp
@@ -27,7 +27,7 @@ CGUIWindowPointer::CGUIWindowPointer(void)
     : CGUIWindow(105, "Pointer.xml")
 {
   m_dwPointer = 0;
-  m_loadOnDemand = false;
+  m_loadType = LOAD_ON_GUI_INIT;
   m_needsScaling = false;
 }
 

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -24,10 +24,18 @@
 #include "GUIWindowManager.h"
 #include "LocalizeStrings.h"
 
+#define CONTROL_BT_HDD			92
+#define CONTROL_BT_DVD      93
+#define CONTROL_BT_STORAGE  94
+#define CONTROL_BT_DEFAULT  95
+#define CONTROL_BT_NETWORK  96
+#define CONTROL_BT_VIDEO		97
+#define CONTROL_BT_HARDWARE	98
+
 CGUIWindowSystemInfo::CGUIWindowSystemInfo(void)
 :CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
 {
-  iControl = CONTROL_BT_DEFAULT;
+  m_section = CONTROL_BT_DEFAULT;
 }
 CGUIWindowSystemInfo::~CGUIWindowSystemInfo(void)
 {
@@ -39,13 +47,24 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_INIT:
     {
       CGUIWindow::OnMessage(message);
-      SetLabelDummy();
+      ResetLabels();
+      SET_CONTROL_LABEL(50, g_infoManager.GetTime(TIME_FORMAT_HH_MM_SS) + " | " + g_infoManager.GetDate());
+      SET_CONTROL_LABEL(51, g_localizeStrings.Get(144)+" "+g_infoManager.GetVersion());
+      SET_CONTROL_LABEL(52, "XBMC4Xbox " + g_infoManager.GetLabel(SYSTEM_BUILD_VERSION) +
+                            " (Compiled : " + g_infoManager.GetLabel(SYSTEM_BUILD_DATE)+")");
+      SET_CONTROL_LABEL(53, g_infoManager.GetLabel(SYSTEM_MPLAYER_VERSION));
+      return true;
+    }
+    break;
+  case GUI_MSG_WINDOW_DEINIT:
+    {
+      CGUIWindow::OnMessage(message);
       return true;
     }
     break;
   case GUI_MSG_CLICKED:
     {
-      iControl=message.GetSenderId();
+      m_section = message.GetSenderId();
     }
     break;
   }
@@ -54,11 +73,11 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
 
 void CGUIWindowSystemInfo::FrameMove()
 {
-  if(iControl == CONTROL_BT_DEFAULT)
+  ResetLabels();
+  int i = 2;
+  if (m_section == CONTROL_BT_DEFAULT)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20154));
-    int i = 2;
     SetControlLabel(i++, "%s %s", 22011, SYSTEM_CPU_TEMPERATURE);
     SetControlLabel(i++, "%s %s", 22010, SYSTEM_GPU_TEMPERATURE);
     SetControlLabel(i++, "%s: %s", 13300, SYSTEM_FAN_SPEED);
@@ -71,11 +90,9 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s: %s", 12390, SYSTEM_UPTIME);
     SetControlLabel(i++, "%s: %s", 12394, SYSTEM_TOTALUPTIME);
   }
-  else if(iControl == CONTROL_BT_HDD)
+  else if(m_section == CONTROL_BT_HDD)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20156));
-    int i = 2;
 #ifdef HAS_SYSINFO
     SetControlLabel(i++, "%s %s", 13154, SYSTEM_HDD_MODEL);
     SetControlLabel(i++, "%s %s", 13155, SYSTEM_HDD_SERIAL);
@@ -88,20 +105,17 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s %s", 13151, SYSTEM_HDD_TEMPERATURE);
 #endif
   }
-  else if(iControl == CONTROL_BT_DVD)
+  else if(m_section == CONTROL_BT_DVD)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20157));
-    int i = 2;
 #ifdef HAS_SYSINFO
     SetControlLabel(i++, "%s %s", 13152, SYSTEM_DVD_MODEL);
     SetControlLabel(i++, "%s %s", 13153, SYSTEM_DVD_FIRMWARE);
     SetControlLabel(i++, "%s %s", 13294, SYSTEM_DVD_ZONE);
 #endif
   }
-  else if(iControl == CONTROL_BT_STORAGE)
+  else if(m_section == CONTROL_BT_STORAGE)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20155));
     // for backward compatibility just show Free space info else would be to long...
     SET_CONTROL_LABEL(2, g_infoManager.GetLabel(SYSTEM_FREE_SPACE_C));
@@ -118,11 +132,9 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(11, "%s: %s", 20161, SYSTEM_USED_SPACE_PERCENT);
     SET_CONTROL_LABEL(12,g_infoManager.GetLabel(SYSTEM_FREE_SPACE_PERCENT));
   }
-  else if(iControl == CONTROL_BT_NETWORK)
+  else if(m_section == CONTROL_BT_NETWORK)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20158));
-    int i = 2;
     SetControlLabel(i++, "%s %s", 146, NETWORK_IS_DHCP);
 #ifdef HAS_SYSINFO
     SetControlLabel(i++, "%s %s", 151, NETWORK_LINK_STATE);
@@ -135,11 +147,9 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s: %s", 20307, NETWORK_DNS2_ADDRESS);
     SetControlLabel(i++, "%s %s", 13295, SYSTEM_INTERNET_STATE);
   }
-  else if(iControl == CONTROL_BT_VIDEO)
+  else if(m_section == CONTROL_BT_VIDEO)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20159));
-    int i = 2;
 #ifdef HAS_SYSINFO
     SetControlLabel(i++, "%s %s", 13286, SYSTEM_VIDEO_ENCODER_INFO);
     SetControlLabel(i++, "%s %s", 13287, SYSTEM_SCREEN_RESOLUTION);
@@ -147,11 +157,9 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s %s", 13293, SYSTEM_XBE_REGION);
 #endif
   }
-  else if(iControl == CONTROL_BT_HARDWARE)
+  else if(m_section == CONTROL_BT_HARDWARE)
   {
-    SetLabelDummy();
     SET_CONTROL_LABEL(40,g_localizeStrings.Get(20160));
-    int i = 2;
 #ifdef HAS_SYSINFO
     SetControlLabel(i++, "%s %s", 13288, SYSTEM_XBOX_VERSION);
     SetControlLabel(i++, "%s %s", 13289, SYSTEM_XBOX_SERIAL);
@@ -165,16 +173,12 @@ void CGUIWindowSystemInfo::FrameMove()
     SetControlLabel(i++, "%s 4: %s", 13169, SYSTEM_CONTROLLER_PORT_4);
 #endif
   }
-  SET_CONTROL_LABEL(50, g_infoManager.GetTime(TIME_FORMAT_HH_MM_SS) + " | " + g_infoManager.GetDate());
-  SET_CONTROL_LABEL(51, g_localizeStrings.Get(144)+" "+g_infoManager.GetVersion());
-  SET_CONTROL_LABEL(52, "XBMC4Xbox "+g_infoManager.GetLabel(SYSTEM_BUILD_VERSION)+" (Compiled: "+g_infoManager.GetLabel(SYSTEM_BUILD_DATE)+")");
-  SET_CONTROL_LABEL(53, g_infoManager.GetLabel(SYSTEM_MPLAYER_VERSION));
   CGUIWindow::FrameMove();
 }
-void CGUIWindowSystemInfo::SetLabelDummy()
+
+void CGUIWindowSystemInfo::ResetLabels()
 {
-  // Set Label Dummy Entry! ""
-  for (int i=2; i<=12; i++ )
+  for (int i = 2; i <= 12; i++)
   {
 #ifdef HAS_SYSINFO
     SET_CONTROL_LABEL(i,"");

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -174,7 +174,7 @@ void CGUIWindowSystemInfo::FrameMove()
 void CGUIWindowSystemInfo::SetLabelDummy()
 {
   // Set Label Dummy Entry! ""
-  for (int i=2; i<12; i++ )
+  for (int i=2; i<=12; i++ )
   {
 #ifdef HAS_SYSINFO
     SET_CONTROL_LABEL(i,"");

--- a/xbmc/windows/GUIWindowSystemInfo.cpp
+++ b/xbmc/windows/GUIWindowSystemInfo.cpp
@@ -36,6 +36,7 @@ CGUIWindowSystemInfo::CGUIWindowSystemInfo(void)
 :CGUIWindow(WINDOW_SYSTEM_INFORMATION, "SettingsSystemInfo.xml")
 {
   m_section = CONTROL_BT_DEFAULT;
+  m_loadType = KEEP_IN_MEMORY;
 }
 CGUIWindowSystemInfo::~CGUIWindowSystemInfo(void)
 {
@@ -59,6 +60,7 @@ bool CGUIWindowSystemInfo::OnMessage(CGUIMessage& message)
   case GUI_MSG_WINDOW_DEINIT:
     {
       CGUIWindow::OnMessage(message);
+      ResetLabels();
       return true;
     }
     break;

--- a/xbmc/windows/GUIWindowSystemInfo.h
+++ b/xbmc/windows/GUIWindowSystemInfo.h
@@ -30,15 +30,8 @@ public:
   virtual bool OnMessage(CGUIMessage& message);
   virtual void FrameMove();
 private:
-  #define CONTROL_BT_HDD			92
-  #define CONTROL_BT_DVD      93
-  #define CONTROL_BT_STORAGE  94
-  #define CONTROL_BT_DEFAULT  95
-  #define CONTROL_BT_NETWORK  96
-  #define CONTROL_BT_VIDEO		97
-  #define CONTROL_BT_HARDWARE	98
-  unsigned int iControl;
-  void SetLabelDummy();
+  unsigned int m_section;
+  void ResetLabels();
   void SetControlLabel(int id, const char *format, int label, int info);
 };
 

--- a/xbmc/windows/GUIWindowWeather.cpp
+++ b/xbmc/windows/GUIWindowWeather.cpp
@@ -62,6 +62,7 @@ FIXME'S
 CGUIWindowWeather::CGUIWindowWeather(void)
     : CGUIWindow(WINDOW_WEATHER, "MyWeather.xml")
 {
+  m_loadType = KEEP_IN_MEMORY;
   m_iCurWeather = 0;
 #ifdef _USE_ZIP_
 


### PR DESCRIPTION
- This is backport of [#1283](https://github.com/xbmc/xbmc/pull/1283)

This PR add option to keep GUIControls XML files inside memory. From my testing if all windows were opened at least once, memory consuption will be around ~15MB higher. Because of that this feature is enabled on 128MB RAM Xboxes and disabled on 64MB Xboxes by default. You can manually toggle it via advancedsettings.xml. Add following lines to advancedsettings.xml to enable/disable this feature:

```
  <gui>
    <keepinmemory>true|false</keepinmemory>
  </gui>
```