### PR TITLE
Allow skins to query directories (e.g. plugins) to fill static content #3522

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -2833,6 +2833,22 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					RelativePath=".\xbmc\interfaces\info\SkinVariable.h">
 				</File>
 			</Filter>
+			<Filter
+				Name="listproviders"
+				Filter="">
+				<File
+					RelativePath=".\xbmc\listproviders\IListProvider.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\listproviders\IListProvider.h">
+				</File>
+				<File
+					RelativePath=".\xbmc\listproviders\StaticProvider.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\listproviders\StaticProvider.h">
+				</File>
+			</Filter>
 		</Filter>
 		<Filter
 			Name="Header Files"

--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -2837,6 +2837,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 				Name="listproviders"
 				Filter="">
 				<File
+					RelativePath=".\xbmc\listproviders\DirectoryProvider.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\listproviders\DirectoryProvider.h">
+				</File>
+				<File
 					RelativePath=".\xbmc\listproviders\IListProvider.cpp">
 				</File>
 				<File

--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -29,6 +29,9 @@
 #include "video/VideoInfoTag.h"
 #include "settings/AdvancedSettings.h"
 
+#define STRINGIZE_(x) #x
+#define STRINGIZE(x) STRINGIZE_(x)
+
 bool CFavourites::Load(CFileItemList &items)
 {
   items.Clear();
@@ -119,7 +122,7 @@ bool CFavourites::AddOrRemove(CFileItem *item, int contextWindow)
   CFileItemList items;
   Load(items);
 
-  CStdString executePath(GetExecutePath(item, contextWindow));
+  CStdString executePath(GetExecutePath(*item, contextWindow));
 
   CFileItemPtr match = items.Get(executePath);
   if (match)
@@ -145,7 +148,7 @@ bool CFavourites::IsFavourite(CFileItem *item, int contextWindow)
   CFileItemList items;
   if (!Load(items)) return false;
 
-  return items.Contains(GetExecutePath(item, contextWindow));
+  return items.Contains(GetExecutePath(*item, contextWindow));
 }
 
 static CStdString Paramify(const CStdString& param)
@@ -156,24 +159,34 @@ static CStdString Paramify(const CStdString& param)
   return "\"" + result + "\"";
 }
 
-CStdString CFavourites::GetExecutePath(const CFileItem *item, int contextWindow)
+CStdString CFavourites::GetExecutePath(const CFileItem &item, int contextWindow)
+{
+  CStdString text;
+  text.Format("%i", contextWindow);
+  return GetExecutePath(item, text);
+}
+
+CStdString CFavourites::GetExecutePath(const CFileItem &item, const std::string &contextWindow)
 {
   CStdString execute;
-  if (item->m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
-                            !(item->IsSmartPlayList() || item->IsPlayList())))
-    execute.Format("ActivateWindow(%i,%s)", contextWindow, Paramify(item->GetPath()));
-  else if (item->GetPath().Left(9).Equals("plugin://"))
-    execute.Format("RunPlugin(%s)", Paramify(item->GetPath()));
-  else if (contextWindow == WINDOW_SCRIPTS)
-    execute.Format("RunScript(%s)", item->GetPath());
-  else if (contextWindow == WINDOW_PROGRAMS)
-    execute.Format("RunXBE(%s)", Paramify(item->GetPath()));
+  if (item.m_bIsFolder && (g_advancedSettings.m_playlistAsFolders ||
+                            !(item.IsSmartPlayList() || item.IsPlayList())))
+  {
+    if (!contextWindow.empty())
+      execute.Format("ActivateWindow(%s,%s)", contextWindow, Paramify(item.GetPath()));
+  }
+  else if (item.GetPath().Left(9).Equals("plugin://"))
+    execute.Format("RunPlugin(%s)", Paramify(item.GetPath()));
+  else if (contextWindow == STRINGIZE(WINDOW_SCRIPTS))
+    execute.Format("RunScript(%s)", item.GetPath());
+  else if (contextWindow == STRINGIZE(WINDOW_PROGRAMS))
+    execute.Format("RunXBE(%s)", Paramify(item.GetPath()));
   else  // assume a media file
   {
-    if (item->IsVideoDb() && item->HasVideoInfoTag())
-      execute.Format("PlayMedia(%s)", Paramify(item->GetVideoInfoTag()->m_strFileNameAndPath));
+    if (item.IsVideoDb() && item.HasVideoInfoTag())
+      execute.Format("PlayMedia(%s)", Paramify(item.GetVideoInfoTag()->m_strFileNameAndPath));
     else
-      execute.Format("PlayMedia(%s)", Paramify(item->GetPath()));
+      execute.Format("PlayMedia(%s)", Paramify(item.GetPath()));
   }
   return execute;
 }

--- a/xbmc/Favourites.cpp
+++ b/xbmc/Favourites.cpp
@@ -173,7 +173,7 @@ CStdString CFavourites::GetExecutePath(const CFileItem &item, const std::string 
                             !(item.IsSmartPlayList() || item.IsPlayList())))
   {
     if (!contextWindow.empty())
-      execute.Format("ActivateWindow(%s,%s)", contextWindow, Paramify(item.GetPath()));
+      execute.Format("ActivateWindow(%s,%s,return)", contextWindow, Paramify(item.GetPath()));
   }
   else if (item.GetPath().Left(9).Equals("plugin://"))
     execute.Format("RunPlugin(%s)", Paramify(item.GetPath()));

--- a/xbmc/Favourites.h
+++ b/xbmc/Favourites.h
@@ -32,6 +32,7 @@ public:
   static bool Save(const CFileItemList& items);
   static bool IsFavourite(CFileItem *item, int contextWindow);
 
+  static CStdString GetExecutePath(const CFileItem &item, int contextWindow);
+  static CStdString GetExecutePath(const CFileItem &item, const std::string &contextWindow);
 private:
-  static CStdString GetExecutePath(const CFileItem *item, int contextWindow);
 };

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -1102,7 +1102,15 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter)
 
 bool CGUIBaseContainer::CanFocus() const
 {
-  return (!m_items.empty() && CGUIControl::CanFocus());
+  if (CGUIControl::CanFocus())
+  {
+    /*
+     We allow focus if we have items available or if we have a list provider
+     that's in the process of updating.
+     */
+    return !m_items.empty() || (m_listProvider && m_listProvider->IsUpdating());
+  }
+  return false;
 }
 
 void CGUIBaseContainer::OnFocus()

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -48,6 +48,8 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_analogScrollCount = 0;
   m_staticContent = false;
   m_staticUpdateTime = 0;
+  m_staticDefaultItem = -1;
+  m_staticDefaultAlways = false;
   m_wasReset = false;
   m_layout = NULL;
   m_focusedLayout = NULL;
@@ -650,7 +652,8 @@ void CGUIBaseContainer::SetFocus(bool bOnOff)
 
 void CGUIBaseContainer::SaveStates(vector<CControlState> &states)
 {
-  states.push_back(CControlState(GetID(), GetSelectedItem()));
+  if (!m_staticDefaultAlways)
+    states.push_back(CControlState(GetID(), GetSelectedItem()));
 }
 
 void CGUIBaseContainer::SetPageControl(int id)
