### PR TITLE
[GUIDialogVideoInfo] Split of Actor name and Actor role

### DIFF
--- a/skin/Confluence Lite/720p/DialogVideoInfo.xml
+++ b/skin/Confluence Lite/720p/DialogVideoInfo.xml
@@ -1051,7 +1051,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 						</control>
 					</itemlayout>
 					<focusedlayout height="40" width="430">
@@ -1080,7 +1080,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 						</control>
 					</focusedlayout>
 				</control>

--- a/skin/Confluence/720p/DialogVideoInfo.xml
+++ b/skin/Confluence/720p/DialogVideoInfo.xml
@@ -1057,7 +1057,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 						</control>
 					</itemlayout>
 					<focusedlayout height="40" width="430">
@@ -1086,7 +1086,7 @@
 							<align>left</align>
 							<aligny>center</aligny>
 							<selectedcolor>white</selectedcolor>
-							<info>ListItem.Label</info>
+							<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 						</control>
 					</focusedlayout>
 				</control>

--- a/skin/PM3.HD/720p/DialogVideoInfo.xml
+++ b/skin/PM3.HD/720p/DialogVideoInfo.xml
@@ -814,7 +814,7 @@
 					<align>left</align>
 					<aligny>center</aligny>
 					<selectedcolor>white</selectedcolor>
-					<info>ListItem.Label</info>
+					<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 				</control>
 			</itemlayout>
 			<focusedlayout height="35" width="380">
@@ -843,7 +843,7 @@
 					<align>left</align>
 					<aligny>center</aligny>
 					<selectedcolor>white</selectedcolor>
-					<info>ListItem.Label</info>
+					<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 				</control>
 			</focusedlayout>
 		</control>

--- a/skin/Project Mayhem III/PAL/DialogVideoInfo.xml
+++ b/skin/Project Mayhem III/PAL/DialogVideoInfo.xml
@@ -923,7 +923,7 @@
 					<aligny>center</aligny>
 					<selectedcolor>green</selectedcolor>
 					<align>left</align>
-					<info>ListItem.Label</info>
+					<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 				</control>
 			</itemlayout>
 			<focusedlayout height="29" width="250">
@@ -952,7 +952,7 @@
 					<aligny>center</aligny>
 					<selectedcolor>green</selectedcolor>
 					<align>left</align>
-					<info>ListItem.Label</info>
+					<label>$INFO[ListItem.Label] $LOCALIZE[20347] $INFO[ListItem.Label2]</label>
 				</control>
 			</focusedlayout>
 		</control>

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -115,7 +115,7 @@ bool CGUIWindowVideoInfo::OnMessage(CGUIMessage& message)
       m_hasUpdatedThumb = false;
 
       CGUIDialog::OnMessage(message);
-      m_bViewReview = true;
+      m_bViewReview = false;
       CGUIMessage msg(GUI_MSG_LABEL_RESET, GetID(), CONTROL_DISC);
       OnMessage(msg);
       for (int i = 0; i < 1000; ++i)

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -299,7 +299,8 @@ void CGUIWindowVideoInfo::SetMovie(const CFileItem *item)
       if (CFile::Exists(item->GetCachedActorThumb()))
         item->SetThumbnailImage(item->GetCachedActorThumb());
       item->SetIconImage("DefaultActor.png");
-      item->SetLabel(character);
+      item->SetLabel(it->strName);
+      item->SetLabel2(it->strRole);
       m_castList->Add(item);
     }
     // set fanart property for tvshows and movies

--- a/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
+++ b/xbmc/video/dialogs/GUIDialogVideoInfo.cpp
@@ -290,11 +290,6 @@ void CGUIWindowVideoInfo::SetMovie(const CFileItem *item)
   { // movie/show/episode
     for (CVideoInfoTag::iCast it = m_movieItem->GetVideoInfoTag()->m_cast.begin(); it != m_movieItem->GetVideoInfoTag()->m_cast.end(); ++it)
     {
-      CStdString character;
-      if (it->strRole.IsEmpty())
-        character = it->strName;
-      else
-        character.Format("%s %s %s", it->strName.c_str(), g_localizeStrings.Get(20347).c_str(), it->strRole.c_str());
       CFileItemPtr item(new CFileItem(it->strName));
       if (CFile::Exists(item->GetCachedActorThumb()))
         item->SetThumbnailImage(item->GetCachedActorThumb());


### PR DESCRIPTION
This PR do next things:

1. Splits actor name and actor role in separate labels. Actor name is now accessed by ListItem.Label while actor role is accessed by ListItem.Label2
2. Container with ID 50 which holds list of actors is visible by default on Window initalization
