### PR TITLE
Restore possibility to type in the value field of a smartplaylist rule for browsable fields #1701

### DIFF
--- a/xbmc/SmartPlaylist.cpp
+++ b/xbmc/SmartPlaylist.cpp
@@ -632,6 +632,17 @@ CStdString CSmartPlaylistRule::GetParameter() const
   return StringUtils::JoinString(m_parameter, " / ");
 }
 
+void CSmartPlaylistRule::SetParameter(const CStdString &value)
+{
+  m_parameter.clear();
+  StringUtils::SplitString(value, " / ", m_parameter);
+}
+
+void CSmartPlaylistRule::SetParameter(const std::vector<CStdString> &values)
+{
+  m_parameter.assign(values.begin(), values.end());
+}
+
 CStdString CSmartPlaylistRule::GetVideoResolutionQuery(const CStdString &parameter) const
 {
   CStdString retVal(" in (select distinct idFile from streamdetails where iVideoWidth ");

--- a/xbmc/SmartPlaylist.cpp
+++ b/xbmc/SmartPlaylist.cpp
@@ -620,14 +620,14 @@ CStdString CSmartPlaylistRule::GetLocalizedOperator(SEARCH_OPERATOR oper)
   return g_localizeStrings.Get(16018);
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedRule(const CStdString &type) const
+CStdString CSmartPlaylistRule::GetLocalizedRule() const
 {
   CStdString rule;
-  rule.Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetLocalizedParameter(type).c_str());
+  rule.Format("%s %s %s", GetLocalizedField(m_field).c_str(), GetLocalizedOperator(m_operator).c_str(), GetParameter().c_str());
   return rule;
 }
 
-CStdString CSmartPlaylistRule::GetLocalizedParameter(const CStdString &type) const
+CStdString CSmartPlaylistRule::GetParameter() const
 {
   return StringUtils::JoinString(m_parameter, " / ");
 }

--- a/xbmc/SmartPlaylist.h
+++ b/xbmc/SmartPlaylist.h
@@ -97,6 +97,8 @@ public:
 
   CStdString                  GetLocalizedRule() const;
   CStdString                  GetParameter() const;
+  void                        SetParameter(const CStdString &value);
+  void                        SetParameter(const std::vector<CStdString> &values);
 
   Field                       m_field;
   SEARCH_OPERATOR             m_operator;

--- a/xbmc/SmartPlaylist.h
+++ b/xbmc/SmartPlaylist.h
@@ -95,8 +95,8 @@ public:
   static std::vector<SortBy>  GetOrders(const CStdString &type);
   static FIELD_TYPE           GetFieldType(Field field);
 
-  CStdString                  GetLocalizedRule(const CStdString &type) const;
-  CStdString                  GetLocalizedParameter(const CStdString &type) const;
+  CStdString                  GetLocalizedRule() const;
+  CStdString                  GetParameter() const;
 
   Field                       m_field;
   SEARCH_OPERATOR             m_operator;

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -285,7 +285,7 @@ void CGUIDialogMediaFilter::CreateSettings()
       {
         CStdString *values = new CStdString();
         if (filter.rule != NULL && filter.rule->m_parameter.size() > 0)
-          *values = filter.rule->GetLocalizedParameter(m_mediaType);
+          *values = filter.rule->GetParameter();
         filter.data = values;
 
         AddButton(filter.field, filter.label);
@@ -438,7 +438,7 @@ void CGUIDialogMediaFilter::OnSettingChanged(SettingInfo &setting)
         for (int index = 0; index < items.Size(); index++)
           filter.rule->m_parameter.push_back(items[index]->GetLabel());
 
-        *(CStdString *)filter.data = filter.rule->GetLocalizedParameter(m_mediaType);
+        *(CStdString *)filter.data = filter.rule->GetParameter();
       }
       else
       {

--- a/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistEditor.cpp
@@ -263,7 +263,7 @@ void CGUIDialogSmartPlaylistEditor::UpdateButtons()
     if (m_playlist.m_ruleCombination.m_rules[i].m_field == FieldNone)
       item->SetLabel(g_localizeStrings.Get(21423));
     else
-      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i].GetLocalizedRule(m_playlist.GetType()));
+      item->SetLabel(m_playlist.m_ruleCombination.m_rules[i].GetLocalizedRule());
     m_ruleLabels->Add(item);
   }
   CGUIMessage msg(GUI_MSG_LABEL_BIND, GetID(), CONTROL_RULE_LIST, 0, 0, m_ruleLabels);

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -70,14 +70,11 @@ bool CGUIDialogSmartPlaylistRule::OnMessage(CGUIMessage& message)
         OnOK();
       else if (iControl == CONTROL_CANCEL)
         OnCancel();
-      else if (iControl == CONTROL_VALUE && CSmartPlaylistRule::GetFieldType(m_rule.m_field) != CSmartPlaylistRule::BROWSEABLE_FIELD)
+      else if (iControl == CONTROL_VALUE)
       {
         CStdString parameter;
         OnEditChanged(iControl, parameter);
-        m_rule.m_parameter.clear();
-
-        if (!parameter.empty())
-          m_rule.m_parameter.push_back(parameter);
+        m_rule.SetParameter(parameter);
       }
       else if (iControl == CONTROL_OPERATOR)
         OnOperator();
@@ -441,8 +438,6 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   switch (fieldType)
   {
   case CSmartPlaylistRule::BROWSEABLE_FIELD:
-    type = CGUIEditControl::INPUT_TYPE_READONLY;
-    break;
   case CSmartPlaylistRule::BROWSEABLE_NUMERIC_FIELD:
   case CSmartPlaylistRule::TEXT_FIELD:
   case CSmartPlaylistRule::PLAYLIST_FIELD:

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -278,7 +278,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
     }
     g_mediaManager.GetLocalDrives(sources);
 
-    CStdString path = m_rule.GetLocalizedParameter(m_type);
+    CStdString path = m_rule.GetParameter();
     CGUIDialogFileBrowser::ShowAndGetDirectory(sources, g_localizeStrings.Get(657), path, false);
     if (m_rule.m_parameter.size() > 0)
       m_rule.m_parameter.clear();
@@ -435,7 +435,7 @@ void CGUIDialogSmartPlaylistRule::UpdateButtons()
   m_rule.m_operator = (CSmartPlaylistRule::SEARCH_OPERATOR)selected.GetParam1();
 
   // update the parameter edit control appropriately
-  SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetLocalizedParameter(m_type));
+  SET_CONTROL_LABEL2(CONTROL_VALUE, m_rule.GetParameter());
   CGUIEditControl::INPUT_TYPE type = CGUIEditControl::INPUT_TYPE_TEXT;
   CSmartPlaylistRule::FIELD_TYPE fieldType = CSmartPlaylistRule::GetFieldType(m_rule.m_field);
   switch (fieldType)


### PR DESCRIPTION
- This is backport of [#1701](https://github.com/xbmc/xbmc/pull/1701)