@@ -681,6 +684,8 @@ void CGUIBaseContainer::DoRender(unsigned int currentTime)
 void CGUIBaseContainer::AllocResources()
 {
   CalculateLayout();
+  if (m_staticDefaultItem != -1) // select default item
+    SelectStaticItemById(m_staticDefaultItem);
 }
 
 void CGUIBaseContainer::FreeResources(bool immediately)
@@ -1127,4 +1132,28 @@ void CGUIBaseContainer::GetCacheOffsets(int &cacheBefore, int &cacheAfter)
 bool CGUIBaseContainer::CanFocus() const
 {
   return (!m_items.empty() && CGUIControl::CanFocus());
+}
+
+void CGUIBaseContainer::SelectStaticItemById(int id)
+{
+  if (m_staticContent)
+  {
+    for (unsigned int i = 0 ; i < m_items.size() ; i++)
+    {
+      CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[i]);
+      if (item->m_iprogramCount == id)
+      {
+        SelectItem(i);
+        return;
+      }
+    }
+  }
+}
+
+void CGUIBaseContainer::OnFocus()
+{
+  if (m_staticDefaultAlways)
+    SelectStaticItemById(m_staticDefaultItem);
+
+  CGUIControl::OnFocus();
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -27,7 +27,8 @@
 #include "utils/TimeUtils.h"
 #include "XMLUtils.h"
 #include "SkinInfo.h"
-#include "GUIStaticItem.h"
+#include "FileItem.h"
+#include "listproviders/IListProvider.h"
 
 using namespace std;
 
@@ -46,20 +47,18 @@ CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, fl
   m_renderTime = 0;
   m_orientation = orientation;
   m_analogScrollCount = 0;
-  m_staticContent = false;
-  m_staticUpdateTime = 0;
-  m_staticDefaultItem = -1;
-  m_staticDefaultAlways = false;
   m_wasReset = false;
   m_layout = NULL;
   m_focusedLayout = NULL;
   m_cacheItems = preloadItems;
   m_scrollItemsPerFrame = 0.0f;
   m_type = VIEW_TYPE_NONE;
+  m_listProvider = NULL;
 }
 
 CGUIBaseContainer::~CGUIBaseContainer(void)
 {
+  delete m_listProvider;
 }
 
 void CGUIBaseContainer::Render()
@@ -303,7 +302,7 @@ bool CGUIBaseContainer::OnMessage(CGUIMessage& message)
 {
   if (message.GetControlId() == GetID() )
   {
-    if (!m_staticContent)
+    if (!m_listProvider)
     {
       if (message.GetMessage() == GUI_MSG_LABEL_BIND && message.GetPointer())
       { // bind our items
@@ -605,14 +604,11 @@ bool CGUIBaseContainer::OnClick(int actionID)
   int subItem = 0;
   if (actionID == ACTION_SELECT_ITEM || actionID == ACTION_MOUSE_LEFT_CLICK)
   {
-    if (m_staticContent)
+    if (m_listProvider)
     { // "select" action
       int selected = GetSelectedItem();
       if (selected >= 0 && selected < (int)m_items.size())
-      {
-        CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[selected]);
-        item->GetClickActions().ExecuteActions(GetID(), GetParentID());
-      }
+        m_listProvider->OnClick(m_items[selected]);
       return true;
     }
     // grab the currently focused subitem (if applicable)
@@ -652,7 +648,7 @@ void CGUIBaseContainer::SetFocus(bool bOnOff)
 
 void CGUIBaseContainer::SaveStates(vector<CControlState> &states)
 {
-  if (!m_staticDefaultAlways)
+  if (!m_listProvider || !m_listProvider->AlwaysFocusDefaultItem())
     states.push_back(CControlState(GetID(), GetSelectedItem()));
 }
 
@@ -685,17 +681,18 @@ void CGUIBaseContainer::AllocResources()
 {
   CGUIControl::AllocResources();
   CalculateLayout();
-  UpdateStaticItems(true);
-  if (m_staticDefaultItem != -1) // select default item
-    SelectStaticItemById(m_staticDefaultItem);
+  UpdateListProvider(true);
+  if (m_listProvider)
+    SelectItem(m_listProvider->GetDefaultItem());
 }
 
 void CGUIBaseContainer::FreeResources(bool immediately)
 {
   CGUIControl::FreeResources(immediately);
-  if (m_staticContent)
-  { // free any static content
+  if (m_listProvider)
+  {
     Reset();
+    m_listProvider->Reset();
   }
   m_scroller.Stop();
 }
@@ -747,50 +744,33 @@ void CGUIBaseContainer::UpdateVisibility(const CGUIListItem *item)
     SelectItem(itemIndex);
   }
 
-  UpdateStaticItems();
+  UpdateListProvider();
 }
 
-void CGUIBaseContainer::UpdateStaticItems(bool refreshItems)
+void CGUIBaseContainer::UpdateListProvider(bool refreshItems)
 {
-  if (m_staticContent)
-  { // update our item list with our new content, but only add those items that should
-    // be visible.  Save the previous item and keep it if we are adding that one.
-    std::vector<CGUIListItemPtr> items;
-    int reselect = -1;
-    int selected = GetSelectedItem();
-    CGUIListItem* selectedItem = (selected >= 0 && (unsigned int)selected < m_items.size()) ? m_items[selected].get() : NULL;
-    bool updateItemsProperties = false;
-    if (!m_staticUpdateTime)
-      m_staticUpdateTime = CTimeUtils::GetFrameTime();
-    if (CTimeUtils::GetFrameTime() - m_staticUpdateTime > 1000)
+  if (m_listProvider)
+  {
+    if (m_listProvider->Update(refreshItems))
     {
-      m_staticUpdateTime = CTimeUtils::GetFrameTime();
-      updateItemsProperties = true;
-    }
-    for (unsigned int i = 0; i < m_staticItems.size(); ++i)
-    {
-      CGUIStaticItemPtr staticItem = boost::static_pointer_cast<CGUIStaticItem>(m_staticItems[i]);
-      if(staticItem->UpdateVisibility(GetParentID()))
-        refreshItems = true;
-      if (staticItem->IsVisible())
-      {
-        items.push_back(staticItem);
-        // if item is selected and it changed position, re-select it
-        if (staticItem.get() == selectedItem && selected != (int)items.size() - 1)
-          reselect = items.size() - 1;
-      }
-      // update any properties
-      if (updateItemsProperties)
-        staticItem->UpdateProperties(GetParentID());
-    }
-    if (refreshItems)
-    {
+      // save the current item
+      int currentItem = GetSelectedItem();
+      CGUIListItem *current = (currentItem >= 0 && currentItem < (int)m_items.size()) ? m_items[currentItem].get() : NULL;
       Reset();
-      m_items = items;
+      m_listProvider->Fetch(m_items);
       SetPageControlRange();
-      if (reselect >= 0 && reselect < (int)m_items.size())
-        SelectItem(reselect);
+      // update the newly selected item
+      for (int i = 0; i < (int)m_items.size(); i++)
+      {
+        if (m_items[i].get() == current && i != currentItem)
+        {
+          SelectItem(i);
+          break;
+        }
+      }
     }
+    // always update the scroll by letter, as the list provider may have altered labels
+    // while not actually changing the list items.
     UpdateScrollByLetter();
   }
 }
@@ -921,37 +901,19 @@ void CGUIBaseContainer::LoadLayout(TiXmlElement *layout)
   }
 }
 
-void CGUIBaseContainer::LoadContent(TiXmlElement *content)
+void CGUIBaseContainer::LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways)
 {
-  TiXmlElement *root = content->FirstChildElement("content");
-  if (!root)
-    return;
-
-  g_SkinInfo.ResolveIncludes(root);
-
-  vector<CGUIListItemPtr> items;
-  TiXmlElement *item = root->FirstChildElement("item");
-  while (item)
-  {
-    g_SkinInfo.ResolveIncludes(item);
-    if (item->FirstChild())
-    {
-      CGUIStaticItemPtr newItem(new CGUIStaticItem(item, GetParentID()));
-      items.push_back(newItem);
-    }
-    item = item->NextSiblingElement("item");
-  }
-  SetStaticContent(items, false);
+  delete m_listProvider;
+  m_listProvider = IListProvider::Create(content, GetParentID());
+  if (m_listProvider)
+    m_listProvider->SetDefaultItem(defaultItem, defaultAlways);
 }
 
-void CGUIBaseContainer::SetStaticContent(const vector<CGUIListItemPtr> &items, bool forceUpdate /* = true */)
+void CGUIBaseContainer::SetListProvider(IListProvider *provider)
 {
-  m_staticContent = true;
-  m_staticUpdateTime = 0;
-  m_staticItems.clear();
-  m_staticItems.assign(items.begin(), items.end());
-  if (forceUpdate)
-    UpdateStaticItems(true);
+  delete m_listProvider;
+  m_listProvider = provider;
+  UpdateListProvider(true);
 }
 
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)
@@ -1136,26 +1098,10 @@ bool CGUIBaseContainer::CanFocus() const
   return (!m_items.empty() && CGUIControl::CanFocus());
 }
 
