### PR TITLE
Settings: don't use integers when adding setting options

### DIFF
--- a/language/English/strings.po
+++ b/language/English/strings.po
@@ -3154,7 +3154,13 @@ msgctxt "#1260"
 msgid "Announce these services to other systems via Zeroconf"
 msgstr ""
 
-#empty strings from id 1261 to 1274
+#empty strings from id 1261 to 1270
+
+msgctxt "#1271"
+msgid "Device name"
+msgstr ""
+
+#empty strings from id 1272 to 1274
 
 msgctxt "#1275"
 msgid "Filter %s"

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -320,6 +320,7 @@ const infomap system_labels[] =  {{ "hasnetwork",           SYSTEM_ETHERNET_LINK
                                   { "profilethumb",         SYSTEM_PROFILETHUMB },
                                   { "launchxbe",            SYSTEM_LAUNCHING_XBE },
                                   { "progressbar",          SYSTEM_PROGRESS_BAR },
+                                  { "friendlyname",         SYSTEM_FRIENDLY_NAME },
                                   { "alarmpos",             SYSTEM_ALARM_POS },
                                   { "startupwindow",        SYSTEM_STARTUP_WINDOW }};
 
@@ -1695,6 +1696,15 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
       int percent;
       if (GetInt(percent, SYSTEM_PROGRESS_BAR) && percent > 0)
         strLabel.Format("%i", percent);
+    }
+    break;
+  case SYSTEM_FRIENDLY_NAME:
+    {
+      CStdString friendlyName = g_guiSettings.GetString("services.friendlyname");
+      if (friendlyName.Equals("XBMC"))
+        strLabel.Format("%s (%s)", friendlyName.c_str(), "XBOX");
+      else
+        strLabel = friendlyName;
     }
     break;
   case LCD_PLAY_ICON:

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -1700,7 +1700,7 @@ CStdString CGUIInfoManager::GetLabel(int info, int contextWindow)
     break;
   case SYSTEM_FRIENDLY_NAME:
     {
-      CStdString friendlyName = g_guiSettings.GetString("services.friendlyname");
+      CStdString friendlyName = g_guiSettings.GetString("services.devicename");
       if (friendlyName.Equals("XBMC"))
         strLabel.Format("%s (%s)", friendlyName.c_str(), "XBOX");
       else

--- a/xbmc/GUIInfoManager.h
+++ b/xbmc/GUIInfoManager.h
@@ -427,6 +427,7 @@ namespace INFO
 #define SYSTEM_SETTING              710
 #define SYSTEM_HAS_ADDON            711
 #define SYSTEM_IDLE_TIME            715
+#define SYSTEM_FRIENDLY_NAME        716
 
 #define LIBRARY_HAS_MUSIC           720
 #define LIBRARY_HAS_VIDEO           721

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -2234,7 +2234,7 @@ CUPnPServer*
 CUPnP::CreateServer(int port /* = 0 */)
 {
     CUPnPServer* device =
-        new CUPnPServer("XBMC: Media Server:",
+        new CUPnPServer(g_guiSettings.GetString("services.friendlyname"),
                         g_settings.m_UPnPUUIDServer.length()?g_settings.m_UPnPUUIDServer.c_str():NULL,
                         port);
 
@@ -2334,8 +2334,8 @@ CUPnPRenderer*
 CUPnP::CreateRenderer(int port /* = 0 */)
 {
     CUPnPRenderer* device =
-        new CUPnPRenderer("XBMC: Media Renderer",
-                          true,
+        new CUPnPRenderer(g_guiSettings.GetString("services.friendlyname"),
+                          (g_guiSettings.GetString("services.friendlyname") != "XBMC" ? false : true),
                           (g_settings.m_UPnPUUIDRenderer.length() ? g_settings.m_UPnPUUIDRenderer.c_str() : NULL),
                           port);
 

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -198,396 +198,396 @@ void CGUISettings::Initialize()
 
   // Pictures settings
   AddGroup(0, 1);
-  AddCategory(0, "pictures", 14081);
-  AddBool(1, "pictures.usetags", 14082, true);
-  AddBool(2,"pictures.generatethumbs",13360,true);
-  AddBool(3, "pictures.useexifrotation", 20184, true);
-  AddBool(4, "pictures.showvideos", 22022, false);
-  AddInt(8, "pictures.displayresolution", 169, (int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
+  CSettingsCategory* pic = AddCategory(0, "pictures", 14081);
+  AddBool(pic, "pictures.usetags", 14082, true);
+  AddBool(pic,"pictures.generatethumbs",13360,true);
+  AddBool(pic, "pictures.useexifrotation", 20184, true);
+  AddBool(pic, "pictures.showvideos", 22022, false);
+  AddInt(pic, "pictures.displayresolution", 169, (int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
 
-  AddCategory(0, "slideshow", 108);
-  AddInt(1, "slideshow.staytime", 12378, 5, 1, 1, 100, SPIN_CONTROL_INT_PLUS, MASK_SECS);
-  AddBool(2, "slideshow.displayeffects", 12379, true);
-  AddBool(0, "slideshow.shuffle", 13319, false);
+  CSettingsCategory* cat = AddCategory(0, "slideshow", 108);
+  AddInt(cat, "slideshow.staytime", 12378, 5, 1, 1, 100, SPIN_CONTROL_INT_PLUS, MASK_SECS);
+  AddBool(cat, "slideshow.displayeffects", 12379, true);
+  AddBool(NULL, "slideshow.shuffle", 13319, false);
 
   // Programs settings
   AddGroup(1, 0);
-  AddCategory(1, "myprograms", 16000);
-  AddBool(1, "myprograms.autoffpatch", 29999, false);
-  AddSeparator(2,"myprograms.sep1");
-  AddBool(3, "myprograms.gameautoregion",511,false);
-  AddInt(4, "myprograms.ntscmode", 16110, 0, 0, 1, 3, SPIN_CONTROL_TEXT);
-  AddSeparator(5,"myprograms.sep2");
-  AddString(6, "myprograms.trainerpath", 20003, "select folder", BUTTON_CONTROL_PATH_INPUT, false, 657);
-  AddSeparator(7,"myprograms.sep3");
-  AddBool(8, "myprograms.usedashpath", 13007, true);
-  AddString(9, "myprograms.dashboard", 13006, "C:\\xboxdash.xbe", BUTTON_CONTROL_PATH_INPUT, false, 655);
+  CSettingsCategory* pro = AddCategory(1, "myprograms", 16000);
+  AddBool(pro, "myprograms.autoffpatch", 29999, false);
+  AddSeparator(pro,"myprograms.sep1");
+  AddBool(pro, "myprograms.gameautoregion",511,false);
+  AddInt(pro, "myprograms.ntscmode", 16110, 0, 0, 1, 3, SPIN_CONTROL_TEXT);
+  AddSeparator(pro,"myprograms.sep2");
+  AddString(pro, "myprograms.trainerpath", 20003, "select folder", BUTTON_CONTROL_PATH_INPUT, false, 657);
+  AddSeparator(pro,"myprograms.sep3");
+  AddBool(pro, "myprograms.usedashpath", 13007, true);
+  AddString(pro, "myprograms.dashboard", 13006, "C:\\xboxdash.xbe", BUTTON_CONTROL_PATH_INPUT, false, 655);
 
   // My Weather settings
   AddGroup(2, 8);
-  AddCategory(2, "weather", 16000);
-  AddString(1, "weather.areacode1", 14019, "USNY0996 - New York, NY", BUTTON_CONTROL_STANDARD);
-  AddString(2, "weather.areacode2", 14020, "UKXX0085 - London, United Kingdom", BUTTON_CONTROL_STANDARD);
-  AddString(3, "weather.areacode3", 14021, "JAXX0085 - Tokyo, Japan", BUTTON_CONTROL_STANDARD);
-  AddSeparator(4, "weather.sep1");
-  AddString(5, "weather.plugin", 23000, "", SPIN_CONTROL_TEXT, true);
-  AddString(6, "weather.pluginsettings", 23001, "", BUTTON_CONTROL_STANDARD, true);
+  CSettingsCategory* wea = AddCategory(2, "weather", 16000);
+  AddString(wea, "weather.areacode1", 14019, "USNY0996 - New York, NY", BUTTON_CONTROL_STANDARD);
+  AddString(wea, "weather.areacode2", 14020, "UKXX0085 - London, United Kingdom", BUTTON_CONTROL_STANDARD);
+  AddString(wea, "weather.areacode3", 14021, "JAXX0085 - Tokyo, Japan", BUTTON_CONTROL_STANDARD);
+  AddSeparator(wea, "weather.sep1");
+  AddString(wea, "weather.plugin", 23000, "", SPIN_CONTROL_TEXT, true);
+  AddString(wea, "weather.pluginsettings", 23001, "", BUTTON_CONTROL_STANDARD, true);
 
   // My Music Settings
   AddGroup(3, 2);
-  AddCategory(3,"musiclibrary",14022);
-  AddBool(1, "musiclibrary.enabled", 421, true);
-  AddBool(2, "musiclibrary.showcompilationartists", 13414, true);
-  AddSeparator(3,"musiclibrary.sep1");
-  AddBool(4,"musiclibrary.downloadinfo", 20192, false);
-  AddString(6, "musiclibrary.scraper", 20194, "tadb.xml", SPIN_CONTROL_TEXT);
-  AddString(7, "musiclibrary.scrapersettings", 21417, "", BUTTON_CONTROL_STANDARD);
-  AddBool(8, "musiclibrary.updateonstartup", 22000, false);
-  AddBool(0, "musiclibrary.backgroundupdate", 22001, false);
-  AddSeparator(9,"musiclibrary.sep2");
-  AddString(10, "musiclibrary.cleanup", 334, "", BUTTON_CONTROL_STANDARD);
-  AddString(11, "musiclibrary.export", 20196, "", BUTTON_CONTROL_STANDARD);
-  AddString(12, "musiclibrary.import", 20197, "", BUTTON_CONTROL_STANDARD);
+  CSettingsCategory* ml = AddCategory(3,"musiclibrary",14022);
+  AddBool(ml, "musiclibrary.enabled", 421, true);
+  AddBool(ml, "musiclibrary.showcompilationartists", 13414, true);
+  AddSeparator(ml,"musiclibrary.sep1");
+  AddBool(ml,"musiclibrary.downloadinfo", 20192, false);
+  AddString(ml, "musiclibrary.scraper", 20194, "tadb.xml", SPIN_CONTROL_TEXT);
+  AddString(ml, "musiclibrary.scrapersettings", 21417, "", BUTTON_CONTROL_STANDARD);
+  AddBool(ml, "musiclibrary.updateonstartup", 22000, false);
+  AddBool(NULL, "musiclibrary.backgroundupdate", 22001, false);
+  AddSeparator(ml,"musiclibrary.sep2");
+  AddString(ml, "musiclibrary.cleanup", 334, "", BUTTON_CONTROL_STANDARD);
+  AddString(ml, "musiclibrary.export", 20196, "", BUTTON_CONTROL_STANDARD);
+  AddString(ml, "musiclibrary.import", 20197, "", BUTTON_CONTROL_STANDARD);
 
-  AddCategory(3, "musicplayer", 14086);
-  AddBool(1, "musicplayer.autoplaynextitem", 489, true);
-  AddBool(2, "musicplayer.queuebydefault", 14084, false);
-  AddSeparator(3, "musicplayer.sep1");
-  AddInt(4, "musicplayer.replaygaintype", 638, REPLAY_GAIN_ALBUM, REPLAY_GAIN_NONE, 1, REPLAY_GAIN_TRACK, SPIN_CONTROL_TEXT);
-  AddInt(0, "musicplayer.replaygainpreamp", 641, 89, 77, 1, 101, SPIN_CONTROL_INT_PLUS, MASK_DB);
-  AddInt(0, "musicplayer.replaygainnogainpreamp", 642, 89, 77, 1, 101, SPIN_CONTROL_INT_PLUS, MASK_DB);
-  AddBool(0, "musicplayer.replaygainavoidclipping", 643, false);
-  AddInt(5, "musicplayer.crossfade", 13314, 0, 0, 1, 15, SPIN_CONTROL_INT_PLUS, MASK_SECS, TEXT_OFF);
-  AddBool(6, "musicplayer.crossfadealbumtracks", 13400, true);
-  AddSeparator(7, "musicplayer.sep2");
-  AddString(8, "musicplayer.visualisation", 250, DEFAULT_VISUALISATION, SPIN_CONTROL_TEXT);
-  AddSeparator(9, "musicplayer.sep3");
-  AddInt(10, "musicplayer.defaultplayer", 22003, PLAYER_PAPLAYER, PLAYER_MPLAYER, 1, PLAYER_PAPLAYER, SPIN_CONTROL_TEXT);
+  CSettingsCategory* mp = AddCategory(3, "musicplayer", 14086);
+  AddBool(mp, "musicplayer.autoplaynextitem", 489, true);
+  AddBool(mp, "musicplayer.queuebydefault", 14084, false);
+  AddSeparator(mp, "musicplayer.sep1");
+  AddInt(mp, "musicplayer.replaygaintype", 638, REPLAY_GAIN_ALBUM, REPLAY_GAIN_NONE, 1, REPLAY_GAIN_TRACK, SPIN_CONTROL_TEXT);
+  AddInt(NULL, "musicplayer.replaygainpreamp", 641, 89, 77, 1, 101, SPIN_CONTROL_INT_PLUS, MASK_DB);
+  AddInt(NULL, "musicplayer.replaygainnogainpreamp", 642, 89, 77, 1, 101, SPIN_CONTROL_INT_PLUS, MASK_DB);
+  AddBool(NULL, "musicplayer.replaygainavoidclipping", 643, false);
+  AddInt(mp, "musicplayer.crossfade", 13314, 0, 0, 1, 15, SPIN_CONTROL_INT_PLUS, MASK_SECS, TEXT_OFF);
+  AddBool(mp, "musicplayer.crossfadealbumtracks", 13400, true);
+  AddSeparator(mp, "musicplayer.sep2");
+  AddString(mp, "musicplayer.visualisation", 250, DEFAULT_VISUALISATION, SPIN_CONTROL_TEXT);
+  AddSeparator(mp, "musicplayer.sep3");
+  AddInt(mp, "musicplayer.defaultplayer", 22003, PLAYER_PAPLAYER, PLAYER_MPLAYER, 1, PLAYER_PAPLAYER, SPIN_CONTROL_TEXT);
 #ifdef _XBOX
-  AddBool(11, "musicplayer.outputtoallspeakers", 252, false);
+  AddBool(mp, "musicplayer.outputtoallspeakers", 252, false);
 #endif
 
-  AddCategory(3, "musicfiles", 14081);
-  AddBool(1, "musicfiles.usetags", 258, false);
-  AddString(2, "musicfiles.trackformat", 13307, "[%N. ]%A - %T", EDIT_CONTROL_INPUT, false, 16016);
-  AddString(3, "musicfiles.trackformatright", 13387, "%D", EDIT_CONTROL_INPUT, false, 16016);
+  CSettingsCategory* mf = AddCategory(3, "musicfiles", 14081);
+  AddBool(mf, "musicfiles.usetags", 258, false);
+  AddString(mf, "musicfiles.trackformat", 13307, "[%N. ]%A - %T", EDIT_CONTROL_INPUT, false, 16016);
+  AddString(mf, "musicfiles.trackformatright", 13387, "%D", EDIT_CONTROL_INPUT, false, 16016);
   // advanced per-view trackformats.
-  AddString(0, "musicfiles.nowplayingtrackformat", 13307, "", EDIT_CONTROL_INPUT, false, 16016);
-  AddString(0, "musicfiles.nowplayingtrackformatright", 13387, "", EDIT_CONTROL_INPUT, false, 16016);
-  AddString(0, "musicfiles.librarytrackformat", 13307, "", EDIT_CONTROL_INPUT, false, 16016);
-  AddString(0, "musicfiles.librarytrackformatright", 13387, "", EDIT_CONTROL_INPUT, false, 16016);
-  AddBool(4, "musicfiles.findremotethumbs", 14059, true);
+  AddString(NULL, "musicfiles.nowplayingtrackformat", 13307, "", EDIT_CONTROL_INPUT, false, 16016);
+  AddString(NULL, "musicfiles.nowplayingtrackformatright", 13387, "", EDIT_CONTROL_INPUT, false, 16016);
+  AddString(NULL, "musicfiles.librarytrackformat", 13307, "", EDIT_CONTROL_INPUT, false, 16016);
+  AddString(NULL, "musicfiles.librarytrackformatright", 13387, "", EDIT_CONTROL_INPUT, false, 16016);
+  AddBool(mf, "musicfiles.findremotethumbs", 14059, true);
 
-  AddCategory(3, "scrobbler", 15221);
-  AddBool(1, "scrobbler.lastfmsubmit", 15201, false);
-  AddBool(2, "scrobbler.lastfmsubmitradio", 15250, false);
-  AddString(3, "scrobbler.lastfmusername", 15202, "", EDIT_CONTROL_INPUT, false, 15202);
-  AddString(4, "scrobbler.lastfmpass", 15203, "", EDIT_CONTROL_MD5_INPUT, false, 15203);
-  AddSeparator(5, "scrobbler.sep1");
-  AddBool(6, "scrobbler.librefmsubmit", 15217, false);
-  AddString(7, "scrobbler.librefmusername", 15218, "", EDIT_CONTROL_INPUT, false, 15218);
-  AddString(8, "scrobbler.librefmpass", 15219, "", EDIT_CONTROL_MD5_INPUT, false, 15219);
+  CSettingsCategory* scr = AddCategory(3, "scrobbler", 15221);
+  AddBool(scr, "scrobbler.lastfmsubmit", 15201, false);
+  AddBool(scr, "scrobbler.lastfmsubmitradio", 15250, false);
+  AddString(scr, "scrobbler.lastfmusername", 15202, "", EDIT_CONTROL_INPUT, false, 15202);
+  AddString(scr, "scrobbler.lastfmpass", 15203, "", EDIT_CONTROL_MD5_INPUT, false, 15203);
+  AddSeparator(scr, "scrobbler.sep1");
+  AddBool(scr, "scrobbler.librefmsubmit", 15217, false);
+  AddString(scr, "scrobbler.librefmusername", 15218, "", EDIT_CONTROL_INPUT, false, 15218);
+  AddString(scr, "scrobbler.librefmpass", 15219, "", EDIT_CONTROL_MD5_INPUT, false, 15219);
 
-  AddCategory(3, "audiocds", 620);
-  AddBool(2, "audiocds.usecddb", 227, true);
-  AddSeparator(3, "audiocds.sep1");
-  AddPath(4,"audiocds.recordingpath",20000,"select writable folder",BUTTON_CONTROL_PATH_INPUT,false,657);
-  AddString(5, "audiocds.trackpathformat", 13307, "%A - %B/[%N. ][%A - ]%T", EDIT_CONTROL_INPUT, false, 16016);
-  AddInt(6, "audiocds.encoder", 621, CDDARIP_ENCODER_LAME, CDDARIP_ENCODER_LAME, 1, CDDARIP_ENCODER_FLAC, SPIN_CONTROL_TEXT);
-  AddInt(7, "audiocds.quality", 622, CDDARIP_QUALITY_CBR, CDDARIP_QUALITY_CBR, 1, CDDARIP_QUALITY_EXTREME, SPIN_CONTROL_TEXT);
-  AddInt(8, "audiocds.bitrate", 623, 192, 128, 32, 320, SPIN_CONTROL_INT_PLUS, MASK_KBPS);
-  AddInt(9, "audiocds.compressionlevel", 665, 5, 0, 1, 8, SPIN_CONTROL_INT_PLUS);
+  CSettingsCategory* acd = AddCategory(3, "audiocds", 620);
+  AddBool(acd, "audiocds.usecddb", 227, true);
+  AddSeparator(acd, "audiocds.sep1");
+  AddPath(acd,"audiocds.recordingpath",20000,"select writable folder",BUTTON_CONTROL_PATH_INPUT,false,657);
+  AddString(acd, "audiocds.trackpathformat", 13307, "%A - %B/[%N. ][%A - ]%T", EDIT_CONTROL_INPUT, false, 16016);
+  AddInt(acd, "audiocds.encoder", 621, CDDARIP_ENCODER_LAME, CDDARIP_ENCODER_LAME, 1, CDDARIP_ENCODER_FLAC, SPIN_CONTROL_TEXT);
+  AddInt(acd, "audiocds.quality", 622, CDDARIP_QUALITY_CBR, CDDARIP_QUALITY_CBR, 1, CDDARIP_QUALITY_EXTREME, SPIN_CONTROL_TEXT);
+  AddInt(acd, "audiocds.bitrate", 623, 192, 128, 32, 320, SPIN_CONTROL_INT_PLUS, MASK_KBPS);
+  AddInt(acd, "audiocds.compressionlevel", 665, 5, 0, 1, 8, SPIN_CONTROL_INT_PLUS);
 
-  AddCategory(3, "karaoke", 13327);
-  AddBool(1, "karaoke.enabled", 13323, false);
-  AddBool(2, "karaoke.voiceenabled", 13361, false);
-  AddInt(3, "karaoke.volume", 13376, 100, 0, 1, 100, SPIN_CONTROL_INT, MASK_PERCENT);
-  AddString(4, "karaoke.port0voicemask", 13382, "None", SPIN_CONTROL_TEXT);
-  AddString(5, "karaoke.port1voicemask", 13383, "None", SPIN_CONTROL_TEXT);
-  AddString(6, "karaoke.port2voicemask", 13384, "None", SPIN_CONTROL_TEXT);
-  AddString(7, "karaoke.port3voicemask", 13385, "None", SPIN_CONTROL_TEXT);
+  CSettingsCategory* kar = AddCategory(3, "karaoke", 13327);
+  AddBool(kar, "karaoke.enabled", 13323, false);
+  AddBool(kar, "karaoke.voiceenabled", 13361, false);
+  AddInt(kar, "karaoke.volume", 13376, 100, 0, 1, 100, SPIN_CONTROL_INT, MASK_PERCENT);
+  AddString(kar, "karaoke.port0voicemask", 13382, "None", SPIN_CONTROL_TEXT);
+  AddString(kar, "karaoke.port1voicemask", 13383, "None", SPIN_CONTROL_TEXT);
+  AddString(kar, "karaoke.port2voicemask", 13384, "None", SPIN_CONTROL_TEXT);
+  AddString(kar, "karaoke.port3voicemask", 13385, "None", SPIN_CONTROL_TEXT);
 
   // System settings
   AddGroup(4, 13000);
 #ifdef HAS_XBOX_HARDWARE
-  AddCategory(4, "system", 128);
-  AddBool(3, "system.mceremote", 13601, false);
-  AddInt(4, "system.shutdowntime", 357, 0, 0, 5, 120, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF);
-  AddInt(5, "system.ledcolour", 13339, LED_COLOUR_NO_CHANGE, LED_COLOUR_NO_CHANGE, 1, LED_COLOUR_OFF, SPIN_CONTROL_TEXT);
-  AddInt(6, "system.leddisableonplayback", 13345, LED_PLAYBACK_OFF, LED_PLAYBACK_OFF, 1, LED_PLAYBACK_VIDEO_MUSIC, SPIN_CONTROL_TEXT);
-  AddBool(7, "system.ledenableonpaused", 20313, true);
-  AddSeparator(8, "system.sep1");
-  AddBool(9, "system.fanspeedcontrol", 13302, false);
-  AddInt(10, "system.fanspeed", 13300, CFanController::Instance()->GetFanSpeed(), 5, 5, 50, SPIN_CONTROL_TEXT);
-  AddSeparator(11, "system.sep2");
-  AddBool(12, "system.autotemperature", 13301, false);
-  AddInt(13, "system.targettemperature", 13299, 55, 40, 1, 68, SPIN_CONTROL_TEXT);
-  AddInt(14, "system.minfanspeed", 13411, 1, 1, 1, 50, SPIN_CONTROL_TEXT);
+  CSettingsCategory* sys = AddCategory(4, "system", 128);
+  AddBool(sys, "system.mceremote", 13601, false);
+  AddInt(sys, "system.shutdowntime", 357, 0, 0, 5, 120, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF);
+  AddInt(sys, "system.ledcolour", 13339, LED_COLOUR_NO_CHANGE, LED_COLOUR_NO_CHANGE, 1, LED_COLOUR_OFF, SPIN_CONTROL_TEXT);
+  AddInt(sys, "system.leddisableonplayback", 13345, LED_PLAYBACK_OFF, LED_PLAYBACK_OFF, 1, LED_PLAYBACK_VIDEO_MUSIC, SPIN_CONTROL_TEXT);
+  AddBool(sys, "system.ledenableonpaused", 20313, true);
+  AddSeparator(sys, "system.sep1");
+  AddBool(sys, "system.fanspeedcontrol", 13302, false);
+  AddInt(sys, "system.fanspeed", 13300, CFanController::Instance()->GetFanSpeed(), 5, 5, 50, SPIN_CONTROL_TEXT);
+  AddSeparator(sys, "system.sep2");
+  AddBool(sys, "system.autotemperature", 13301, false);
+  AddInt(sys, "system.targettemperature", 13299, 55, 40, 1, 68, SPIN_CONTROL_TEXT);
+  AddInt(sys, "system.minfanspeed", 13411, 1, 1, 1, 50, SPIN_CONTROL_TEXT);
 #endif
   
-  AddCategory(4, "videooutput", 21373);
-  AddInt(1, "videooutput.aspect", 21374, VIDEO_NORMAL, VIDEO_NORMAL, 1, VIDEO_WIDESCREEN, SPIN_CONTROL_TEXT);
-  AddBool(2,  "videooutput.hd480p", 21378, true);
-  AddBool(3,  "videooutput.hd720p", 21379, true);
-  AddBool(4,  "videooutput.hd1080i", 21380, false);
+  CSettingsCategory* vo = AddCategory(4, "videooutput", 21373);
+  AddInt(vo, "videooutput.aspect", 21374, VIDEO_NORMAL, VIDEO_NORMAL, 1, VIDEO_WIDESCREEN, SPIN_CONTROL_TEXT);
+  AddBool(vo,  "videooutput.hd480p", 21378, true);
+  AddBool(vo,  "videooutput.hd720p", 21379, true);
+  AddBool(vo,  "videooutput.hd1080i", 21380, false);
 
-  AddCategory(4, "audiooutput", 772);
-  AddInt(3, "audiooutput.mode", 337, AUDIO_ANALOG, AUDIO_ANALOG, 1, AUDIO_DIGITAL, SPIN_CONTROL_TEXT);
-  AddBool(4, "audiooutput.ac3passthrough", 364, true);
-  AddBool(5, "audiooutput.dtspassthrough", 254, true);
-  AddBool(6, "audiooutput.aacpassthrough", 299, false);
+  CSettingsCategory* ao = AddCategory(4, "audiooutput", 772);
+  AddInt(ao, "audiooutput.mode", 337, AUDIO_ANALOG, AUDIO_ANALOG, 1, AUDIO_DIGITAL, SPIN_CONTROL_TEXT);
+  AddBool(ao, "audiooutput.ac3passthrough", 364, true);
+  AddBool(ao, "audiooutput.dtspassthrough", 254, true);
+  AddBool(ao, "audiooutput.aacpassthrough", 299, false);
 #ifdef _XBOX
-  AddBool(10, "audiooutput.downmixmultichannel", 548, true);
+  AddBool(ao, "audiooutput.downmixmultichannel", 548, true);
 #endif
 
-  AddCategory(4, "lcd", 448);
-  AddInt(2, "lcd.type", 4501, LCD_TYPE_NONE, LCD_TYPE_NONE, 1, LCD_TYPE_VFD, SPIN_CONTROL_TEXT);
-  AddInt(3, "lcd.modchip", 471, MODCHIP_SMARTXX, MODCHIP_SMARTXX, 1, MODCHIP_XECUTER3, SPIN_CONTROL_TEXT);
-  AddInt(4, "lcd.backlight", 463, 80, 0, 5, 100, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
-  AddInt(5, "lcd.contrast", 465, 100, 0, 5, 100, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
-  AddSeparator(6, "lcd.sep1");
-  AddInt(7, "lcd.disableonplayback", 20310, LED_PLAYBACK_OFF, LED_PLAYBACK_OFF, 1, LED_PLAYBACK_VIDEO_MUSIC, SPIN_CONTROL_TEXT);
-  AddBool(8, "lcd.enableonpaused", 20312, true);
+  CSettingsCategory* lcd = AddCategory(4, "lcd", 448);
+  AddInt(lcd, "lcd.type", 4501, LCD_TYPE_NONE, LCD_TYPE_NONE, 1, LCD_TYPE_VFD, SPIN_CONTROL_TEXT);
+  AddInt(lcd, "lcd.modchip", 471, MODCHIP_SMARTXX, MODCHIP_SMARTXX, 1, MODCHIP_XECUTER3, SPIN_CONTROL_TEXT);
+  AddInt(lcd, "lcd.backlight", 463, 80, 0, 5, 100, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
+  AddInt(lcd, "lcd.contrast", 465, 100, 0, 5, 100, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
+  AddSeparator(lcd, "lcd.sep1");
+  AddInt(lcd, "lcd.disableonplayback", 20310, LED_PLAYBACK_OFF, LED_PLAYBACK_OFF, 1, LED_PLAYBACK_VIDEO_MUSIC, SPIN_CONTROL_TEXT);
+  AddBool(lcd, "lcd.enableonpaused", 20312, true);
 
-  AddCategory(4, "debug", 14092);
-  AddBool(1, "debug.showloginfo", 20191, false);
-  AddPath(2, "debug.screenshotpath",20004,"select writable folder",BUTTON_CONTROL_PATH_INPUT,false,657);
+  CSettingsCategory* dbg = AddCategory(4, "debug", 14092);
+  AddBool(dbg, "debug.showloginfo", 20191, false);
+  AddPath(dbg, "debug.screenshotpath",20004,"select writable folder",BUTTON_CONTROL_PATH_INPUT,false,657);
 
-  AddCategory(4, "autorun", 447);
-  AddBool(1, "autorun.dvd", 240, true);
-  AddBool(2, "autorun.vcd", 241, true);
-  AddBool(3, "autorun.cdda", 242, true);
-  AddBool(4, "autorun.xbox", 243, true);
-  AddBool(5, "autorun.video", 244, true);
-  AddBool(6, "autorun.music", 245, true);
-  AddBool(7, "autorun.pictures", 246, true);
+  CSettingsCategory* ar = AddCategory(4, "autorun", 447);
+  AddBool(ar, "autorun.dvd", 240, true);
+  AddBool(ar, "autorun.vcd", 241, true);
+  AddBool(ar, "autorun.cdda", 242, true);
+  AddBool(ar, "autorun.xbox", 243, true);
+  AddBool(ar, "autorun.video", 244, true);
+  AddBool(ar, "autorun.music", 245, true);
+  AddBool(ar, "autorun.pictures", 246, true);
 
-  AddCategory(4, "harddisk", 440);
-  AddInt(1, "harddisk.spindowntime", 229, 0, 0, 1, 60, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF); // Minutes
-  AddInt(2, "harddisk.remoteplayspindown", 13001, 0, 0, 1, 3, SPIN_CONTROL_TEXT); // off, music, video, both
-  AddInt(0, "harddisk.remoteplayspindownminduration", 13004, 20, 0, 1, 20, SPIN_CONTROL_INT_PLUS, MASK_MINS); // Minutes
-  AddInt(0, "harddisk.remoteplayspindowndelay", 13003, 20, 5, 5, 300, SPIN_CONTROL_INT_PLUS, MASK_SECS); // seconds
-  AddInt(3, "harddisk.aamlevel", 21386, AAM_FAST, AAM_FAST, 1, AAM_QUIET, SPIN_CONTROL_TEXT);
-  AddInt(4, "harddisk.apmlevel", 21390, APM_HIPOWER, APM_HIPOWER, 1, APM_LOPOWER_STANDBY, SPIN_CONTROL_TEXT);
+  CSettingsCategory* hdd = AddCategory(4, "harddisk", 440);
+  AddInt(hdd, "harddisk.spindowntime", 229, 0, 0, 1, 60, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF); // Minutes
+  AddInt(hdd, "harddisk.remoteplayspindown", 13001, 0, 0, 1, 3, SPIN_CONTROL_TEXT); // off, music, video, both
+  AddInt(NULL, "harddisk.remoteplayspindownminduration", 13004, 20, 0, 1, 20, SPIN_CONTROL_INT_PLUS, MASK_MINS); // Minutes
+  AddInt(NULL, "harddisk.remoteplayspindowndelay", 13003, 20, 5, 5, 300, SPIN_CONTROL_INT_PLUS, MASK_SECS); // seconds
+  AddInt(hdd, "harddisk.aamlevel", 21386, AAM_FAST, AAM_FAST, 1, AAM_QUIET, SPIN_CONTROL_TEXT);
+  AddInt(hdd, "harddisk.apmlevel", 21390, APM_HIPOWER, APM_HIPOWER, 1, APM_LOPOWER_STANDBY, SPIN_CONTROL_TEXT);
 
-  AddCategory(4, "dvdplayercache", 483);
-  AddInt(1, "dvdplayercache.video", 14096, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(2, "dvdplayercache.videotime", 14097, 8, 0, 1, 30, SPIN_CONTROL_INT_PLUS, MASK_SECS);
-  AddSeparator(3, "dvdplayercache.sep1");
-  AddInt(4, "dvdplayercache.audio", 14098, 384, 0, 128, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(5, "dvdplayercache.audiotime", 14099, 8, 0, 1, 30, SPIN_CONTROL_INT_PLUS, MASK_SECS);
+  CSettingsCategory* dpc = AddCategory(4, "dvdplayercache", 483);
+  AddInt(dpc, "dvdplayercache.video", 14096, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(dpc, "dvdplayercache.videotime", 14097, 8, 0, 1, 30, SPIN_CONTROL_INT_PLUS, MASK_SECS);
+  AddSeparator(dpc, "dvdplayercache.sep1");
+  AddInt(dpc, "dvdplayercache.audio", 14098, 384, 0, 128, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(dpc, "dvdplayercache.audiotime", 14099, 8, 0, 1, 30, SPIN_CONTROL_INT_PLUS, MASK_SECS);
 
-  AddCategory(4, "cache", 439);
-  AddInt(1, "cache.harddisk", 14025, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddSeparator(2, "cache.sep1");
-  AddInt(3, "cachevideo.dvdrom", 14026, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(4, "cachevideo.lan", 14027, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(5, "cachevideo.internet", 14028, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddSeparator(6, "cache.sep2");
-  AddInt(7, "cacheaudio.dvdrom", 14030, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(8, "cacheaudio.lan", 14031, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(9, "cacheaudio.internet", 14032, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddSeparator(10, "cache.sep3");
-  AddInt(11, "cachedvd.dvdrom", 14034, 512, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddInt(12, "cachedvd.lan", 14035, 512, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
-  AddSeparator(13, "cache.sep4");
-  AddInt(14, "cacheunknown.internet", 14060, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  CSettingsCategory* cac = AddCategory(4, "cache", 439);
+  AddInt(cac, "cache.harddisk", 14025, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddSeparator(cac, "cache.sep1");
+  AddInt(cac, "cachevideo.dvdrom", 14026, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(cac, "cachevideo.lan", 14027, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(cac, "cachevideo.internet", 14028, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddSeparator(cac, "cache.sep2");
+  AddInt(cac, "cacheaudio.dvdrom", 14030, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(cac, "cacheaudio.lan", 14031, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(cac, "cacheaudio.internet", 14032, 256, 0, 256, 4096, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddSeparator(cac, "cache.sep3");
+  AddInt(cac, "cachedvd.dvdrom", 14034, 512, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddInt(cac, "cachedvd.lan", 14035, 512, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
+  AddSeparator(cac, "cache.sep4");
+  AddInt(cac, "cacheunknown.internet", 14060, 1024, 0, 256, 16384, SPIN_CONTROL_INT_PLUS, MASK_KB, TEXT_OFF);
 
   // !! Should be the last category, else disabling it will cause problems!
-  AddCategory(4, "masterlock", 12360);
-  AddString(1, "masterlock.lockcode"       , 20100, "-", BUTTON_CONTROL_STANDARD);
-  AddBool(4, "masterlock.startuplock"      , 20076,false);
-  AddBool(5, "masterlock.enableshutdown"   , 12362,false);  
+  CSettingsCategory* mst = AddCategory(4, "masterlock", 12360);
+  AddString(mst, "masterlock.lockcode"       , 20100, "-", BUTTON_CONTROL_STANDARD);
+  AddBool(mst, "masterlock.startuplock"      , 20076,false);
+  AddBool(mst, "masterlock.enableshutdown"   , 12362,false);  
   // hidden masterlock settings
-  AddInt(0,"masterlock.maxretries", 12364, 3, 3, 1, 100, SPIN_CONTROL_TEXT);
+  AddInt(NULL,"masterlock.maxretries", 12364, 3, 3, 1, 100, SPIN_CONTROL_TEXT);
 
   // video settings
   AddGroup(5, 3);
-  AddCategory(5, "videolibrary", 14022);
-  AddBool(2, "videolibrary.enabled", 421, true);
-  AddBool(3, "videolibrary.showunwatchedplots", 20369, true);
-  AddBool(4, "videolibrary.seasonthumbs", 20382, true);
-  AddBool(5, "videolibrary.actorthumbs", 20402, false);
-  AddInt(0, "videolibrary.flattentvshows", 20412, 1, 0, 1, 2, SPIN_CONTROL_TEXT);
-  AddBool(7, "videolibrary.groupmoviesets", 20458, false);
-  AddBool(8, "videolibrary.updateonstartup", 22000, false);
-  AddBool(0, "videolibrary.backgroundupdate", 22001, false);
-  AddSeparator(10, "videolibrary.sep3");
-  AddString(11, "videolibrary.cleanup", 334, "", BUTTON_CONTROL_STANDARD);
-  AddString(12, "videolibrary.export", 647, "", BUTTON_CONTROL_STANDARD);
-  AddString(13, "videolibrary.import", 648, "", BUTTON_CONTROL_STANDARD);
+  CSettingsCategory* vdl = AddCategory(5, "videolibrary", 14022);
+  AddBool(vdl, "videolibrary.enabled", 421, true);
+  AddBool(vdl, "videolibrary.showunwatchedplots", 20369, true);
+  AddBool(vdl, "videolibrary.seasonthumbs", 20382, true);
+  AddBool(vdl, "videolibrary.actorthumbs", 20402, false);
+  AddInt(NULL, "videolibrary.flattentvshows", 20412, 1, 0, 1, 2, SPIN_CONTROL_TEXT);
+  AddBool(vdl, "videolibrary.groupmoviesets", 20458, false);
+  AddBool(vdl, "videolibrary.updateonstartup", 22000, false);
+  AddBool(NULL, "videolibrary.backgroundupdate", 22001, false);
+  AddSeparator(vdl, "videolibrary.sep3");
+  AddString(vdl, "videolibrary.cleanup", 334, "", BUTTON_CONTROL_STANDARD);
+  AddString(vdl, "videolibrary.export", 647, "", BUTTON_CONTROL_STANDARD);
+  AddString(vdl, "videolibrary.import", 648, "", BUTTON_CONTROL_STANDARD);
 
-  AddCategory(5, "videoplayer", 14086);
-  AddInt(1, "videoplayer.resumeautomatically", 12017, RESUME_ASK, RESUME_NO, 1, RESUME_ASK, SPIN_CONTROL_TEXT);
-  AddString(2, "videoplayer.calibrate", 214, "", BUTTON_CONTROL_STANDARD);
-  AddSeparator(3, "videoplayer.sep1");
-  AddInt(4, "videoplayer.rendermethod", 13354, RENDER_HQ_RGB_SHADER, RENDER_LQ_RGB_SHADER, 1, RENDER_HQ_RGB_SHADERV2, SPIN_CONTROL_TEXT);
-  AddInt(5, "videoplayer.displayresolution", 169, (int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
-  AddInt(6, "videoplayer.framerateconversions", 336, FRAME_RATE_LEAVE_AS_IS, FRAME_RATE_LEAVE_AS_IS, 1, FRAME_RATE_USE_PAL60, SPIN_CONTROL_TEXT);
-  AddInt(7, "videoplayer.flicker", 13100, 1, 0, 1, 5, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
-  AddBool(8, "videoplayer.soften", 215, false);
-  AddFloat(9, "videoplayer.errorinaspect", 22021, 3.0f, 0.0f, 1.0f, 20.0f);
-  AddSeparator(11, "videoplayer.sep2");
-  AddInt(12, "videoplayer.defaultplayer", 22003, PLAYER_DVDPLAYER, PLAYER_MPLAYER, 1, PLAYER_DVDPLAYER, SPIN_CONTROL_TEXT);
-  AddBool(13, "videoplayer.allcodecs", 22025, false);
-  AddBool(14, "videoplayer.fast", 22026, false);
-  AddInt(15, "videoplayer.skiploopfilter", 14100, VS_SKIPLOOP_NONREF, VS_SKIPLOOP_DEFAULT, 1, VS_SKIPLOOP_ALL, SPIN_CONTROL_TEXT);
+  CSettingsCategory* vp = AddCategory(5, "videoplayer", 14086);
+  AddInt(vp, "videoplayer.resumeautomatically", 12017, RESUME_ASK, RESUME_NO, 1, RESUME_ASK, SPIN_CONTROL_TEXT);
+  AddString(vp, "videoplayer.calibrate", 214, "", BUTTON_CONTROL_STANDARD);
+  AddSeparator(vp, "videoplayer.sep1");
+  AddInt(vp, "videoplayer.rendermethod", 13354, RENDER_HQ_RGB_SHADER, RENDER_LQ_RGB_SHADER, 1, RENDER_HQ_RGB_SHADERV2, SPIN_CONTROL_TEXT);
+  AddInt(vp, "videoplayer.displayresolution", 169, (int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
+  AddInt(vp, "videoplayer.framerateconversions", 336, FRAME_RATE_LEAVE_AS_IS, FRAME_RATE_LEAVE_AS_IS, 1, FRAME_RATE_USE_PAL60, SPIN_CONTROL_TEXT);
+  AddInt(vp, "videoplayer.flicker", 13100, 1, 0, 1, 5, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
+  AddBool(vp, "videoplayer.soften", 215, false);
+  AddFloat(vp, "videoplayer.errorinaspect", 22021, 3.0f, 0.0f, 1.0f, 20.0f);
+  AddSeparator(vp, "videoplayer.sep2");
+  AddInt(vp, "videoplayer.defaultplayer", 22003, PLAYER_DVDPLAYER, PLAYER_MPLAYER, 1, PLAYER_DVDPLAYER, SPIN_CONTROL_TEXT);
+  AddBool(vp, "videoplayer.allcodecs", 22025, false);
+  AddBool(vp, "videoplayer.fast", 22026, false);
+  AddInt(vp, "videoplayer.skiploopfilter", 14100, VS_SKIPLOOP_NONREF, VS_SKIPLOOP_DEFAULT, 1, VS_SKIPLOOP_ALL, SPIN_CONTROL_TEXT);
 
-  AddCategory(5, "myvideos", 14081);
-  AddBool(0, "myvideos.treatstackasfile", 20051, true);
-  AddBool(0, "myvideos.extractflags",20433, false);
-  AddBool(3, "myvideos.cleanstrings", 20419, false);
-  AddBool(0, "myvideos.extractthumb",20433, false);
+  CSettingsCategory* vid = AddCategory(5, "myvideos", 14081);
+  AddBool(NULL, "myvideos.treatstackasfile", 20051, true);
+  AddBool(NULL, "myvideos.extractflags",20433, false);
+  AddBool(vid, "myvideos.cleanstrings", 20419, false);
+  AddBool(NULL, "myvideos.extractthumb",20433, false);
 
-  AddCategory(5, "subtitles", 287);
-  AddString(1, "subtitles.font", 288, "Arial.ttf", SPIN_CONTROL_TEXT);
-  AddInt(2, "subtitles.height", 289, 28, 16, 2, 74, SPIN_CONTROL_TEXT); // use text as there is a disk based lookup needed
-  AddInt(3, "subtitles.style", 736, FONT_STYLE_BOLD, FONT_STYLE_NORMAL, 1, FONT_STYLE_BOLD | FONT_STYLE_ITALICS, SPIN_CONTROL_TEXT);
-  AddInt(4, "subtitles.color", 737, SUBTITLE_COLOR_START + 1, SUBTITLE_COLOR_START, 1, SUBTITLE_COLOR_END, SPIN_CONTROL_TEXT);
-  AddString(5, "subtitles.charset", 735, "DEFAULT", SPIN_CONTROL_TEXT);
-  AddSeparator(7, "subtitles.sep1");
-  AddPath(11, "subtitles.custompath", 21366, "", BUTTON_CONTROL_PATH_INPUT, false, 657);
-  AddSeparator(12,"subtitles.sep2");
-  AddBool(13, "subtitles.searchrars", 13249, false);
+  CSettingsCategory* sub = AddCategory(5, "subtitles", 287);
+  AddString(sub, "subtitles.font", 288, "Arial.ttf", SPIN_CONTROL_TEXT);
+  AddInt(sub, "subtitles.height", 289, 28, 16, 2, 74, SPIN_CONTROL_TEXT); // use text as there is a disk based lookup needed
+  AddInt(sub, "subtitles.style", 736, FONT_STYLE_BOLD, FONT_STYLE_NORMAL, 1, FONT_STYLE_BOLD | FONT_STYLE_ITALICS, SPIN_CONTROL_TEXT);
+  AddInt(sub, "subtitles.color", 737, SUBTITLE_COLOR_START + 1, SUBTITLE_COLOR_START, 1, SUBTITLE_COLOR_END, SPIN_CONTROL_TEXT);
+  AddString(sub, "subtitles.charset", 735, "DEFAULT", SPIN_CONTROL_TEXT);
+  AddSeparator(sub, "subtitles.sep1");
+  AddPath(sub, "subtitles.custompath", 21366, "", BUTTON_CONTROL_PATH_INPUT, false, 657);
+  AddSeparator(sub,"subtitles.sep2");
+  AddBool(sub, "subtitles.searchrars", 13249, false);
 
-  AddCategory(5, "dvds", 14087);
-  AddInt(2, "dvds.playerregion", 21372, 0, 0, 1, 8, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
-  AddBool(3, "dvds.automenu", 21882, false);
-  AddBool(4, "dvds.useexternaldvdplayer", 20001, false);
-  AddString(5, "dvds.externaldvdplayer", 20002, "",  BUTTON_CONTROL_PATH_INPUT, true, 655);
+  CSettingsCategory* dvd = AddCategory(5, "dvds", 14087);
+  AddInt(dvd, "dvds.playerregion", 21372, 0, 0, 1, 8, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
+  AddBool(dvd, "dvds.automenu", 21882, false);
+  AddBool(dvd, "dvds.useexternaldvdplayer", 20001, false);
+  AddString(dvd, "dvds.externaldvdplayer", 20002, "",  BUTTON_CONTROL_PATH_INPUT, true, 655);
 
   // Don't add the category - makes them hidden in the GUI
-  //AddCategory(5, "postprocessing", 14041);
-  AddBool(2, "postprocessing.enable", 286, false);
-  AddBool(3, "postprocessing.auto", 307, true); // only has effect if PostProcessing.Enable is on.
-  AddBool(4, "postprocessing.verticaldeblocking", 308, false);
-  AddInt(5, "postprocessing.verticaldeblocklevel", 308, 0, 0, 1, 100, SPIN_CONTROL_INT);
-  AddBool(6, "postprocessing.horizontaldeblocking", 309, false);
-  AddInt(7, "postprocessing.horizontaldeblocklevel", 309, 0, 0, 1, 100, SPIN_CONTROL_INT);
-  AddBool(8, "postprocessing.autobrightnesscontrastlevels", 310, false);
-  AddBool(9, "postprocessing.dering", 311, false);
+  AddCategory(5, "postprocessing", 14041);
+  AddBool(NULL, "postprocessing.enable", 286, false);
+  AddBool(NULL, "postprocessing.auto", 307, true); // only has effect if PostProcessing.Enable is on.
+  AddBool(NULL, "postprocessing.verticaldeblocking", 308, false);
+  AddInt(NULL, "postprocessing.verticaldeblocklevel", 308, 0, 0, 1, 100, SPIN_CONTROL_INT);
+  AddBool(NULL, "postprocessing.horizontaldeblocking", 309, false);
+  AddInt(NULL, "postprocessing.horizontaldeblocklevel", 309, 0, 0, 1, 100, SPIN_CONTROL_INT);
+  AddBool(NULL, "postprocessing.autobrightnesscontrastlevels", 310, false);
+  AddBool(NULL, "postprocessing.dering", 311, false);
 
-  AddCategory(5, "scrapers", 21412);
-  AddString(1, "scrapers.moviedefault", 21413, "tmdb.xml", SPIN_CONTROL_TEXT);
-  AddString(2, "scrapers.tvshowdefault", 21414, "tvdb.xml", SPIN_CONTROL_TEXT);
-  AddString(3, "scrapers.musicvideodefault", 21415, "mtv.xml", SPIN_CONTROL_TEXT);
-  AddSeparator(4,"scrapers.sep2");
-  AddBool(5, "scrapers.langfallback", 21416, false);
+  CSettingsCategory* scp = AddCategory(5, "scrapers", 21412);
+  AddString(scp, "scrapers.moviedefault", 21413, "tmdb.xml", SPIN_CONTROL_TEXT);
+  AddString(scp, "scrapers.tvshowdefault", 21414, "tvdb.xml", SPIN_CONTROL_TEXT);
+  AddString(scp, "scrapers.musicvideodefault", 21415, "mtv.xml", SPIN_CONTROL_TEXT);
+  AddSeparator(scp,"scrapers.sep2");
+  AddBool(scp, "scrapers.langfallback", 21416, false);
 
   // network settings
   AddGroup(6, 705);
 
-  AddCategory(6, "services", 14036);
-  AddBool(1, "services.upnpserver", 21360, false);
-  AddBool(2, "services.upnprenderer", 21881, false);
-  AddSeparator(3,"services.sep3");
+  CSettingsCategory* srv = AddCategory(6, "services", 14036);
+  AddBool(srv, "services.upnpserver", 21360, false);
+  AddBool(srv, "services.upnprenderer", 21881, false);
+  AddSeparator(srv,"services.sep3");
 
-  AddBool(4,  "services.webserver",        263, false);
-  AddString(5,"services.webserverport",    730, "80", EDIT_CONTROL_NUMBER_INPUT, false, 730);
-  AddString(6,"services.webserverusername",1048, "xbmc", EDIT_CONTROL_INPUT);
-  AddString(7,"services.webserverpassword",733, "", EDIT_CONTROL_HIDDEN_INPUT, true, 733);
+  AddBool(srv,  "services.webserver",        263, false);
+  AddString(srv,"services.webserverport",    730, "80", EDIT_CONTROL_NUMBER_INPUT, false, 730);
+  AddString(srv,"services.webserverusername",1048, "xbmc", EDIT_CONTROL_INPUT);
+  AddString(srv,"services.webserverpassword",733, "", EDIT_CONTROL_HIDDEN_INPUT, true, 733);
 
 #ifdef HAS_EVENT_SERVER
-  AddSeparator(8,"services.sep1");
-  AddBool(9,  "services.esenabled",         794, true);
-  AddString(0,"services.esport",            792, "9777", EDIT_CONTROL_NUMBER_INPUT, false, 792);
-  AddInt(0,   "services.esportrange",       793, 10, 1, 1, 100, SPIN_CONTROL_INT);
-  AddInt(0,   "services.esmaxclients",      797, 20, 1, 1, 100, SPIN_CONTROL_INT);
-  AddInt(0,   "services.esinitialdelay",    795, 750, 5, 5, 10000, SPIN_CONTROL_INT);
-  AddInt(0,   "services.escontinuousdelay", 796, 25, 5, 5, 10000, SPIN_CONTROL_INT);
+  AddSeparator(srv,"services.sep1");
+  AddBool(srv,  "services.esenabled",         794, true);
+  AddString(NULL,"services.esport",            792, "9777", EDIT_CONTROL_NUMBER_INPUT, false, 792);
+  AddInt(NULL,   "services.esportrange",       793, 10, 1, 1, 100, SPIN_CONTROL_INT);
+  AddInt(NULL,   "services.esmaxclients",      797, 20, 1, 1, 100, SPIN_CONTROL_INT);
+  AddInt(NULL,   "services.esinitialdelay",    795, 750, 5, 5, 10000, SPIN_CONTROL_INT);
+  AddInt(NULL,   "services.escontinuousdelay", 796, 25, 5, 5, 10000, SPIN_CONTROL_INT);
 #endif
 
-  AddSeparator(11, "services.sep2");
-  AddBool(12,  "services.ftpserver",        167, true);
-  AddString(13,"services.ftpserveruser",    1245, "xbox", SPIN_CONTROL_TEXT);
-  AddString(14,"services.ftpserverpassword",1246, "xbox", EDIT_CONTROL_HIDDEN_INPUT, true, 1246);
-  AddBool(15,  "services.ftpautofatx",      771, true);
+  AddSeparator(srv, "services.sep2");
+  AddBool(srv,  "services.ftpserver",        167, true);
+  AddString(srv,"services.ftpserveruser",    1245, "xbox", SPIN_CONTROL_TEXT);
+  AddString(srv,"services.ftpserverpassword",1246, "xbox", EDIT_CONTROL_HIDDEN_INPUT, true, 1246);
+  AddBool(srv,  "services.ftpautofatx",      771, true);
 
-  AddCategory(6,"autodetect",           1250  );
-  AddBool(1,    "autodetect.onoff",     1251, false);
-  AddBool(2,    "autodetect.popupinfo", 1254, true);
-  AddString(3,  "autodetect.nickname",  1252, "XBMC-NickName",EDIT_CONTROL_INPUT, false, 1252);
-  AddSeparator(4, "autodetect.sep1");
-  AddBool(5,    "autodetect.senduserpw",1255, true); // can be in advanced.xml! default:true
+  CSettingsCategory* atd = AddCategory(6,"autodetect",           1250  );
+  AddBool(atd,    "autodetect.onoff",     1251, false);
+  AddBool(atd,    "autodetect.popupinfo", 1254, true);
+  AddString(atd,  "autodetect.nickname",  1252, "XBMC-NickName",EDIT_CONTROL_INPUT, false, 1252);
+  AddSeparator(atd, "autodetect.sep1");
+  AddBool(atd,    "autodetect.senduserpw",1255, true); // can be in advanced.xml! default:true
 
-  AddCategory(6, "smb", 1200);
-  AddString(3, "smb.winsserver",  1207,   "",  EDIT_CONTROL_IP_INPUT);
-  AddString(4, "smb.workgroup",   1202,   "WORKGROUP", EDIT_CONTROL_INPUT, false, 1202);
+  CSettingsCategory* smb = AddCategory(6, "smb", 1200);
+  AddString(smb, "smb.winsserver",  1207,   "",  EDIT_CONTROL_IP_INPUT);
+  AddString(smb, "smb.workgroup",   1202,   "WORKGROUP", EDIT_CONTROL_INPUT, false, 1202);
 
-  AddCategory(6, "network", 705);
-  AddInt(1, "network.assignment", 715, NETWORK_DHCP, NETWORK_DASH, 1, NETWORK_STATIC, SPIN_CONTROL_TEXT);
-  AddString(2, "network.ipaddress", 719, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-  AddString(3, "network.subnet", 720, "255.255.255.0", EDIT_CONTROL_IP_INPUT);
-  AddString(4, "network.gateway", 721, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-  AddString(5, "network.dns", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-  AddString(6, "network.dns2", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
-  AddString(7, "network.dnssuffix", 22002, "", EDIT_CONTROL_INPUT, true);
-  AddInt(8, "network.bandwidth", 14042, 0, 0, 512, 100*1024, SPIN_CONTROL_INT_PLUS, MASK_KBPS, TEXT_OFF);
+  CSettingsCategory* net = AddCategory(6, "network", 705);
+  AddInt(net, "network.assignment", 715, NETWORK_DHCP, NETWORK_DASH, 1, NETWORK_STATIC, SPIN_CONTROL_TEXT);
+  AddString(net, "network.ipaddress", 719, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+  AddString(net, "network.subnet", 720, "255.255.255.0", EDIT_CONTROL_IP_INPUT);
+  AddString(net, "network.gateway", 721, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+  AddString(net, "network.dns", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+  AddString(net, "network.dns2", 722, "0.0.0.0", EDIT_CONTROL_IP_INPUT);
+  AddString(net, "network.dnssuffix", 22002, "", EDIT_CONTROL_INPUT, true);
+  AddInt(net, "network.bandwidth", 14042, 0, 0, 512, 100*1024, SPIN_CONTROL_INT_PLUS, MASK_KBPS, TEXT_OFF);
 
-  AddSeparator(12, "network.sep1");
-  AddBool(13, "network.usehttpproxy", 708, false);
-  AddString(14, "network.httpproxyserver", 706, "", EDIT_CONTROL_INPUT);
-  AddString(15, "network.httpproxyport", 730, "8080", EDIT_CONTROL_NUMBER_INPUT, false, 707);
-  AddString(16, "network.httpproxyusername", 1048, "", EDIT_CONTROL_INPUT);
-  AddString(17, "network.httpproxypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT,true,733);
+  AddSeparator(net, "network.sep1");
+  AddBool(net, "network.usehttpproxy", 708, false);
+  AddString(net, "network.httpproxyserver", 706, "", EDIT_CONTROL_INPUT);
+  AddString(net, "network.httpproxyport", 730, "8080", EDIT_CONTROL_NUMBER_INPUT, false, 707);
+  AddString(net, "network.httpproxyusername", 1048, "", EDIT_CONTROL_INPUT);
+  AddString(net, "network.httpproxypassword", 733, "", EDIT_CONTROL_HIDDEN_INPUT,true,733);
 
   // appearance settings
   AddGroup(7, 480);
-  AddCategory(7,"lookandfeel", 166);
-  AddString(1, "lookandfeel.skin",166,DEFAULT_SKIN, SPIN_CONTROL_TEXT);
-  AddString(2, "lookandfeel.skintheme",15111,"SKINDEFAULT", SPIN_CONTROL_TEXT);
-  AddString(3, "lookandfeel.skincolors",14078, "SKINDEFAULT", SPIN_CONTROL_TEXT);
-  AddString(4, "lookandfeel.font",13303,"Default", SPIN_CONTROL_TEXT);
-  AddInt(5, "lookandfeel.skinzoom",20109, 0, -20, 2, 20, SPIN_CONTROL_INT, MASK_PERCENT);
-  AddInt(6, "lookandfeel.startupwindow",512,1, WINDOW_HOME, 1, WINDOW_PYTHON_END, SPIN_CONTROL_TEXT);
-  AddString(7, "lookandfeel.soundskin",15108,"SKINDEFAULT", SPIN_CONTROL_TEXT);
-  AddSeparator(8, "lookandfeel.sep2");
-  AddBool(9, "lookandfeel.enablerssfeeds",13305,  true);
-  AddString(10, "lookandfeel.rssedit", 21450, "", BUTTON_CONTROL_STANDARD);
-  AddSeparator(14, "lookandfeel.sep3");
-  AddBool(15, "lookandfeel.enablemouse", 21369, false);
+  CSettingsCategory* laf = AddCategory(7,"lookandfeel", 166);
+  AddString(laf, "lookandfeel.skin",166,DEFAULT_SKIN, SPIN_CONTROL_TEXT);
+  AddString(laf, "lookandfeel.skintheme",15111,"SKINDEFAULT", SPIN_CONTROL_TEXT);
+  AddString(laf, "lookandfeel.skincolors",14078, "SKINDEFAULT", SPIN_CONTROL_TEXT);
+  AddString(laf, "lookandfeel.font",13303,"Default", SPIN_CONTROL_TEXT);
+  AddInt(laf, "lookandfeel.skinzoom",20109, 0, -20, 2, 20, SPIN_CONTROL_INT, MASK_PERCENT);
+  AddInt(laf, "lookandfeel.startupwindow",512,1, WINDOW_HOME, 1, WINDOW_PYTHON_END, SPIN_CONTROL_TEXT);
+  AddString(laf, "lookandfeel.soundskin",15108,"SKINDEFAULT", SPIN_CONTROL_TEXT);
+  AddSeparator(laf, "lookandfeel.sep2");
+  AddBool(laf, "lookandfeel.enablerssfeeds",13305,  true);
+  AddString(laf, "lookandfeel.rssedit", 21450, "", BUTTON_CONTROL_STANDARD);
+  AddSeparator(laf, "lookandfeel.sep3");
+  AddBool(laf, "lookandfeel.enablemouse", 21369, false);
 
-  AddCategory(7, "locale", 14090);
-  AddString(1, "locale.language",248,"english", SPIN_CONTROL_TEXT);
-  AddString(2, "locale.country", 20026, "UK (24h)", SPIN_CONTROL_TEXT);
-  AddString(3, "locale.charset",14091,"DEFAULT", SPIN_CONTROL_TEXT); // charset is set by the language file
-  AddSeparator(4, "locale.sep1");
-  AddString(5, "locale.time", 14065, "", BUTTON_CONTROL_MISC_INPUT);
-  AddString(6, "locale.date", 14064, "", BUTTON_CONTROL_MISC_INPUT);
-  AddInt(7, "locale.timezone", 14074, 0, 0, 1, g_timezone.GetNumberOfTimeZones(), SPIN_CONTROL_TEXT);
-  AddBool(8, "locale.usedst", 14075, false);
-  AddSeparator(9, "locale.sep2");
-  AddBool(10, "locale.timeserver", 168, false);
-  AddString(11, "locale.timeserveraddress", 731, "pool.ntp.org", EDIT_CONTROL_INPUT);
+  CSettingsCategory* loc = AddCategory(7, "locale", 14090);
+  AddString(loc, "locale.language",248,"english", SPIN_CONTROL_TEXT);
+  AddString(loc, "locale.country", 20026, "UK (24h)", SPIN_CONTROL_TEXT);
+  AddString(loc, "locale.charset",14091,"DEFAULT", SPIN_CONTROL_TEXT); // charset is set by the language file
+  AddSeparator(loc, "locale.sep1");
+  AddString(loc, "locale.time", 14065, "", BUTTON_CONTROL_MISC_INPUT);
+  AddString(loc, "locale.date", 14064, "", BUTTON_CONTROL_MISC_INPUT);
+  AddInt(loc, "locale.timezone", 14074, 0, 0, 1, g_timezone.GetNumberOfTimeZones(), SPIN_CONTROL_TEXT);
+  AddBool(loc, "locale.usedst", 14075, false);
+  AddSeparator(loc, "locale.sep2");
+  AddBool(loc, "locale.timeserver", 168, false);
+  AddString(loc, "locale.timeserveraddress", 731, "pool.ntp.org", EDIT_CONTROL_INPUT);
 
-  AddCategory(7, "videoscreen", 131);
-  AddInt(1, "videoscreen.resolution",169,(int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
-  AddString(2, "videoscreen.guicalibration",214,"", BUTTON_CONTROL_STANDARD);
-  AddInt(3, "videoscreen.flickerfilter", 13100, 5, 0, 1, 5, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
-  AddBool(4, "videoscreen.soften", 215, false);
+  CSettingsCategory* vs = AddCategory(7, "videoscreen", 131);
+  AddInt(vs, "videoscreen.resolution",169,(int)AUTORES, (int)HDTV_1080i, 1, (int)AUTORES, SPIN_CONTROL_TEXT);
+  AddString(vs, "videoscreen.guicalibration",214,"", BUTTON_CONTROL_STANDARD);
+  AddInt(vs, "videoscreen.flickerfilter", 13100, 5, 0, 1, 5, SPIN_CONTROL_INT_PLUS, -1, TEXT_OFF);
+  AddBool(vs, "videoscreen.soften", 215, false);
 
-  AddCategory(7, "filelists", 14081);
-  AddBool(1, "filelists.showparentdiritems", 13306, true);
-  AddBool(2, "filelists.showextensions", 497, true);
-  AddBool(3, "filelists.ignorethewhensorting", 13399, true);
-  AddBool(4, "filelists.allowfiledeletion", 14071, false);
-  AddBool(5, "filelists.showaddsourcebuttons", 21382,  true);
-  AddBool(6, "filelists.showhidden", 21330, false);
-  AddSeparator(7, "filelists.sep1");
-  AddBool(8, "filelists.unrollarchives",516, false);
+  CSettingsCategory* fl = AddCategory(7, "filelists", 14081);
+  AddBool(fl, "filelists.showparentdiritems", 13306, true);
+  AddBool(fl, "filelists.showextensions", 497, true);
+  AddBool(fl, "filelists.ignorethewhensorting", 13399, true);
+  AddBool(fl, "filelists.allowfiledeletion", 14071, false);
+  AddBool(fl, "filelists.showaddsourcebuttons", 21382,  true);
+  AddBool(fl, "filelists.showhidden", 21330, false);
+  AddSeparator(fl, "filelists.sep1");
+  AddBool(fl, "filelists.unrollarchives",516, false);
 
-  AddCategory(7, "screensaver", 360);
-  AddInt(1, "screensaver.time", 355, 3, 1, 1, 60, SPIN_CONTROL_INT_PLUS, MASK_MINS);
-  AddString(2, "screensaver.mode", 356, "Dim", SPIN_CONTROL_TEXT);
-  AddBool(3, "screensaver.usemusicvisinstead", 13392, true);
-  AddBool(4, "screensaver.usedimonpause", 22014, true);
-  AddSeparator(5, "screensaver.sep1");
-  AddInt(6, "screensaver.dimlevel", 362, 20, 0, 10, 80, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
-  AddPath(7, "screensaver.slideshowpath", 774, "F:\\Pictures\\", BUTTON_CONTROL_PATH_INPUT, false, 657);
-  AddSeparator(8, "screensaver.sep2");
-  AddString(9, "screensaver.preview", 1000, "", BUTTON_CONTROL_STANDARD);
+  CSettingsCategory* ss = AddCategory(7, "screensaver", 360);
+  AddInt(ss, "screensaver.time", 355, 3, 1, 1, 60, SPIN_CONTROL_INT_PLUS, MASK_MINS);
+  AddString(ss, "screensaver.mode", 356, "Dim", SPIN_CONTROL_TEXT);
+  AddBool(ss, "screensaver.usemusicvisinstead", 13392, true);
+  AddBool(ss, "screensaver.usedimonpause", 22014, true);
+  AddSeparator(ss, "screensaver.sep1");
+  AddInt(ss, "screensaver.dimlevel", 362, 20, 0, 10, 80, SPIN_CONTROL_INT_PLUS, MASK_PERCENT);
+  AddPath(ss, "screensaver.slideshowpath", 774, "F:\\Pictures\\", BUTTON_CONTROL_PATH_INPUT, false, 657);
+  AddSeparator(ss, "screensaver.sep2");
+  AddString(ss, "screensaver.preview", 1000, "", BUTTON_CONTROL_STANDARD);
 
-  AddPath(0,"system.playlistspath",20006,"set default",BUTTON_CONTROL_PATH_INPUT,false);
+  AddPath(NULL,"system.playlistspath",20006,"set default",BUTTON_CONTROL_PATH_INPUT,false);
 }
 
 CGUISettings::~CGUISettings(void)
@@ -602,13 +602,14 @@ void CGUISettings::AddGroup(int groupID, int labelID)
     settingsGroups.push_back(pGroup);
 }
 
-void CGUISettings::AddCategory(int groupID, const char *strSetting, int labelID)
+CSettingsCategory* CGUISettings::AddCategory(int groupID, const char *strSetting, int labelID)
 {
   for (unsigned int i = 0; i < settingsGroups.size(); i++)
   {
     if (settingsGroups[i]->GetGroupID() == groupID)
-      settingsGroups[i]->AddCategory(CStdString(strSetting).ToLower(), labelID);
+      return settingsGroups[i]->AddCategory(CStdString(strSetting).ToLower(), labelID);
   }
+  return NULL;
 }
 
 CSettingsGroup *CGUISettings::GetGroup(int groupID)
@@ -624,15 +625,17 @@ CSettingsGroup *CGUISettings::GetGroup(int groupID)
   return NULL;
 }
 
-void CGUISettings::AddSeparator(int iOrder, const char *strSetting)
+void CGUISettings::AddSeparator(CSettingsCategory* cat, const char *strSetting)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingSeparator *pSetting = new CSettingSeparator(iOrder, CStdString(strSetting).ToLower());
   if (!pSetting) return;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
 }
 
-void CGUISettings::AddBool(int iOrder, const char *strSetting, int iLabel, bool bData, int iControlType)
+void CGUISettings::AddBool(CSettingsCategory* cat, const char *strSetting, int iLabel, bool bData, int iControlType)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingBool* pSetting = new CSettingBool(iOrder, CStdString(strSetting).ToLower(), iLabel, bData, iControlType);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
@@ -681,8 +684,9 @@ void CGUISettings::ToggleBool(const char *strSetting)
   CLog::Log(LOGDEBUG,"Error: Requested setting (%s) was not found.  It must be case-sensitive", strSetting);
 }
 
-void CGUISettings::AddFloat(int iOrder, const char *strSetting, int iLabel, float fData, float fMin, float fStep, float fMax, int iControlType)
+void CGUISettings::AddFloat(CSettingsCategory* cat, const char *strSetting, int iLabel, float fData, float fMin, float fStep, float fMax, int iControlType)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingFloat* pSetting = new CSettingFloat(iOrder, CStdString(strSetting).ToLower(), iLabel, fData, fMin, fStep, fMax, iControlType);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
@@ -733,22 +737,25 @@ void CGUISettings::LoadMasterLock(TiXmlElement *pRootElement)
 }
 
 
-void CGUISettings::AddInt(int iOrder, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
+void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingInt* pSetting = new CSettingInt(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, strFormat);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
 }
 
-void CGUISettings::AddInt(int iOrder, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, int iFormat, int iLabelMin/*=-1*/)
+void CGUISettings::AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, int iFormat, int iLabelMin/*=-1*/)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingInt* pSetting = new CSettingInt(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, iFormat, iLabelMin);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
 }
 
-void CGUISettings::AddHex(int iOrder, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
+void CGUISettings::AddHex(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, const char *strFormat)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingHex* pSetting = new CSettingHex(iOrder, CStdString(strSetting).ToLower(), iLabel, iData, iMin, iStep, iMax, iControlType, strFormat);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
@@ -783,15 +790,17 @@ void CGUISettings::SetInt(const char *strSetting, int iSetting)
   ASSERT(false);
 }
 
-void CGUISettings::AddString(int iOrder, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
+void CGUISettings::AddString(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingString* pSetting = new CSettingString(iOrder, CStdString(strSetting).ToLower(), iLabel, strData, iControlType, bAllowEmpty, iHeadingString);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));
 }
 
-void CGUISettings::AddPath(int iOrder, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
+void CGUISettings::AddPath(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType, bool bAllowEmpty, int iHeadingString)
 {
+  int iOrder = cat?++cat->m_entries:0;
   CSettingPath* pSetting = new CSettingPath(iOrder, CStdString(strSetting).ToLower(), iLabel, strData, iControlType, bAllowEmpty, iHeadingString);
   if (!pSetting) return ;
   settingsMap.insert(pair<CStdString, CSetting*>(CStdString(strSetting).ToLower(), pSetting));

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -478,7 +478,7 @@ void CGUISettings::Initialize()
   AddGroup(6, 705);
 
   CSettingsCategory* srv = AddCategory(6, "services", 14036);
-  AddString(srv,"services.friendlyname", 1271, "XBMC", EDIT_CONTROL_INPUT);
+  AddString(srv,"services.devicename", 1271, "XBMC", EDIT_CONTROL_INPUT);
   AddSeparator(srv,"services.sep4");
   AddBool(srv, "services.upnpserver", 21360, false);
   AddBool(srv, "services.upnprenderer", 21881, false);

--- a/xbmc/settings/GUISettings.cpp
+++ b/xbmc/settings/GUISettings.cpp
@@ -478,6 +478,8 @@ void CGUISettings::Initialize()
   AddGroup(6, 705);
 
   CSettingsCategory* srv = AddCategory(6, "services", 14036);
+  AddString(srv,"services.friendlyname", 1271, "XBMC", EDIT_CONTROL_INPUT);
+  AddSeparator(srv,"services.sep4");
   AddBool(srv, "services.upnpserver", 21360, false);
   AddBool(srv, "services.upnprenderer", 21881, false);
   AddSeparator(srv,"services.sep3");

--- a/xbmc/settings/GUISettings.h
+++ b/xbmc/settings/GUISettings.h
@@ -296,11 +296,13 @@ public:
   {
     m_strCategory = strCategory;
     m_labelID = labelID;
+    m_entries = 0;
   }
   ~CSettingsCategory() {};
 
   CStdString m_strCategory;
   int m_labelID;
+  int m_entries;
 };
 
 typedef std::vector<CSettingsCategory *> vecSettingsCategory;
@@ -320,11 +322,12 @@ public:
     m_vecCategories.clear();
   };
 
-  void AddCategory(const char *strCategory, int labelID)
+  CSettingsCategory* AddCategory(const char *strCategory, int labelID)
   {
     CSettingsCategory *pCategory = new CSettingsCategory(strCategory, labelID);
     if (pCategory)
       m_vecCategories.push_back(pCategory);
+    return pCategory;
   }
   void GetCategories(vecSettingsCategory &vecCategories);
   int GetLabelID() { return m_labelID; };
@@ -346,32 +349,32 @@ public:
   void Initialize();
 
   void AddGroup(int groupID, int labelID);
-  void AddCategory(int groupID, const char *strCategory, int labelID);
+  CSettingsCategory* AddCategory(int groupID, const char *strCategory, int labelID);
   CSettingsGroup *GetGroup(int windowID);
 
-  void AddBool(int iOrder, const char *strSetting, int iLabel, bool bSetting, int iControlType = CHECKMARK_CONTROL);
+  void AddBool(CSettingsCategory* cat, const char *strSetting, int iLabel, bool bSetting, int iControlType = CHECKMARK_CONTROL);
   bool GetBool(const char *strSetting) const;
   void SetBool(const char *strSetting, bool bSetting);
   void ToggleBool(const char *strSetting);
 
-  void AddFloat(int iOrder, const char *strSetting, int iLabel, float fSetting, float fMin, float fStep, float fMax, int iControlType = SPIN_CONTROL_FLOAT);
+  void AddFloat(CSettingsCategory* cat, const char *strSetting, int iLabel, float fSetting, float fMin, float fStep, float fMax, int iControlType = SPIN_CONTROL_FLOAT);
   float GetFloat(const char *strSetting) const;
   void SetFloat(const char *strSetting, float fSetting);
 
-  void AddInt(int iOrder, const char *strSetting, int iLabel, int fSetting, int iMin, int iStep, int iMax, int iControlType, const char *strFormat = NULL);
-  void AddInt(int iOrder, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, int iFormat, int iLabelMin=-1);
+  void AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int fSetting, int iMin, int iStep, int iMax, int iControlType, const char *strFormat = NULL);
+  void AddInt(CSettingsCategory* cat, const char *strSetting, int iLabel, int iData, int iMin, int iStep, int iMax, int iControlType, int iFormat, int iLabelMin=-1);
   int GetInt(const char *strSetting) const;
   void SetInt(const char *strSetting, int fSetting);
 
-  void AddHex(int iOrder, const char *strSetting, int iLabel, int fSetting, int iMin, int iStep, int iMax, int iControlType, const char *strFormat = NULL);
+  void AddHex(CSettingsCategory* cat, const char *strSetting, int iLabel, int fSetting, int iMin, int iStep, int iMax, int iControlType, const char *strFormat = NULL);
 
-  void AddString(int iOrder, const char *strSetting, int iLabel, const char *strData, int iControlType = EDIT_CONTROL_INPUT, bool bAllowEmpty = false, int iHeadingString = -1);
-  void AddPath(int iOrder, const char *strSetting, int iLabel, const char *strData, int iControlType = EDIT_CONTROL_INPUT, bool bAllowEmpty = false, int iHeadingString = -1);
+  void AddString(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType = EDIT_CONTROL_INPUT, bool bAllowEmpty = false, int iHeadingString = -1);
+  void AddPath(CSettingsCategory* cat, const char *strSetting, int iLabel, const char *strData, int iControlType = EDIT_CONTROL_INPUT, bool bAllowEmpty = false, int iHeadingString = -1);
 
   const CStdString &GetString(const char *strSetting, bool bPrompt=true) const;
   void SetString(const char *strSetting, const char *strData);
 
-  void AddSeparator(int iOrder, const char *strSetting);
+  void AddSeparator(CSettingsCategory* cat, const char *strSetting);
 
   CSetting *GetSetting(const char *strSetting);
 


### PR DESCRIPTION
- First commits adds new way for adding setting categories. Instead of using integers all over the place, we are now using **CSettingsCategory**
- Other commits adds support for new infolabel: **System.Friendlyname**