### PR TITLE
Always load Startup.xml #2022

### DIFF
--- a/skin/Confluence Lite/720p/Startup.xml
+++ b/skin/Confluence Lite/720p/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>!Skin.HasSetting(Use_Startup_Playlist)</visible>
@@ -12,7 +12,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>Skin.HasSetting(Use_Startup_Playlist)</visible>

--- a/skin/Confluence/720p/Startup.xml
+++ b/skin/Confluence/720p/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>!Skin.HasSetting(Use_Startup_Playlist)</visible>
@@ -12,7 +12,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>Skin.HasSetting(Use_Startup_Playlist)</visible>

--- a/skin/PM3.HD/720p/Startup.xml
+++ b/skin/PM3.HD/720p/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>!Skin.HasSetting(Use_Startup_Playlist)</visible>
@@ -12,7 +12,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<visible>Skin.HasSetting(Use_Startup_Playlist)</visible>

--- a/skin/Project Mayhem III/PAL/Startup.xml
+++ b/skin/Project Mayhem III/PAL/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<animation effect="fade" start="0" end="0">Focus</animation>
@@ -13,7 +13,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<animation effect="fade" start="0" end="0">Focus</animation>

--- a/skin/Project Mayhem III/PAL16x9/Startup.xml
+++ b/skin/Project Mayhem III/PAL16x9/Startup.xml
@@ -4,7 +4,7 @@
 	<controls>
 		<control type="button" id="10">
 			<description>trigger</description>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<animation effect="fade" start="0" end="0">Focus</animation>
@@ -13,7 +13,7 @@
 		<control type="button" id="10">
 			<description>trigger with startup Playlist</description>
 			<onfocus>XBMC.PlayMedia($INFO[Skin.String(Startup_Playlist_Path)])</onfocus>
-			<onfocus>ReplaceWindow(Home)</onfocus>
+		  <onfocus>ReplaceWindow($INFO[System.StartupWindow])</onfocus>
 			<texturenofocus>-</texturenofocus>
 			<texturefocus>-</texturefocus>
 			<animation effect="fade" start="0" end="0">Focus</animation>

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -318,7 +318,8 @@ const infomap system_labels[] =  {{ "hasnetwork",           SYSTEM_ETHERNET_LINK
                                   { "profilethumb",         SYSTEM_PROFILETHUMB },
                                   { "launchxbe",            SYSTEM_LAUNCHING_XBE },
                                   { "progressbar",          SYSTEM_PROGRESS_BAR },
-                                  { "alarmpos",             SYSTEM_ALARM_POS }};
+                                  { "alarmpos",             SYSTEM_ALARM_POS },
+                                  { "startupwindow",        SYSTEM_STARTUP_WINDOW }};
 
 const infomap system_param[] =   {{ "hasalarm",         SYSTEM_HAS_ALARM },
                                   { "getbool",          SYSTEM_GET_BOOL },
@@ -1627,6 +1628,9 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     break;
   case SYSTEM_CURRENT_WINDOW:
     return g_localizeStrings.Get(g_windowManager.GetFocusedWindow());
+    break;
+  case SYSTEM_STARTUP_WINDOW:
+    strLabel.Format("%i", g_guiSettings.GetInt("lookandfeel.startupwindow"));
     break;
   case SYSTEM_CURRENT_CONTROL:
     {

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -179,6 +179,7 @@ namespace INFO
 #define LCD_TIME_43                 178
 #define LCD_TIME_44                 179
 #define SYSTEM_ALARM_LESS_OR_EQUAL  180
+#define SYSTEM_STARTUP_WINDOW       187
 
 #define NETWORK_IP_ADDRESS          190
 #define NETWORK_MAC_ADDRESS         191

--- a/xbmc/guilib/SkinInfo.cpp
+++ b/xbmc/guilib/SkinInfo.cpp
@@ -52,7 +52,6 @@ void CSkinInfo::SetDefaults()
   m_effectsSlowDown = 1.0f;
   m_Version = 1.0;
   m_debugging = false;
-  m_onlyAnimateToHome = true;
   m_iNumCreditLines = 0;
   m_skinzoom = 1.0f;
   m_bLegacy = false;
@@ -310,10 +309,7 @@ bool CSkinInfo::LoadStartupWindows(const TiXmlElement *startup)
     m_startupWindows.push_back(CStartupWindow(WINDOW_FILES, "7"));
     m_startupWindows.push_back(CStartupWindow(WINDOW_SETTINGS_MENU, "5"));
     m_startupWindows.push_back(CStartupWindow(WINDOW_SCRIPTS, "247"));
-    m_onlyAnimateToHome = true;
   }
-  else
-    m_onlyAnimateToHome = false;
   return true;
 }
 
@@ -365,7 +361,7 @@ bool CSkinInfo::GetResolution(const TiXmlNode *root, const char *tag, RESOLUTION
 int CSkinInfo::GetFirstWindow() const
 {
   int startWindow = GetStartWindow();
-  if (HasSkinFile("Startup.xml") && (!m_onlyAnimateToHome || startWindow == WINDOW_HOME))
+  if (HasSkinFile("Startup.xml"))
     startWindow = WINDOW_STARTUP_ANIM;
   return startWindow;
 }

--- a/xbmc/guilib/SkinInfo.h
+++ b/xbmc/guilib/SkinInfo.h
@@ -139,7 +139,6 @@ protected:
   CGUIIncludes m_includes;
 
   std::vector<CStartupWindow> m_startupWindows;
-  bool m_onlyAnimateToHome;
   bool m_debugging;
 
   float m_skinzoom;


### PR DESCRIPTION
- This is backport of [#2022](https://github.com/xbmc/xbmc/pull/2022)

INFO: Skinners should always use ReplaceWindow(**$INFO[System.StartupWindow]**) instead of ReplaceWindow(**Home**)