-void CGUIBaseContainer::SelectStaticItemById(int id)
-{
-  if (m_staticContent)
-  {
-    for (unsigned int i = 0 ; i < m_items.size() ; i++)
-    {
-      CGUIStaticItemPtr item = boost::static_pointer_cast<CGUIStaticItem>(m_items[i]);
-      if (item->m_iprogramCount == id)
-      {
-        SelectItem(i);
-        return;
-      }
-    }
-  }
-}
-
 void CGUIBaseContainer::OnFocus()
 {
-  if (m_staticDefaultAlways)
-    SelectStaticItemById(m_staticDefaultItem);
+  if (m_listProvider && m_listProvider->AlwaysFocusDefaultItem())
+    SelectItem(m_listProvider->GetDefaultItem());
 
   CGUIControl::OnFocus();
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -683,7 +683,9 @@ void CGUIBaseContainer::DoRender(unsigned int currentTime)
 
 void CGUIBaseContainer::AllocResources()
 {
+  CGUIControl::AllocResources();
   CalculateLayout();
+  UpdateStaticItems(true);
   if (m_staticDefaultItem != -1) // select default item
     SelectStaticItemById(m_staticDefaultItem);
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -658,6 +658,13 @@ void CGUIBaseContainer::SetPageControl(int id)
   m_pageControl = id;
 }
 
+bool CGUIBaseContainer::GetOffsetRange(int &minOffset, int &maxOffset) const
+{
+  minOffset = 0;
+  maxOffset = GetRows() - m_itemsPerPage;
+  return true;
+}
+
 void CGUIBaseContainer::ValidateOffset()
 {
 }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -760,14 +760,21 @@ void CGUIBaseContainer::UpdateListProvider(bool refreshItems)
       m_listProvider->Fetch(m_items);
       SetPageControlRange();
       // update the newly selected item
+      bool found = false;
       for (int i = 0; i < (int)m_items.size(); i++)
       {
-        if (m_items[i].get() == current && i != currentItem)
+        if (m_items[i].get() == current)
         {
-          SelectItem(i);
-          break;
+          found = true;
+          if (i != currentItem)
+          {
+            SelectItem(i);
+            break;
+          }
         }
       }
+      if (!found && currentItem >= (int)m_items.size())
+        SelectItem(m_items.size()-1);
     }
     // always update the scroll by letter, as the list provider may have altered labels
     // while not actually changing the list items.

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -102,6 +102,7 @@ protected:
   virtual void Scroll(int amount);
   virtual bool MoveDown(bool wrapAround);
   virtual bool MoveUp(bool wrapAround);
+  virtual bool GetOffsetRange(int &minOffset, int &maxOffset) const;
   virtual void ValidateOffset();
   virtual int  CorrectOffset(int offset, int cursor) const;
   virtual void UpdateLayout(bool refreshAllItems = false);

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -71,6 +71,7 @@ public:
   virtual void DoRender(unsigned int currentTime);
   void LoadLayout(TiXmlElement *layout);
   void LoadContent(TiXmlElement *content);
+  void SetDefaultControl(int id, bool always) { m_staticDefaultItem = id; m_staticDefaultAlways = always; };
 
   VIEW_TYPE GetType() const { return m_type; };
   const CStdString &GetLabel() const { return m_label; };
@@ -110,12 +111,14 @@ protected:
   virtual void UpdatePageControl(int offset);
   virtual void CalculateLayout();
   virtual void SelectItem(int item) {};
+  void SelectStaticItemById(int id);
   virtual bool SelectItemFromPoint(const CPoint &point) { return false; };
   virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const { return -1; };
   virtual void Reset();
   virtual unsigned int GetNumItems() const { return m_items.size(); };
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
+  virtual void OnFocus();
   void UpdateStaticItems(bool refreshItems = false);
 
   inline float Size() const;
@@ -158,6 +161,8 @@ protected:
   CStdString m_label;
 
   bool m_staticContent;
+  bool m_staticDefaultAlways;
+  int  m_staticDefaultItem;
   unsigned int m_staticUpdateTime;
   std::vector<CGUIListItemPtr> m_staticItems;
   bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -37,6 +37,8 @@ typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
  \brief
  */
 
+class IListProvider;
+
 class CGUIBaseContainer : public CGUIControl
 {
 public:
@@ -70,8 +72,7 @@ public:
 
   virtual void DoRender(unsigned int currentTime);
   void LoadLayout(TiXmlElement *layout);
-  void LoadContent(TiXmlElement *content);
-  void SetDefaultControl(int id, bool always) { m_staticDefaultItem = id; m_staticDefaultAlways = always; };
+  void LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways);
 
   VIEW_TYPE GetType() const { return m_type; };
   const CStdString &GetLabel() const { return m_label; };
@@ -83,7 +84,10 @@ public:
   virtual bool GetCondition(int condition, int data) const;
   CStdString GetLabel(int info) const;
 
