### PR TITLE
fix crash when using Container.NumItems infolabel with epggrid control #1880

### DIFF
--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1553,7 +1553,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
         if (control && control->IsContainer())
         {
           if (info == CONTAINER_VIEWMODE)
-            strLabel = ((CGUIBaseContainer *)control)->GetLabel();
+            strLabel = ((IGUIContainer *)control)->GetLabel();
           else if (info == CONTAINER_VIEWCOUNT)
             strLabel.Format("%i", window->GetViewCount());
         }
@@ -2441,7 +2441,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
     {
       const CGUIControl *control = window->GetControl(data1);
       if (control && control->IsContainer())
-        item = ((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag());
+        item = ((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag());
     }
 
     if (item) // If we got a valid item, do the lookup
@@ -2770,7 +2770,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
             const CGUIControl *control = window->GetControl(info.GetData1());
             if (control && control->IsContainer())
             {
-              CFileItemPtr item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(0));
+              CFileItemPtr item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(0));
               if (item && item->m_iprogramCount == info.GetData2())  // programcount used to store item id
                 bReturn = true;
             }
@@ -2880,7 +2880,7 @@ bool CGUIInfoManager::GetMultiInfoInt(int &value, const GUIInfo &info, int conte
     {
       const CGUIControl *control = window->GetControl(data1);
       if (control && control->IsContainer())
-        item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
+        item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
     }
 
     if (item) // If we got a valid item, do the lookup
@@ -2923,7 +2923,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     {
       const CGUIControl *control = window->GetControl(data1);
       if (control && control->IsContainer())
-        item = boost::static_pointer_cast<CFileItem>(((CGUIBaseContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
+        item = boost::static_pointer_cast<CFileItem>(((IGUIContainer *)control)->GetListItem(info.GetData2(), info.GetInfoFlag()));
     }
 
     if (item) // If we got a valid item, do the lookup
@@ -2997,7 +2997,7 @@ CStdString CGUIInfoManager::GetMultiInfoLabel(const GUIInfo &info, int contextWi
     if (control)
     {
       if (control->IsContainer())
-        return ((CGUIBaseContainer *)control)->GetLabel(info.m_info);
+        return ((IGUIContainer *)control)->GetLabel(info.m_info);
       else if (control->GetControlType() == CGUIControl::GUICONTROL_GROUPLIST)
         return ((CGUIControlGroupList *)control)->GetLabel(info.m_info);
       else if (control->GetControlType() == CGUIControl::GUICONTROL_TEXTBOX)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -59,6 +59,7 @@
 #include "music/LastFmManager.h"
 #include "pictures/PictureInfoTag.h"
 #include "music/tags/MusicInfoTag.h"
+#include "guilib/IGUIContainer.h"
 #include "video/VideoDatabase.h"
 #include "music/dialogs/GUIDialogMusicScan.h"
 #include "video/dialogs/GUIDialogVideoScan.h"

--- a/xbmc/GUIViewControl.cpp
+++ b/xbmc/GUIViewControl.cpp
@@ -25,6 +25,7 @@
 #include "FileItem.h"
 #include "GUIInfoManager.h"
 #include "LocalizeStrings.h"
+#include "guilib/IGUIContainer.h"
 
 CGUIViewControl::CGUIViewControl(void)
 {

--- a/xbmc/GUIViewControl.cpp
+++ b/xbmc/GUIViewControl.cpp
@@ -122,7 +122,7 @@ void CGUIViewControl::SetCurrentView(int viewMode)
   }
 
   // Update our view control
-  UpdateViewAsControl(((CGUIBaseContainer *)pNewView)->GetLabel());
+  UpdateViewAsControl(((IGUIContainer *)pNewView)->GetLabel());
 }
 
 void CGUIViewControl::SetItems(CFileItemList &items)
@@ -237,11 +237,11 @@ int CGUIViewControl::GetCurrentControl() const
 // returns the number-th view's viewmode (type and id)
 int CGUIViewControl::GetViewModeNumber(int number) const
 {
-  CGUIBaseContainer *nextView = NULL;
+  IGUIContainer *nextView = NULL;
   if (number >= 0 || number < (int)m_visibleViews.size())
-    nextView = (CGUIBaseContainer *)m_visibleViews[number];
+    nextView = (IGUIContainer *)m_visibleViews[number];
   else if (m_visibleViews.size())
-    nextView = (CGUIBaseContainer *)m_visibleViews[0];
+    nextView = (IGUIContainer *)m_visibleViews[0];
   if (nextView)
     return (nextView->GetType() << 16) | nextView->GetID();
   return 0;  // no view modes :(
@@ -257,7 +257,7 @@ int CGUIViewControl::GetViewModeByID(int id) const
 {
   for (unsigned int i = 0; i < m_visibleViews.size(); ++i)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     if (view->GetID() == id)
       return (view->GetType() << 16) | view->GetID();
   }
@@ -272,7 +272,7 @@ int CGUIViewControl::GetNextViewMode(int direction) const
 
   int viewNumber = (m_currentView + direction) % (int)m_visibleViews.size();
   if (viewNumber < 0) viewNumber += m_visibleViews.size();
-  CGUIBaseContainer *nextView = (CGUIBaseContainer *)m_visibleViews[viewNumber];
+  IGUIContainer *nextView = (IGUIContainer *)m_visibleViews[viewNumber];
   return (nextView->GetType() << 16) | nextView->GetID();
 }
 
@@ -289,7 +289,7 @@ int CGUIViewControl::GetView(VIEW_TYPE type, int id) const
 {
   for (int i = 0; i < (int)m_visibleViews.size(); i++)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     if ((type == VIEW_TYPE_NONE || type == view->GetType()) && (!id || view->GetID() == id))
       return i;
   }
@@ -303,7 +303,7 @@ void CGUIViewControl::UpdateViewAsControl(const CStdString &viewLabel)
   g_windowManager.SendMessage(msg);
   for (unsigned int i = 0; i < m_visibleViews.size(); i++)
   {
-    CGUIBaseContainer *view = (CGUIBaseContainer *)m_visibleViews[i];
+    IGUIContainer *view = (IGUIContainer *)m_visibleViews[i];
     CGUIMessage msg(GUI_MSG_LABEL_ADD, m_parentWindow, m_viewAsControl, i);
     CStdString label;
     label.Format(g_localizeStrings.Get(534).c_str(), view->GetLabel().c_str()); // View: %s

--- a/xbmc/GUIViewControl.h
+++ b/xbmc/GUIViewControl.h
@@ -20,9 +20,12 @@
  *
  */
 
-#include "GUIViewState.h"
+#include <vector>
+#include "utils/StdString.h"
+#include "guilib/GraphicContext.h" // for VIEW_TYPE
 
-#include "GUIBaseContainer.h"
+class CGUIControl;
+class CFileItemList;
 
 class CGUIViewControl
 {

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -63,6 +63,8 @@
 #include "music/dialogs/GUIDialogMusicScan.h"
 #include "dialogs/GUIDialogFileBrowser.h"
 #include "video/dialogs/GUIDialogVideoScan.h"
+#include "guilib/TextureManager.h"
+#include "guilib/IGUIContainer.h"
 #include "utils/fstrcmp.h"
 #include "utils/Trainer.h"
 #ifdef HAS_XBOX_HARDWARE
@@ -1582,31 +1584,31 @@ void CUtil::RemoveIllegalChars( CStdString& strText)
 {
   char szRemoveIllegal [1024];
   strcpy(szRemoveIllegal , strText.c_str());
-  static char legalChars[] = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~.ßåÄäÖöüøéèçàùêÂñáïëìíâãæîğòôóõ÷ú";
+  static char legalChars[] = " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890!#$%&'()-@[]^_`{}~.ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½";
   
   char *cursor;
   for (cursor = szRemoveIllegal; *(cursor += strspn(cursor, legalChars)); /**/ )
   {
     // Convert FatX illegal characters, if possible, to the closest "looking" character:
-    if (strchr("ÂÁÀÄÃÅ", (int) *cursor)) *cursor = 'A';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'A';
     else
-    if (strchr("âáàäãå", (int) *cursor)) *cursor = 'a';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'a';
     else
-    if (strchr("ÔÓÒÖÕ", (int) *cursor)) *cursor = 'O';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'O';
     else
-    if (strchr("ôóòöõ", (int) *cursor)) *cursor = 'o';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'o';
     else
-    if (strchr("ÛÚÙÜ", (int) *cursor)) *cursor = 'U';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'U';
     else
-    if (strchr("ûúùüµ", (int) *cursor)) *cursor = 'u';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'u';
     else
-    if (strchr("ÊÉÈË", (int) *cursor)) *cursor = 'E';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'E';
     else
-    if (strchr("êéèë", (int) *cursor)) *cursor = 'e';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'e';
     else
-    if (strchr("ÎÍÌÏ", (int) *cursor)) *cursor = 'I';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'I';
     else
-    if (strchr("îìíï", (int) *cursor)) *cursor = 'i';
+    if (strchr("ï¿½ï¿½ï¿½ï¿½", (int) *cursor)) *cursor = 'i';
     else
     *cursor = '_';
   }

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -36,8 +36,19 @@ using namespace std;
 #define HOLD_TIME_START 100
 #define HOLD_TIME_END   3000
 
+IGUIContainer::IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
+  : CGUIControl(parentID, controlID, posX, posY, width, height)
+{
+}
+
+void IGUIContainer::SetType(VIEW_TYPE type, const CStdString &label)
+{
+  m_type = type;
+  m_label = label;
+}
+
 CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
-    : CGUIControl(parentID, controlID, posX, posY, width, height)
+    : IGUIContainer(parentID, controlID, posX, posY, width, height)
     , m_scroller(scroller)
 {
   m_cursor = 0;
@@ -921,12 +932,6 @@ void CGUIBaseContainer::SetListProvider(IListProvider *provider)
 void CGUIBaseContainer::SetRenderOffset(const CPoint &offset)
 {
   m_renderOffset = offset;
-}
-
-void CGUIBaseContainer::SetType(VIEW_TYPE type, const CStdString &label)
-{
-  m_type = type;
-  m_label = label;
 }
 
 void CGUIBaseContainer::FreeMemory(int keepStart, int keepEnd)

--- a/xbmc/guilib/GUIBaseContainer.cpp
+++ b/xbmc/guilib/GUIBaseContainer.cpp
@@ -36,17 +36,6 @@ using namespace std;
 #define HOLD_TIME_START 100
 #define HOLD_TIME_END   3000
 
-IGUIContainer::IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
-  : CGUIControl(parentID, controlID, posX, posY, width, height)
-{
-}
-
-void IGUIContainer::SetType(VIEW_TYPE type, const CStdString &label)
-{
-  m_type = type;
-  m_label = label;
-}
-
 CGUIBaseContainer::CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems)
     : IGUIContainer(parentID, controlID, posX, posY, width, height)
     , m_scroller(scroller)

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -39,7 +39,24 @@ typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 class IListProvider;
 
-class CGUIBaseContainer : public CGUIControl
+class IGUIContainer : public CGUIControl
+{
+protected:
+  VIEW_TYPE m_type;
+  CStdString m_label;
+public:
+  IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height);
+  virtual bool IsContainer() const { return true; };
+
+  VIEW_TYPE GetType() const { return m_type; };
+  const CStdString &GetLabel() const { return m_label; };
+  void SetType(VIEW_TYPE type, const CStdString &label);
+
+  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
+  virtual CStdString GetLabel(int info) const                                  = 0;
+};
+
+class CGUIBaseContainer : public IGUIContainer
 {
 public:
   CGUIBaseContainer(int parentID, int controlID, float posX, float posY, float width, float height, ORIENTATION orientation, const CScroller& scroller, int preloadItems);
@@ -73,15 +90,10 @@ public:
   void LoadLayout(TiXmlElement *layout);
   void LoadListProvider(TiXmlElement *content, int defaultItem, bool defaultAlways);
 
-  VIEW_TYPE GetType() const { return m_type; };
-  const CStdString &GetLabel() const { return m_label; };
-  void SetType(VIEW_TYPE type, const CStdString &label);
-
-  virtual bool IsContainer() const { return true; };
-  CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
+  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const;
 
   virtual bool GetCondition(int condition, int data) const;
-  CStdString GetLabel(int info) const;
+  virtual CStdString GetLabel(int info) const;
 
   /*! \brief Set the list provider for this container (for python).
    \param provider the list provider to use for this container.
@@ -158,9 +170,6 @@ protected:
   void UpdateScrollOffset();
 
   CScroller m_scroller;
-
-  VIEW_TYPE m_type;
-  CStdString m_label;
 
   IListProvider *m_listProvider;
 

--- a/xbmc/guilib/GUIBaseContainer.h
+++ b/xbmc/guilib/GUIBaseContainer.h
@@ -25,12 +25,9 @@
  *
  */
 
-#include "GUIControl.h"
+#include "IGUIContainer.h"
 #include "GUIListItemLayout.h"
-#include "boost/shared_ptr.hpp"
 #include "utils/Stopwatch.h"
-
-typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
 
 /*!
  \ingroup controls
@@ -38,23 +35,6 @@ typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
  */
 
 class IListProvider;
-
-class IGUIContainer : public CGUIControl
-{
-protected:
-  VIEW_TYPE m_type;
-  CStdString m_label;
-public:
-  IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height);
-  virtual bool IsContainer() const { return true; };
-
-  VIEW_TYPE GetType() const { return m_type; };
-  const CStdString &GetLabel() const { return m_label; };
-  void SetType(VIEW_TYPE type, const CStdString &label);
-
-  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
-  virtual CStdString GetLabel(int info) const                                  = 0;
-};
 
 class CGUIBaseContainer : public IGUIContainer
 {

--- a/xbmc/guilib/IGUIContainer.h
+++ b/xbmc/guilib/IGUIContainer.h
@@ -1,0 +1,54 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include "GUIControl.h"
+#include "boost/shared_ptr.hpp"
+
+typedef boost::shared_ptr<CGUIListItem> CGUIListItemPtr;
+
+/*!
+ \ingroup controls
+ \brief
+ */
+
+class IGUIContainer : public CGUIControl
+{
+protected:
+  VIEW_TYPE m_type;
+  CStdString m_label;
+public:
+  IGUIContainer(int parentID, int controlID, float posX, float posY, float width, float height)
+   : CGUIControl(parentID, controlID, posX, posY, width, height), m_type(VIEW_TYPE_NONE) {}
+
+  virtual bool IsContainer() const { return true; };
+
+  VIEW_TYPE GetType() const { return m_type; };
+  const CStdString &GetLabel() const { return m_label; };
+  void SetType(VIEW_TYPE type, const CStdString &label)
+  {
+    m_type = type;
+    m_label = label;
+  }
+
+  virtual CGUIListItemPtr GetListItem(int offset, unsigned int flag = 0) const = 0;
+  virtual CStdString GetLabel(int info) const                                  = 0;
+};

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -73,6 +73,7 @@
 #include "utils/ScraperParser.h"
 #include "FileItem.h"
 #include "GUIToggleButtonControl.h"
+#include "IGUIContainer.h"
 #include "FileSystem/SpecialProtocol.h"
 #include "FileSystem/File.h"
 #include "LocalizeStrings.h"

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -3177,7 +3177,7 @@ void CGUIWindowSettingsCategory::FillInViewModes(CSetting *pSetting, int windowI
     window->Initialize();
     for (int i = 50; i < 60; i++)
     {
-      CGUIBaseContainer *control = (CGUIBaseContainer *)window->GetControl(i);
+      IGUIContainer *control = (IGUIContainer *)window->GetControl(i);
       if (control)
       {
         int type = (control->GetType() << 16) | i;

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -24,6 +24,7 @@
 #include "FileSystem/VirtualDirectory.h"
 #include "FileSystem/DirectoryHistory.h"
 #include "GUIViewControl.h"
+#include "GUIViewState.h"
 #include "dialogs/GUIDialogContextMenu.h"
 #include "SmartPlayList.h"
 


### PR DESCRIPTION
- This partial backport of [#1880](https://github.com/xbmc/xbmc/pull/1880)

Second commit is just cleanup which moves IGUIContainer inside it's separate file. Everything else is just to make code up-to-date with Kodi's since we don't have EPG.