-  void SetStaticContent(const std::vector<CGUIListItemPtr> &items, bool forceUpdate = true);
+  /*! \brief Set the list provider for this container (for python).
+   \param provider the list provider to use for this container.
+   */
+  void SetListProvider(IListProvider *provider);
 
   /*! \brief Set the offset of the first item in the container from the container's position
    Useful for lists/panels where the focused item may be larger than the non-focused items and thus
@@ -111,7 +115,6 @@ protected:
   virtual void UpdatePageControl(int offset);
   virtual void CalculateLayout();
   virtual void SelectItem(int item) {};
-  void SelectStaticItemById(int id);
   virtual bool SelectItemFromPoint(const CPoint &point) { return false; };
   virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const { return -1; };
   virtual void Reset();
@@ -119,7 +122,7 @@ protected:
   virtual int GetCurrentPage() const;
   bool InsideLayout(const CGUIListItemLayout *layout, const CPoint &point) const;
   virtual void OnFocus();
-  void UpdateStaticItems(bool refreshItems = false);
+  void UpdateListProvider(bool refreshItems = false);
 
   inline float Size() const;
   void MoveToRow(int row);
@@ -160,11 +163,8 @@ protected:
   VIEW_TYPE m_type;
   CStdString m_label;
 
-  bool m_staticContent;
-  bool m_staticDefaultAlways;
-  int  m_staticDefaultItem;
-  unsigned int m_staticUpdateTime;
-  std::vector<CGUIListItemPtr> m_staticItems;
+  IListProvider *m_listProvider;
+
   bool m_wasReset;  // true if we've received a Reset message until we've rendered once.  Allows
                     // us to make sure we don't tell the infomanager that we've been moving when
                     // the "movement" was simply due to the list being repopulated (thus cursor position

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1376,8 +1376,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
 
     control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIListContainer *)control)->SetPageControl(pageControl);
     ((CGUIListContainer *)control)->SetRenderOffset(offset);
@@ -1389,8 +1388,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
 
     control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition);
     ((CGUIWrappingListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIWrappingListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIWrappingListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIWrappingListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIWrappingListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIWrappingListContainer *)control)->SetPageControl(pageControl);
     ((CGUIWrappingListContainer *)control)->SetRenderOffset(offset);
@@ -1402,8 +1400,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
 
     control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition, iMovementRange);
     ((CGUIFixedListContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIFixedListContainer *)control)->LoadContent(pControlNode);
-    ((CGUIFixedListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIFixedListContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIFixedListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIFixedListContainer *)control)->SetPageControl(pageControl);
     ((CGUIFixedListContainer *)control)->SetRenderOffset(offset);
@@ -1415,8 +1412,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
 
     control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIPanelContainer *)control)->LoadLayout(pControlNode);
-    ((CGUIPanelContainer *)control)->LoadContent(pControlNode);
-    ((CGUIPanelContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
+    ((CGUIPanelContainer *)control)->LoadListProvider(pControlNode, defaultControl, defaultAlways);
     ((CGUIPanelContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIPanelContainer *)control)->SetPageControl(pageControl);
     ((CGUIPanelContainer *)control)->SetRenderOffset(offset);

--- a/xbmc/guilib/GUIControlFactory.cpp
+++ b/xbmc/guilib/GUIControlFactory.cpp
@@ -1377,6 +1377,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
     control = new CGUIListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIListContainer *)control)->LoadContent(pControlNode);
+    ((CGUIListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
     ((CGUIListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIListContainer *)control)->SetPageControl(pageControl);
     ((CGUIListContainer *)control)->SetRenderOffset(offset);
@@ -1389,6 +1390,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
     control = new CGUIWrappingListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition);
     ((CGUIWrappingListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIWrappingListContainer *)control)->LoadContent(pControlNode);
+    ((CGUIWrappingListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
     ((CGUIWrappingListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIWrappingListContainer *)control)->SetPageControl(pageControl);
     ((CGUIWrappingListContainer *)control)->SetRenderOffset(offset);
@@ -1401,6 +1403,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
     control = new CGUIFixedListContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems, focusPosition, iMovementRange);
     ((CGUIFixedListContainer *)control)->LoadLayout(pControlNode);
     ((CGUIFixedListContainer *)control)->LoadContent(pControlNode);
+    ((CGUIFixedListContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
     ((CGUIFixedListContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIFixedListContainer *)control)->SetPageControl(pageControl);
     ((CGUIFixedListContainer *)control)->SetRenderOffset(offset);
@@ -1413,6 +1416,7 @@ CGUIControl* CGUIControlFactory::Create(int parentID, const FRECT &rect, TiXmlEl
     control = new CGUIPanelContainer(parentID, id, posX, posY, width, height, orientation, scroller, preloadItems);
     ((CGUIPanelContainer *)control)->LoadLayout(pControlNode);
     ((CGUIPanelContainer *)control)->LoadContent(pControlNode);
+    ((CGUIPanelContainer *)control)->SetDefaultControl(defaultControl, defaultAlways);
     ((CGUIPanelContainer *)control)->SetType(viewType, viewLabel);
     ((CGUIPanelContainer *)control)->SetPageControl(pageControl);
     ((CGUIPanelContainer *)control)->SetRenderOffset(offset);

--- a/xbmc/guilib/GUIControlGroupList.cpp
+++ b/xbmc/guilib/GUIControlGroupList.cpp
@@ -201,8 +201,8 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
 
   if (control)
   { // set the navigation of items so that they form a list
-    int beforeID = (m_orientation == VERTICAL) ? GetControlIdUp() : GetControlIdLeft();
-    int afterID = (m_orientation == VERTICAL) ? GetControlIdDown() : GetControlIdRight();
+    CGUIAction beforeAction = (m_orientation == VERTICAL) ? m_actionUp : m_actionLeft;
+    CGUIAction afterAction = (m_orientation == VERTICAL) ? m_actionDown : m_actionRight;
     if (m_children.size())
     {
       // we're inserting at the given position, so grab the items above and below and alter
@@ -212,27 +212,27 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
       if (position == 0)
       { // inserting at the beginning
         after = m_children[0];
-        if (afterID == GetID()) // we're wrapping around bottom->top, so we have to update the last item
+        if (!afterAction.HasActionsMeetingCondition() || afterAction.GetNavigation() == GetID()) // we're wrapping around bottom->top, so we have to update the last item
           before = m_children[m_children.size() - 1];
-        if (beforeID == GetID())   // we're wrapping around top->bottom
-          beforeID = m_children[m_children.size() - 1]->GetID();
-        afterID = after->GetID();
+        if (!beforeAction.HasActionsMeetingCondition() || beforeAction.GetNavigation() == GetID())   // we're wrapping around top->bottom
+          beforeAction = CGUIAction(m_children[m_children.size() - 1]->GetID());
+        afterAction = CGUIAction(after->GetID());
       }
       else if (position == (int)m_children.size())
       { // inserting at the end
         before = m_children[m_children.size() - 1];
-        if (beforeID == GetID())   // we're wrapping around top->bottom, so we have to update the first item
+        if (!beforeAction.HasActionsMeetingCondition() || beforeAction.GetNavigation() == GetID())   // we're wrapping around top->bottom, so we have to update the first item
           after = m_children[0];
-        if (afterID == GetID()) // we're wrapping around bottom->top
-          afterID = m_children[0]->GetID();
-        beforeID = before->GetID();
+        if (!afterAction.HasActionsMeetingCondition() || afterAction.GetNavigation() == GetID()) // we're wrapping around bottom->top
+          afterAction = CGUIAction(m_children[0]->GetID());
+        beforeAction = CGUIAction(before->GetID());
       }
       else
       { // inserting somewhere in the middle
         before = m_children[position - 1];
         after = m_children[position];
-        beforeID = before->GetID();
-        afterID = after->GetID();
+        beforeAction = CGUIAction(before->GetID());
+        afterAction = CGUIAction(after->GetID());
       }
       if (m_orientation == VERTICAL)
       {
@@ -255,15 +255,15 @@ void CGUIControlGroupList::AddControl(CGUIControl *control, int position /*= -1*
     // don't override them if child have already defined actions
     if (m_orientation == VERTICAL)
     {
-      control->SetNavigationAction(ACTION_MOVE_UP, CGUIAction(beforeID));
-      control->SetNavigationAction(ACTION_MOVE_DOWN, CGUIAction(afterID));
+      control->SetNavigationAction(ACTION_MOVE_UP, beforeAction);
+      control->SetNavigationAction(ACTION_MOVE_DOWN, afterAction);
       control->SetNavigationAction(ACTION_MOVE_LEFT, m_actionLeft, false);
       control->SetNavigationAction(ACTION_MOVE_RIGHT, m_actionRight, false);
     }
     else
     {
-      control->SetNavigationAction(ACTION_MOVE_LEFT, CGUIAction(beforeID));
-      control->SetNavigationAction(ACTION_MOVE_RIGHT, CGUIAction(afterID));
+      control->SetNavigationAction(ACTION_MOVE_LEFT, beforeAction);
+      control->SetNavigationAction(ACTION_MOVE_RIGHT, afterAction);
       control->SetNavigationAction(ACTION_MOVE_UP, m_actionUp, false);
       control->SetNavigationAction(ACTION_MOVE_DOWN, m_actionDown, false);
     }

--- a/xbmc/guilib/GUIFixedListContainer.cpp
+++ b/xbmc/guilib/GUIFixedListContainer.cpp
@@ -133,6 +133,14 @@ void CGUIFixedListContainer::Scroll(int amount)
   ScrollToOffset(offset);
 }
 
+bool CGUIFixedListContainer::GetOffsetRange(int &minOffset, int &maxOffset) const
+{
+  GetCursorRange(minOffset, maxOffset);
+  minOffset = -minOffset;
+  maxOffset = m_items.size() - maxOffset - 1;
+  return true;
+}
+
 void CGUIFixedListContainer::ValidateOffset()
 {
   if (!m_layout) return;
@@ -147,16 +155,18 @@ void CGUIFixedListContainer::ValidateOffset()
   // assure our cursor is between these limits
   m_cursor = max(m_cursor, minCursor);
   m_cursor = min(m_cursor, maxCursor);
+  int minOffset, maxOffset;
+  GetOffsetRange(minOffset, maxOffset);
   // and finally ensure our offset is valid
   // don't validate offset if we are scrolling in case the tween image exceed <0, 1> range
-  if (m_offset + maxCursor >= (int)m_items.size() || (!m_scroller.IsScrolling() && m_scroller.GetValue() > ((int)m_items.size() - maxCursor - 1) * m_layout->Size(m_orientation)))
+  if (m_offset > maxOffset || (!m_scroller.IsScrolling() && m_scroller.GetValue() > maxOffset * m_layout->Size(m_orientation)))
   {
-    m_offset = m_items.size() - maxCursor - 1;
+    m_offset = maxOffset;
     m_scroller.SetValue(m_offset * m_layout->Size(m_orientation));
   }
-  if (m_offset < -minCursor || (!m_scroller.IsScrolling() && m_scroller.GetValue() < -minCursor * m_layout->Size(m_orientation)))
+  if (m_offset < minOffset || (!m_scroller.IsScrolling() && m_scroller.GetValue() < minOffset * m_layout->Size(m_orientation)))
   {
-    m_offset = -minCursor;
+    m_offset = minOffset;
     m_scroller.SetValue(m_offset * m_layout->Size(m_orientation));
   }
 }

--- a/xbmc/guilib/GUIFixedListContainer.h
+++ b/xbmc/guilib/GUIFixedListContainer.h
@@ -44,6 +44,7 @@ protected:
   virtual void Scroll(int amount);
   virtual bool MoveDown(bool wrapAround);
   virtual bool MoveUp(bool wrapAround);
+  virtual bool GetOffsetRange(int &minOffset, int &maxOffset) const;
   virtual void ValidateOffset();
   virtual bool SelectItemFromPoint(const CPoint &point);
   virtual int GetCursorFromPoint(const CPoint &point, CPoint *itemPoint = NULL) const;

--- a/xbmc/guilib/GUIListContainer.cpp
+++ b/xbmc/guilib/GUIListContainer.cpp
@@ -189,9 +189,11 @@ void CGUIListContainer::ValidateOffset()
   if (!m_layout) return;
   // first thing is we check the range of our offset
   // don't validate offset if we are scrolling in case the tween image exceed <0, 1> range
-  if (m_offset > (int)m_items.size() - m_itemsPerPage || (!m_scroller.IsScrolling() && m_scroller.GetValue() > ((int)m_items.size() - m_itemsPerPage) * m_layout->Size(m_orientation)))
+  int minOffset, maxOffset;
+  GetOffsetRange(minOffset, maxOffset);
+  if (m_offset > maxOffset || (!m_scroller.IsScrolling() && m_scroller.GetValue() > maxOffset * m_layout->Size(m_orientation)))
   {
-    m_offset = m_items.size() - m_itemsPerPage;
+    m_offset = maxOffset;
     m_scroller.SetValue(m_offset * m_layout->Size(m_orientation));
   }
   if (m_offset < 0 || (!m_scroller.IsScrolling() && m_scroller.GetValue() < 0))

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -46,6 +46,8 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
     const char *id = item->Attribute("id");
     int visibleCondition = 0;
     CGUIControlFactory::GetConditionalVisibility(item, visibleCondition);
+    // NOTE: Use this when backporting #318 PR. Link to commit: https://github.com/xbmc/xbmc/commit/acfe38802f9bc55fd403c87c2fae919283219c3c
+    //SetVisibleCondition(condition, parentID);
     CGUIControlFactory::GetActions(item, "onclick", m_clickActions);
     SetLabel(label.GetLabel(parentID));
     SetLabel2(label2.GetLabel(parentID));
@@ -135,4 +137,10 @@ bool CGUIStaticItem::IsVisible() const
   if (m_visCondition)
     return m_visState;
   return true;
+}
+
+void CGUIStaticItem::SetVisibleCondition(const std::string &condition, int context)
+{
+  m_visCondition = g_infoManager.Register(condition, context);
+  m_visState = false;
 }

--- a/xbmc/guilib/GUIStaticItem.cpp
+++ b/xbmc/guilib/GUIStaticItem.cpp
@@ -89,6 +89,13 @@ CGUIStaticItem::CGUIStaticItem(const TiXmlElement *item, int parentID) : CFileIt
   }
 }
 
+CGUIStaticItem::CGUIStaticItem(const CFileItem &item)
+: CFileItem(item)
+{
+  m_visCondition = 0;
+  m_visState = false;
+}
+
 void CGUIStaticItem::UpdateProperties(int contextWindow)
 {
   for (InfoVector::const_iterator i = m_info.begin(); i != m_info.end(); i++)

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -58,6 +58,7 @@ public:
    \param contextWindow window context to use for any info labels
    */
   CGUIStaticItem(const TiXmlElement *element, int contextWindow);
+  CGUIStaticItem(const CFileItem &item); // for python
   virtual ~CGUIStaticItem() {};
   virtual CGUIListItem *Clone() const { return new CGUIStaticItem(*this); };
 

--- a/xbmc/guilib/GUIStaticItem.h
+++ b/xbmc/guilib/GUIStaticItem.h
@@ -68,6 +68,13 @@ public:
    \param contextWindow window context to use for any info labels
    */
   void UpdateProperties(int contextWindow);
+
+  /*! \brief set a visible condition for this item.
+   \param condition the condition to use.
+   \param context the context for the condition (typically a window id).
+   */
+  void SetVisibleCondition(const std::string &condition, int context);
+
   const CGUIAction &GetClickActions() const { return m_clickActions; };
 
   /*! \brief update visibility of this item

--- a/xbmc/guilib/GUIWrappingListContainer.cpp
+++ b/xbmc/guilib/GUIWrappingListContainer.cpp
@@ -118,6 +118,11 @@ void CGUIWrappingListContainer::Scroll(int amount)
   ScrollToOffset(m_offset + amount);
 }
 
+bool CGUIWrappingListContainer::GetOffsetRange(int &minOffset, int &maxOffset) const
+{
+  return false;
+}
+
 void CGUIWrappingListContainer::ValidateOffset()
 {
   if (m_itemsPerPage <= (int)m_items.size())

--- a/xbmc/guilib/GUIWrappingListContainer.h
+++ b/xbmc/guilib/GUIWrappingListContainer.h
@@ -45,6 +45,7 @@ protected:
   virtual void Scroll(int amount);
   virtual bool MoveDown(bool wrapAround);
   virtual bool MoveUp(bool wrapAround);
+  virtual bool GetOffsetRange(int &minOffset, int &maxOffset) const;
   virtual void ValidateOffset();
   virtual int  CorrectOffset(int offset, int cursor) const;
   virtual bool SelectItemFromPoint(const CPoint &point);

--- a/xbmc/lib/libPython/xbmcmodule/controllist.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/controllist.cpp
@@ -26,6 +26,7 @@
 #include "GUILabel.h"
 #include "control.h"
 #include "pyutil.h"
+#include "listproviders/StaticProvider.h"
 
 using namespace std;
 
@@ -658,7 +659,7 @@ PyDoc_STRVAR(setStaticContent__doc__,
       return NULL;
     }
 
-    vector<CGUIListItemPtr> items;
+    vector<CGUIStaticItemPtr> items;
     
     for (int item = 0; item < PyList_Size(pList); item++)
     {
@@ -668,15 +669,16 @@ PyDoc_STRVAR(setStaticContent__doc__,
         PyErr_SetString(PyExc_TypeError, "Only ListItems can be passed");
         return NULL;
       }
-      // object is a listitem, and we set m_idpeth to 0 as this
-      // is used as the visibility condition for the item in the list
-      ListItem *listItem = (ListItem*)pItem;
-      listItem->item->m_idepth = 0;
 
-      items.push_back((CFileItemPtr &)listItem->item);
+      // NOTE: This code has likely not worked fully correctly for some time
+      //       In particular, the click behaviour won't be working.
+      CGUIStaticItemPtr newItem(new CGUIStaticItem(*((ListItem*)pItem)->item));
+      items.push_back(newItem);
     }
+
     // set static list
-    ((CGUIBaseContainer *)self->pGUIControl)->SetStaticContent(items);
+    IListProvider *provider = new CStaticListProvider(items);
+    ((CGUIBaseContainer *)self->pGUIControl)->SetListProvider(provider);
 
     Py_INCREF(Py_None);
     return Py_None;

--- a/xbmc/lib/libPython/xbmcmodule/controllist.cpp
+++ b/xbmc/lib/libPython/xbmcmodule/controllist.cpp
@@ -26,8 +26,9 @@
 #include "GUILabel.h"
 #include "control.h"
 #include "pyutil.h"
+#ifndef DEBUG
 #include "listproviders/StaticProvider.h"
-
+#endif
 using namespace std;
 
 #ifndef __GNUC__
@@ -658,7 +659,7 @@ PyDoc_STRVAR(setStaticContent__doc__,
       PyErr_SetString(PyExc_TypeError, "Object should be of type List");
       return NULL;
     }
-
+#ifndef DEBUG
     vector<CGUIStaticItemPtr> items;
     
     for (int item = 0; item < PyList_Size(pList); item++)
@@ -679,7 +680,7 @@ PyDoc_STRVAR(setStaticContent__doc__,
     // set static list
     IListProvider *provider = new CStaticListProvider(items);
     ((CGUIBaseContainer *)self->pGUIControl)->SetListProvider(provider);
-
+#endif
     Py_INCREF(Py_None);
     return Py_None;
   }

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -185,3 +185,9 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
   }
   return false;
 }
+
+bool CDirectoryProvider::IsUpdating() const
+{
+  CSingleLock lock(m_section);
+  return m_jobID || m_invalid;
+}

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -1,0 +1,187 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "DirectoryProvider.h"
+#include "filesystem/Directory.h"
+#include "Favourites.h"
+#include "guilib/GUIWindowManager.h"
+#include "utils/JobManager.h"
+#include "utils/StringUtils.h"
+#include "utils/TimeUtils.h"
+#include "guilib/XMLUtils.h"
+#include "utils/SingleLock.h"
+#include "ApplicationMessenger.h"
+#include "FileItem.h"
+
+using namespace std;
+using namespace XFILE;
+
+class CDirectoryJob : public CJob
+{
+public:
+  CDirectoryJob(const std::string &url, int parentID) : m_url(url), m_parentID(parentID) { };
+  virtual ~CDirectoryJob() {};
+
+  virtual const char* GetType() const { return "directory"; };
+  virtual bool operator==(const CJob *job) const
+  {
+    if (strcmp(job->GetType(),GetType()) == 0)
+    {
+      const CDirectoryJob* dirJob = dynamic_cast<const CDirectoryJob*>(job);
+      if (dirJob && dirJob->m_url == m_url)
+        return true;
+    }
+    return false;
+  }
+
+  virtual bool DoWork()
+  {
+    CFileItemList items;
+    if (CDirectory::GetDirectory(m_url, items, ""))
+    {
+      // convert to CGUIStaticItem's and set visibility and targets
+      m_items.reserve(items.Size());
+      for (int i = 0; i < items.Size(); i++)
+      {
+        CGUIStaticItemPtr item(new CGUIStaticItem(*items[i]));
+        if (item->HasProperty("node.visible"))
+          item->SetVisibleCondition(item->GetProperty("node.visible"), m_parentID);
+        m_items.push_back(item);
+      }
+      m_target = items.GetProperty("node.target");
+    }
+    return true;    
+  }
+
+  const std::vector<CGUIStaticItemPtr> &GetItems() const { return m_items; }
+  const std::string &GetTarget() const { return m_target; }
+private:
+  std::string m_url;
+  std::string m_target;
+  int m_parentID;
+  std::vector<CGUIStaticItemPtr> m_items;
+};
+
+CDirectoryProvider::CDirectoryProvider(const TiXmlElement *element, int parentID)
+ : IListProvider(parentID),
+   m_updateTime(0),
+   m_invalid(false),
+   m_jobID(0)
+{
+  assert(element);
+
+  if (!element->NoChildren())
+  {
+    const char *target = element->Attribute("target");
+    if (target)
+      m_target.SetLabel(target, "", parentID);
+    m_url.SetLabel(element->FirstChild()->ValueStr(), "", parentID);
+  }
+}
+
+CDirectoryProvider::~CDirectoryProvider()
+{
+  Reset();
+}
+
+bool CDirectoryProvider::Update(bool refresh)
+{
+  bool changed = refresh;
+  {
+    CSingleLock lock(m_section);
+    changed |= m_invalid;
+    m_invalid = false;
+  }
+
+  // update the URL and fire off a new job if needed
+  CStdString value(m_url.GetLabel(m_parentID, false));
+  if (value != m_currentUrl)
+  {
+    m_currentUrl = value;
+
+    // fire job
+    CSingleLock lock(m_section);
+    if (m_jobID)
+      CJobManager::GetInstance().CancelJob(m_jobID);
+    m_jobID = CJobManager::GetInstance().AddJob(new CDirectoryJob(m_currentUrl, m_parentID), this);
+  }
+
+  for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+    changed |= (*i)->UpdateVisibility(m_parentID);
+  return changed; // TODO: Also returned changed if properties are changed (if so, need to update scroll to letter).
+}
+
+void CDirectoryProvider::Fetch(vector<CGUIListItemPtr> &items) const
+{
+  CSingleLock lock(m_section);
+  items.clear();
+  for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+  {
+    if ((*i)->IsVisible())
+      items.push_back(*i);
+  }
+}
+
+void CDirectoryProvider::Reset()
+{
+  // cancel any pending jobs
+  CSingleLock lock(m_section);
+  if (m_jobID)
+    CJobManager::GetInstance().CancelJob(m_jobID);
+  m_jobID = 0;
+  m_items.clear();
+  m_currentTarget.clear();
+  m_currentUrl.clear();
+  m_invalid = false;
+}
+
+void CDirectoryProvider::OnJobComplete(unsigned int jobID, bool success, CJob *job)
+{
+  CSingleLock lock(m_section);
+  if (success)
+  {
+    m_items = ((CDirectoryJob*)job)->GetItems();
+    m_currentTarget = ((CDirectoryJob*)job)->GetTarget();
+    m_invalid = true;
+  }
+  m_jobID = 0;
+}
+
+bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
+{
+  CFileItem fileItem(*boost::static_pointer_cast<CFileItem>(item));
+  string target = fileItem.GetProperty("node.target");
+  if (target.empty())
+    target = m_currentTarget;
+  if (target.empty())
+    target = m_target.GetLabel(m_parentID, false);
+  if (fileItem.HasProperty("node.target_url"))
+    fileItem.SetPath(fileItem.GetProperty("node.target_url"));
+  // grab the execute string
+  string execute = CFavourites::GetExecutePath(fileItem, target);
+  if (!execute.empty())
+  {
+    CGUIMessage message(GUI_MSG_EXECUTE, 0, 0);
+    message.SetStringParam(execute);
+    g_windowManager.SendMessage(message);
+    return true;
+  }
+  return false;
+}

--- a/xbmc/listproviders/DirectoryProvider.cpp
+++ b/xbmc/listproviders/DirectoryProvider.cpp
@@ -174,6 +174,9 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
     target = m_target.GetLabel(m_parentID, false);
   if (fileItem.HasProperty("node.target_url"))
     fileItem.SetPath(fileItem.GetProperty("node.target_url"));
+
+  CheckContentAttributes(target, fileItem);
+
   // grab the execute string
   string execute = CFavourites::GetExecutePath(fileItem, target);
   if (!execute.empty())
@@ -184,6 +187,28 @@ bool CDirectoryProvider::OnClick(const CGUIListItemPtr &item)
     return true;
   }
   return false;
+}
+
+void CDirectoryProvider::CheckContentAttributes(string &target, CFileItem &fileItem)
+{
+  CStdString path;
+  if (target == "application")
+  {
+    path.Format("%i", WINDOW_PROGRAMS);
+    target = path.c_str();
+    path.Format("%sdefault.xbe", fileItem.GetPath());
+  }
+  else if (target == "script")
+  {
+    path.Format("%i", WINDOW_SCRIPTS);
+    target = path.c_str();
+    path.Format("%sdefault.py", fileItem.GetPath());
+  }
+  if (!path.IsEmpty())
+  {
+    fileItem.m_bIsFolder = false;
+    fileItem.SetPath(path);
+  }
 }
 
 bool CDirectoryProvider::IsUpdating() const

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -38,6 +38,7 @@ public:
   virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
   virtual void Reset();
   virtual bool OnClick(const CGUIListItemPtr &item);
+  virtual bool IsUpdating() const;
 
   // callback from directory job
   virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -38,6 +38,7 @@ public:
   virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
   virtual void Reset();
   virtual bool OnClick(const CGUIListItemPtr &item);
+  void CheckContentAttributes(std::string &target, CFileItem &fileItem);
   virtual bool IsUpdating() const;
 
   // callback from directory job

--- a/xbmc/listproviders/DirectoryProvider.h
+++ b/xbmc/listproviders/DirectoryProvider.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <string>
+#include "IListProvider.h"
+#include "guilib/GUIStaticItem.h"
+#include "utils/Job.h"
+#include "utils/CriticalSection.h"
+
+class TiXmlElement;
+
+class CDirectoryProvider : public IListProvider, public IJobCallback
+{
+public:
+  CDirectoryProvider(const TiXmlElement *element, int parentID);
+  virtual ~CDirectoryProvider();
+
+  virtual bool Update(bool refresh);
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
+  virtual void Reset();
+  virtual bool OnClick(const CGUIListItemPtr &item);
+
+  // callback from directory job
+  virtual void OnJobComplete(unsigned int jobID, bool success, CJob *job);
+private:
+  unsigned int     m_updateTime;
+  bool             m_invalid;
+  unsigned int     m_jobID;
+  CGUIInfoLabel    m_url;
+  CGUIInfoLabel    m_target;
+  std::string      m_currentUrl;
+  std::string      m_currentTarget;   ///< \brief node.target property on the list as a whole
+  std::vector<CGUIStaticItemPtr> m_items;
+  CCriticalSection m_section;
+};

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -20,6 +20,7 @@
 
 #include "IListProvider.h"
 #include "StaticProvider.h"
+#include "DirectoryProvider.h"
 
 IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
 {
@@ -29,6 +30,9 @@ IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
     const TiXmlElement *item = root->FirstChildElement("item");
     if (item)
       return new CStaticListProvider(root, parentID);
+
+    if (!root->NoChildren())
+      return new CDirectoryProvider(root, parentID);
   }
   return NULL;
 }

--- a/xbmc/listproviders/IListProvider.cpp
+++ b/xbmc/listproviders/IListProvider.cpp
@@ -1,0 +1,34 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "IListProvider.h"
+#include "StaticProvider.h"
+
+IListProvider *IListProvider::Create(const TiXmlNode *node, int parentID)
+{
+  const TiXmlElement *root = node->FirstChildElement("content");
+  if (root)
+  {
+    const TiXmlElement *item = root->FirstChildElement("item");
+    if (item)
+      return new CStaticListProvider(root, parentID);
+  }
+  return NULL;
+}

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -1,0 +1,89 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "include.h"
+#include <vector>
+#include "boost/shared_ptr.hpp"
+
+class TiXmlNode;
+class CGUIListItem;
+typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
+
+/*!
+ \ingroup listproviders
+ \brief An interface for providing lists to UI containers.
+ */
+class IListProvider
+{
+public:
+  IListProvider(int parentID) : m_parentID(parentID) {}
+  virtual ~IListProvider() {}
+
+  /*! \brief Factory to create list providers.
+   \param node a TiXmlNode to create.
+   \param parentID id of parent window for context.
+   \return the list provider, NULL if none.
+   */
+  static IListProvider *Create(const TiXmlNode *node, int parentID);
+
+  /*! \brief Update the list content
+   \return true if the content has changed, false otherwise.
+   */
+  virtual bool Update(bool refresh)=0;
+
+  /*! \brief Fetch the current list of items.
+   \param items [out] the list to be filled.
+   */
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const=0;
+
+  /*! \brief Reset the current list of items.
+   Derived classes may choose to ignore this.
+   */
+  virtual void Reset() {};
+
+  /*! \brief Click event on an item.
+   \param item the item that was clicked.
+   \return true if the click was handled, false otherwise.
+   */
+  virtual bool OnClick(const CGUIListItemPtr &item)=0;
+
+  /*! \brief Set the default item to focus. For backwards compatibility.
+   \param item the item to focus.
+   \param always whether this item should always be used on first focus.
+   \sa GetDefaultItem, AlwaysFocusDefaultItem
+   */
+  virtual void SetDefaultItem(int item, bool always) {};
+
+  /*! \brief The default item to focus.
+   \return the item to focus by default. -1 for none.
+   \sa SetDefaultItem, AlwaysFocusDefaultItem
+   */
+  virtual int GetDefaultItem() const { return -1; }
+
+  /*! \brief Whether to always focus the default item.
+   \return true if the default item should always be the one to receive focus.
+   \sa GetDefaultItem, SetDefaultItem
+   */
+  virtual bool AlwaysFocusDefaultItem() const { return false; }
+protected:
+  int m_parentID;
+};

--- a/xbmc/listproviders/IListProvider.h
+++ b/xbmc/listproviders/IListProvider.h
@@ -55,6 +55,11 @@ public:
    */
   virtual void Fetch(std::vector<CGUIListItemPtr> &items) const=0;
 
+  /*! \brief Check whether the list provider is updating content.
+   \return true if in the processing of updating, false otherwise.
+   */
+  virtual bool IsUpdating() const { return false; }
+
   /*! \brief Reset the current list of items.
    Derived classes may choose to ignore this.
    */

--- a/xbmc/listproviders/StaticProvider.cpp
+++ b/xbmc/listproviders/StaticProvider.cpp
@@ -1,0 +1,121 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "StaticProvider.h"
+#include "guilib/XMLUtils.h"
+#include "utils/TimeUtils.h"
+
+using namespace std;
+
+CStaticListProvider::CStaticListProvider(const TiXmlElement *element, int parentID)
+: IListProvider(parentID),
+  m_defaultItem(-1),
+  m_defaultAlways(false),
+  m_updateTime(0)
+{
+  assert(element);
+
+  const TiXmlElement *item = element->FirstChildElement("item");
+  while (item)
+  {
+    if (item->FirstChild())
+    {
+      CGUIStaticItemPtr newItem(new CGUIStaticItem(item, parentID));
+      m_items.push_back(newItem);
+    }
+    item = item->NextSiblingElement("item");
+  }
+
+  if (XMLUtils::GetInt(element, "default", m_defaultItem))
+  {
+    const char *always = element->FirstChildElement("default")->Attribute("always");
+    if (always && strnicmp(always, "true", 4) == 0)
+      m_defaultAlways = true;
+  }
+}
+
+CStaticListProvider::CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items)
+: IListProvider(0),
+  m_defaultItem(-1),
+  m_defaultAlways(false),
+  m_updateTime(0),
+  m_items(items)
+{
+}
+
+CStaticListProvider::~CStaticListProvider()
+{
+}
+
+bool CStaticListProvider::Update(bool refresh)
+{
+  bool changed = refresh;
+  if (!m_updateTime)
+    m_updateTime = CTimeUtils::GetFrameTime();
+  else if (CTimeUtils::GetFrameTime() - m_updateTime > 1000)
+  {
+    m_updateTime = CTimeUtils::GetFrameTime();
+    for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+      (*i)->UpdateProperties(m_parentID);
+  }
+  for (vector<CGUIStaticItemPtr>::iterator i = m_items.begin(); i != m_items.end(); ++i)
+    changed |= (*i)->UpdateVisibility(m_parentID);
+  return changed; // TODO: Also returned changed if properties are changed (if so, need to update scroll to letter).
+}
+
+void CStaticListProvider::Fetch(vector<CGUIListItemPtr> &items) const
+{
+  items.clear();
+  for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+  {
+    if ((*i)->IsVisible())
+      items.push_back(*i);
+  }
+}
+
+void CStaticListProvider::SetDefaultItem(int item, bool always)
+{
+  m_defaultItem = item;
+  m_defaultAlways = always;
+}
+
+int CStaticListProvider::GetDefaultItem() const
+{
+  if (m_defaultItem >= 0)
+  {
+    for (vector<CGUIStaticItemPtr>::const_iterator i = m_items.begin(); i != m_items.end(); ++i)
+    {
+      if ((*i)->m_iprogramCount == m_defaultItem && (*i)->IsVisible())
+        return i - m_items.begin();
+    }
+  }
+  return -1;
+}
+
+bool CStaticListProvider::AlwaysFocusDefaultItem() const
+{
+  return m_defaultAlways;
+}
+
+bool CStaticListProvider::OnClick(const CGUIListItemPtr &item)
+{
+  CGUIStaticItemPtr staticItem = boost::static_pointer_cast<CGUIStaticItem>(item);
+  return staticItem->GetClickActions().ExecuteActions(0, m_parentID);
+}

--- a/xbmc/listproviders/StaticProvider.h
+++ b/xbmc/listproviders/StaticProvider.h
@@ -1,0 +1,44 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "IListProvider.h"
+#include "guilib/GUIStaticItem.h"
+
+class CStaticListProvider : public IListProvider
+{
+public:
+  CStaticListProvider(const TiXmlElement *element, int parentID);
+  CStaticListProvider(const std::vector<CGUIStaticItemPtr> &items); // for python
+  virtual ~CStaticListProvider();
+
+  virtual bool Update(bool refresh);
+  virtual void Fetch(std::vector<CGUIListItemPtr> &items) const;
+  virtual bool OnClick(const CGUIListItemPtr &item);
+  virtual void SetDefaultItem(int item, bool always);
+  virtual int  GetDefaultItem() const;
+  virtual bool AlwaysFocusDefaultItem() const;
+private:
+  int                            m_defaultItem;
+  bool                           m_defaultAlways;
+  unsigned int                   m_updateTime;
+  std::vector<CGUIStaticItemPtr> m_items;
+};


### PR DESCRIPTION
- This is backport of [#3522](https://github.com/xbmc/xbmc/pull/3522)
- You can find more info [here](https://forum.kodi.tv/showthread.php?tid=158812&pid=1549040#pid1549040)
- Thread on Kodi forum is located [here](https://forum.kodi.tv/showthread.php?tid=176864)

**NOTICE:** On Xbox Python is loaded via custom build-in DllLoader and because of it we don't have proper threading while Python is running. Because of that Python can only be started from **main** thread. If you try to run Python from some other thread you will get infinite Progress dialog and that's exactly what's happening if you put plugin VFS path inside List container. I have tried to bypass this and everything is okay if only one plugin is running, but if there are two or more bad things will happen in 90% cases (good example of that would be weather plugin and some list which is calling another plugin to populate with static items). **So until this is fixed don't use VFS path from plugins!**