### PR TITLE
cleanup sorting to (almost) get rid of the old SORT_METHOD_FOO #2959

### DIFF
--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -231,7 +231,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           CDirectory::GetDirectory(pItem->GetPath(), items, ".dat");
           if (items.Size())
           {
-            items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+            items.Sort(SortByLabel, SortOrderAscending);
             g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
             g_playlistPlayer.Add(PLAYLIST_VIDEO, items);
             g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);
@@ -247,7 +247,7 @@ bool CAutorun::RunDisc(IDirectory* pDir, const CStdString& strDrive, int& nAdded
           CDirectory::GetDirectory(pItem->GetPath(), items, ".mpg");
           if (items.Size())
           {
-            items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+            items.Sort(SortBySize, SortOrderDescending);
             g_playlistPlayer.ClearPlaylist(PLAYLIST_VIDEO);
             g_playlistPlayer.Add(PLAYLIST_VIDEO, items);
             g_playlistPlayer.SetCurrentPlaylist(PLAYLIST_VIDEO);

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1252,8 +1252,6 @@ CFileItemList::CFileItemList()
   m_fastLookup = false;
   m_bIsFolder = true;
   m_cacheToDisc = CACHE_IF_SLOW;
-  m_sortMethod = SORT_METHOD_NONE;
-  m_sortOrder = SortOrderNone;
   m_sortIgnoreFolders = false;
   m_replaceListing = false;
 }
@@ -1262,8 +1260,6 @@ CFileItemList::CFileItemList(const CStdString& strPath) : CFileItem(strPath, tru
 {
   m_fastLookup = false;
   m_cacheToDisc = CACHE_IF_SLOW;
-  m_sortMethod = SORT_METHOD_NONE;
-  m_sortOrder = SortOrderNone;
   m_sortIgnoreFolders = false;
   m_replaceListing = false;
 }
@@ -1337,8 +1333,9 @@ void CFileItemList::Clear()
   CSingleLock lock(m_lock);
 
   ClearItems();
-  m_sortMethod = SORT_METHOD_NONE;
-  m_sortOrder = SortOrderNone;
+  m_sortDescription.sortBy = SortByNone;
+  m_sortDescription.sortOrder = SortOrderNone;
+  m_sortDescription.sortAttributes = SortAttributeNone;
   m_sortIgnoreFolders = false;
   m_cacheToDisc = CACHE_IF_SLOW;
   m_sortDetails.clear();
@@ -1447,8 +1444,7 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
   SetPath(itemlist.GetPath());
   SetLabel(itemlist.GetLabel());
   m_sortDetails = itemlist.m_sortDetails;
-  m_sortMethod = itemlist.m_sortMethod;
-  m_sortOrder = itemlist.m_sortOrder;
+  m_sortDescription = itemlist.m_sortDescription;
   m_replaceListing = itemlist.m_replaceListing;
   m_content = itemlist.m_content;
   m_mapProperties = itemlist.m_mapProperties;
@@ -1461,13 +1457,12 @@ bool CFileItemList::Copy(const CFileItemList& items, bool copyItems /* = true */
   *(CFileItem*)this = *(CFileItem*)&items;
 
   // assign the rest of the CFileItemList properties
-  m_replaceListing = items.m_replaceListing;
-  m_content        = items.m_content;
-  m_mapProperties  = items.m_mapProperties;
-  m_cacheToDisc    = items.m_cacheToDisc;
-  m_sortDetails    = items.m_sortDetails;
-  m_sortMethod     = items.m_sortMethod;
-  m_sortOrder      = items.m_sortOrder;
+  m_replaceListing  = items.m_replaceListing;
+  m_content         = items.m_content;
+  m_mapProperties   = items.m_mapProperties;
+  m_cacheToDisc     = items.m_cacheToDisc;
+  m_sortDetails     = items.m_sortDetails;
+  m_sortDescription = items.m_sortDescription;
   m_sortIgnoreFolders = items.m_sortIgnoreFolders;
 
   if (copyItems)
@@ -1586,26 +1581,24 @@ void CFileItemList::FillSortFields(FILEITEMFILLFUNC func)
   std::for_each(m_items.begin(), m_items.end(), func);
 }
 
-void CFileItemList::Sort(SORT_METHOD sortMethod, SortOrder sortOrder)
+void CFileItemList::Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute sortAttributes /* = SortAttributeNone */)
 {
-  //  Already sorted?
-  if (sortMethod == m_sortMethod && m_sortOrder == sortOrder)
+  if (sortBy == SortByNone ||
+     (m_sortDescription.sortBy == sortBy && m_sortDescription.sortOrder == sortOrder &&
+      m_sortDescription.sortAttributes == sortAttributes))
     return;
 
-  SortDescription sorting = SortUtils::TranslateOldSortMethod(sortMethod);
+  SortDescription sorting;
+  sorting.sortBy = sortBy;
   sorting.sortOrder = sortOrder;
+  sorting.sortAttributes = sortAttributes;
 
   Sort(sorting);
-
-  m_sortMethod = sortMethod;
-  m_sortOrder = sortOrder;
+  m_sortDescription = sorting;
 }
 
 void CFileItemList::Sort(SortDescription sortDescription)
 {
-  if (sortDescription.sortBy == SortByNone)
-    return;
-
   if (sortDescription.sortBy == SortByFile ||
       sortDescription.sortBy == SortBySortTitle ||
       sortDescription.sortBy == SortByDateAdded ||
@@ -1615,6 +1608,11 @@ void CFileItemList::Sort(SortDescription sortDescription)
       sortDescription.sortBy == SortByLastPlayed ||
       sortDescription.sortBy == SortByPlaycount)
     sortDescription.sortAttributes = (SortAttribute)((int)sortDescription.sortAttributes | SortAttributeIgnoreFolders);
+
+  if (sortDescription.sortBy == SortByNone ||
+     (m_sortDescription.sortBy == sortDescription.sortBy && m_sortDescription.sortOrder == sortDescription.sortOrder &&
+      m_sortDescription.sortAttributes == sortDescription.sortAttributes))
+    return;
 
   if (m_sortIgnoreFolders)
     sortDescription.sortAttributes = (SortAttribute)((int)sortDescription.sortAttributes | SortAttributeIgnoreFolders);
@@ -1668,8 +1666,9 @@ void CFileItemList::Archive(CArchive& ar)
 
     ar << m_fastLookup;
 
-    ar << (int)m_sortMethod;
-    ar << (int)m_sortOrder;
+    ar << (int)m_sortDescription.sortBy;
+    ar << (int)m_sortDescription.sortOrder;
+    ar << (int)m_sortDescription.sortAttributes;
     ar << m_sortIgnoreFolders;
     ar << (int)m_cacheToDisc;
 
@@ -1677,7 +1676,9 @@ void CFileItemList::Archive(CArchive& ar)
     for (unsigned int j = 0; j < m_sortDetails.size(); ++j)
     {
       const SORT_METHOD_DETAILS &details = m_sortDetails[j];
-      ar << (int)details.m_sortMethod;
+      ar << (int)details.m_sortDescription.sortBy;
+      ar << (int)details.m_sortDescription.sortOrder;
+      ar << (int)details.m_sortDescription.sortAttributes;
       ar << details.m_buttonLabel;
       ar << details.m_labelMasks.m_strLabelFile;
       ar << details.m_labelMasks.m_strLabelFolder;
@@ -1727,9 +1728,11 @@ void CFileItemList::Archive(CArchive& ar)
 
     int tempint;
     ar >> (int&)tempint;
-    m_sortMethod = SORT_METHOD(tempint);
+    m_sortDescription.sortBy = (SortBy)tempint;
     ar >> (int&)tempint;
-    m_sortOrder = SortOrder(tempint);
+    m_sortDescription.sortOrder = (SortOrder)tempint;
+    ar >> (int&)tempint;
+    m_sortDescription.sortAttributes = (SortAttribute)tempint;
     ar >> m_sortIgnoreFolders;
     ar >> (int&)tempint;
     m_cacheToDisc = CACHE_TYPE(tempint);
@@ -1740,7 +1743,11 @@ void CFileItemList::Archive(CArchive& ar)
     {
       SORT_METHOD_DETAILS details;
       ar >> (int&)tempint;
-      details.m_sortMethod = SORT_METHOD(tempint);
+      details.m_sortDescription.sortBy = (SortBy)tempint;
+      ar >> (int&)tempint;
+      details.m_sortDescription.sortOrder = (SortOrder)tempint;
+      ar >> (int&)tempint;
+      details.m_sortDescription.sortAttributes = (SortAttribute)tempint;
       ar >> details.m_buttonLabel;
       ar >> details.m_labelMasks.m_strLabelFile;
       ar >> details.m_labelMasks.m_strLabelFolder;
@@ -2002,7 +2009,7 @@ void CFileItemList::Stack(bool stackFiles /* = true */)
   SetProperty("isstacked", "1");
 
   // items needs to be sorted for stuff below to work properly
-  Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  Sort(SortByLabel, SortOrderAscending);
 
   StackFolders();
 
@@ -2106,7 +2113,7 @@ void CFileItemList::StackFolders()
             item->SetPath(dvdPath);
             item->SetLabel2("");
             item->SetLabelPreformated(true);
-            m_sortMethod = SORT_METHOD_NONE; /* sorting is now broken */
+            m_sortDescription.sortBy = SortByNone; /* sorting is now broken */
           }
         }
       }
@@ -2298,7 +2305,8 @@ bool CFileItemList::Load(int windowID)
     CLog::Log(LOGDEBUG,"Loading fileitems [%s]",GetPath().c_str());
     CArchive ar(&file, CArchive::load);
     ar >> *this;
-    CLog::Log(LOGDEBUG,"  -- items: %i, directory: %s sort method: %i, ascending: %s",Size(),GetPath().c_str(), m_sortMethod, m_sortOrder ? "true" : "false");
+    CLog::Log(LOGDEBUG,"  -- items: %i, directory: %s sort method: %i, ascending: %s", Size(), GetPath().c_str(), m_sortDescription.sortBy,
+      m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
     ar.Close();
     file.Close();
     return true;
@@ -2320,7 +2328,7 @@ bool CFileItemList::Save(int windowID)
   {
     CArchive ar(&file, CArchive::store);
     ar << *this;
-    CLog::Log(LOGDEBUG,"  -- items: %i, sort method: %i, ascending: %s",iSize,m_sortMethod, m_sortOrder ? "true" : "false");
+    CLog::Log(LOGDEBUG,"  -- items: %i, sort method: %i, ascending: %s", iSize, m_sortDescription.sortBy, m_sortDescription.sortOrder == SortOrderAscending ? "true" : "false");
     ar.Close();
     file.Close();
     return true;
@@ -3237,12 +3245,26 @@ bool CFileItemList::UpdateItem(const CFileItem *item)
   return oldItem;
 }
 
-void CFileItemList::AddSortMethod(SORT_METHOD sortMethod, int buttonLabel, const LABEL_MASKS &labelMasks)
+void CFileItemList::AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes /* = SortAttributeNone */)
+{
+  AddSortMethod(sortBy, sortAttributes, buttonLabel, labelMasks);
+}
+
+void CFileItemList::AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks)
+{
+  SortDescription sorting;
+  sorting.sortBy = sortBy;
+  sorting.sortAttributes = sortAttributes;
+
+  AddSortMethod(sorting, buttonLabel, labelMasks);
+}
+
+void CFileItemList::AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks)
 {
   SORT_METHOD_DETAILS sort;
-  sort.m_sortMethod=sortMethod;
-  sort.m_buttonLabel=buttonLabel;
-  sort.m_labelMasks=labelMasks;
+  sort.m_sortDescription = sortDescription;
+  sort.m_buttonLabel = buttonLabel;
+  sort.m_labelMasks = labelMasks;
 
   m_sortDetails.push_back(sort);
 }
@@ -3254,8 +3276,9 @@ void CFileItemList::SetReplaceListing(bool replace)
 
 void CFileItemList::ClearSortState()
 {
-  m_sortMethod = SORT_METHOD_NONE;
-  m_sortOrder = SortOrderNone;
+  m_sortDescription.sortBy = SortByNone;
+  m_sortDescription.sortOrder = SortOrderNone;
+  m_sortDescription.sortAttributes = SortAttributeNone;
 }
 
 CVideoInfoTag* CFileItem::GetVideoInfoTag()

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1447,6 +1447,8 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
   SetPath(itemlist.GetPath());
   SetLabel(itemlist.GetLabel());
   m_sortDetails = itemlist.m_sortDetails;
+  m_sortMethod = itemlist.m_sortMethod;
+  m_sortOrder = itemlist.m_sortOrder;
   m_replaceListing = itemlist.m_replaceListing;
   m_content = itemlist.m_content;
   m_mapProperties = itemlist.m_mapProperties;

--- a/xbmc/FileItem.cpp
+++ b/xbmc/FileItem.cpp
@@ -1445,6 +1445,7 @@ void CFileItemList::Assign(const CFileItemList& itemlist, bool append)
     Clear();
   Append(itemlist);
   SetPath(itemlist.GetPath());
+  SetLabel(itemlist.GetLabel());
   m_sortDetails = itemlist.m_sortDetails;
   m_replaceListing = itemlist.m_replaceListing;
   m_content = itemlist.m_content;

--- a/xbmc/FileItem.h
+++ b/xbmc/FileItem.h
@@ -407,7 +407,7 @@ public:
   void Assign(const CFileItemList& itemlist, bool append = false);
   bool Copy  (const CFileItemList& item, bool copyItems = true);
   void Reserve(int iCount);
-  void Sort(SORT_METHOD sortMethod, SortOrder sortOrder);
+  void Sort(SortBy sortBy, SortOrder sortOrder, SortAttribute sortAttributes = SortAttributeNone);
   /* \brief Sorts the items based on the given sorting options
   In contrast to Sort (see above) this does not change the internal
   state by storing the sorting method and order used and therefore
@@ -435,8 +435,8 @@ public:
    */
   void Stack(bool stackFiles = true);
 
-  SortOrder GetSortOrder() const { return m_sortOrder; }
-  SORT_METHOD GetSortMethod() const { return m_sortMethod; }
+  SortOrder GetSortOrder() const { return m_sortDescription.sortOrder; }
+  SortBy GetSortMethod() const { return m_sortDescription.sortBy; }
   /*! \brief load a CFileItemList out of the cache
 
    The file list may be cached based on which window we're viewing in, as different
@@ -490,7 +490,9 @@ public:
    */
   bool UpdateItem(const CFileItem *item);
 
-  void AddSortMethod(SORT_METHOD method, int buttonLabel, const LABEL_MASKS &labelMasks);
+  void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
+  void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);
+  void AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks);
   bool HasSortDetails() const { return m_sortDetails.size() != 0; };
   const std::vector<SORT_METHOD_DETAILS> &GetSortDetails() const { return m_sortDetails; };
 
@@ -527,8 +529,7 @@ private:
   VECFILEITEMS m_items;
   MAPFILEITEMS m_map;
   bool m_fastLookup;
-  SORT_METHOD m_sortMethod;
-  SortOrder m_sortOrder;
+  SortDescription m_sortDescription;
   bool m_sortIgnoreFolders;
   CACHE_TYPE m_cacheToDisc;
   bool m_replaceListing;

--- a/xbmc/FileSystem/HTSPDirectory.cpp
+++ b/xbmc/FileSystem/HTSPDirectory.cpp
@@ -387,17 +387,9 @@ bool CHTSPDirectory::GetChannels( const CURL &base
     items.Add(item);
   }
 
-  items.AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS("%K[ - %B]", "%Z", "%L", ""));
-
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    items.AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558,   LABEL_MASKS("%B", "%Z", "%L", ""));
-  else
-    items.AddSortMethod(SORT_METHOD_ALBUM,            558,   LABEL_MASKS("%B", "%Z", "%L", ""));
-
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    items.AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%Z", "%B", "%L", ""));
-  else
-    items.AddSortMethod(SORT_METHOD_LABEL,            551, LABEL_MASKS("%Z", "%B", "%L", ""));
+  items.AddSortMethod(SortByTrackNumber,   554, LABEL_MASKS("%K[ - %B]", "%Z", "%L", ""));
+  items.AddSortMethod(SortByAlbum,         558, LABEL_MASKS("%B", "%Z", "%L", ""), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  items.AddSortMethod(SortByLabel,         551, LABEL_MASKS("%Z", "%B", "%L", ""), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
 
   return !channels.empty();
 

--- a/xbmc/FileSystem/LibraryDirectory.cpp
+++ b/xbmc/FileSystem/LibraryDirectory.cpp
@@ -139,7 +139,7 @@ bool CLibraryDirectory::GetDirectory(const CStdString& strPath, CFileItemList &i
       items.Add(item);
     }
   }
-  items.Sort(SORT_METHOD_PLAYLIST_ORDER, SortOrderAscending);
+  items.Sort(SortByPlaylistOrder, SortOrderAscending);
   return true;
 }
 

--- a/xbmc/FileSystem/MultiPathDirectory.cpp
+++ b/xbmc/FileSystem/MultiPathDirectory.cpp
@@ -250,7 +250,7 @@ void CMultiPathDirectory::MergeItems(CFileItemList &items)
     return;
   // sort items by label
   // folders are before files in this sort method
-  items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrderAscending);
   int i = 0;
 
   // if first item in the sorted list is a file, just abort

--- a/xbmc/FileSystem/MythDirectory.cpp
+++ b/xbmc/FileSystem/MythDirectory.cpp
@@ -150,7 +150,7 @@ bool CMythDirectory::GetGuide(const CStdString& base, CFileItemList &items)
     }
   }
 
-  items.AddSortMethod(SORT_METHOD_LABEL, 551 /* Name */, LABEL_MASKS("", "", "%K", ""));
+  items.AddSortMethod(SortByLabel, 551 /* Name */, LABEL_MASKS("", "", "%K", ""));
 
   m_dll->ref_release(list);
   return true;
@@ -229,7 +229,7 @@ bool CMythDirectory::GetGuideForChannel(const CStdString& base, CFileItemList &i
    * result in the guide being shown in the wrong order for skins that sort by date in descending
    * order by default with no option to change to ascending, e.g. Confluence.
    */
-  items.AddSortMethod(SORT_METHOD_NONE, 552 /* Date */, LABEL_MASKS("%K", "%J")); // Still leave the date label
+  items.AddSortMethod(SortByNone, 552 /* Date */, LABEL_MASKS("%K", "%J")); // Still leave the date label
 
   m_dll->ref_release(program);
   return true;
@@ -327,13 +327,8 @@ bool CMythDirectory::GetRecordings(const CStdString& base, CFileItemList &items,
    * the subtitle doesn't influence the sort order and they are sorted by date.
    */
   if (type != TV_SHOWS)
-  {
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      items.AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%K", "%J"));
-    else
-      items.AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%K", "%J"));
-  }
-  items.AddSortMethod(SORT_METHOD_DATE, 552 /* Date */, LABEL_MASKS("%K", "%J"));
+    items.AddSortMethod(SortBySortTitle, 556 /* Name */, LABEL_MASKS("%K", "%J"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  items.AddSortMethod(SortByDate, 552 /* Date */, LABEL_MASKS("%K", "%J"));
 
   return true;
 }
@@ -394,11 +389,8 @@ bool CMythDirectory::GetTvShowFolders(const CStdString& base, CFileItemList &ite
   }
   m_dll->ref_release(list);
 
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    items.AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551 /* Name */, LABEL_MASKS("", "", "%L", "%J"));
-  else
-    items.AddSortMethod(SORT_METHOD_LABEL, 551 /* Name */, LABEL_MASKS("", "", "%L", "%J"));
-  items.AddSortMethod(SORT_METHOD_DATE, 552 /* Date */, LABEL_MASKS("", "", "%L", "%J"));
+  items.AddSortMethod(SortByLabel, 551 /* Name */, LABEL_MASKS("", "", "%L", "%J"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  items.AddSortMethod(SortByDate, 552 /* Date */, LABEL_MASKS("", "", "%L", "%J"));
 
   return true;
 }
@@ -466,15 +458,12 @@ bool CMythDirectory::GetChannels(const CStdString& base, CFileItemList &items)
     m_dll->ref_release(program);
   }
 
-  items.AddSortMethod(SORT_METHOD_LABEL, 551 /* Name */, LABEL_MASKS("%K", "%B"));
+  items.AddSortMethod(SortByLabel, 551 /* Name */, LABEL_MASKS("%K", "%B"));
 
   /*
    * Video sort title is set to the channel number.
    */
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    items.AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556 /* Title */, LABEL_MASKS("%K", "%B"));
-  else
-    items.AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556 /* Title */, LABEL_MASKS("%K", "%B"));
+  items.AddSortMethod(SortBySortTitle, 556 /* Title */, LABEL_MASKS("%K", "%B"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
 
   return true;
 }
@@ -530,7 +519,7 @@ bool CMythDirectory::GetDirectory(const CStdString& strPath, CFileItemList &item
     item->SetLabel(g_localizeStrings.Get(22020)); // Guide
     items.Add(item);
 
-    items.AddSortMethod(SORT_METHOD_NONE, 564 /* Type */, LABEL_MASKS("", "", "%L", "")); // No sorting, as added to list.
+    items.AddSortMethod(SortByNone, 564 /* Type */, LABEL_MASKS("", "", "%L", "")); // No sorting, as added to list.
 
     /*
      * Clear the directory cache so the cached sub-folders are guaranteed to be accurate.

--- a/xbmc/FileSystem/PluginDirectory.cpp
+++ b/xbmc/FileSystem/PluginDirectory.cpp
@@ -207,7 +207,7 @@ void CPluginDirectory::EndOfDirectory(int handle, bool success, bool replaceList
   dir->m_listItems->SetReplaceListing(replaceListing);
 
   if (!dir->m_listItems->HasSortDetails())
-    dir->m_listItems->AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%L", "%D"));
+    dir->m_listItems->AddSortMethod(SortByNone, 552, LABEL_MASKS("%L", "%D"));
 
   // Unload temporary language strings
   ClearPluginStrings();
@@ -233,145 +233,119 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const C
     case SORT_METHOD_LABEL:
     case SORT_METHOD_LABEL_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T", label2Mask));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", label2Mask), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_TITLE:
     case SORT_METHOD_TITLE_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", label2Mask));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByTitle, 556, LABEL_MASKS("%T", label2Mask), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_ARTIST:
     case SORT_METHOD_ARTIST_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%T", "%A"));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%T", "%A"));
+        dir->m_listItems->AddSortMethod(SortByArtist, 557, LABEL_MASKS("%T", "%A"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_ALBUM:
     case SORT_METHOD_ALBUM_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%T", "%B"));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%T", "%B"));
+        dir->m_listItems->AddSortMethod(SortByAlbum, 558, LABEL_MASKS("%T", "%B"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_DATE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%T", "%J"));
+        dir->m_listItems->AddSortMethod(SortByDate, 552, LABEL_MASKS("%T", "%J"));
         break;
       }
     case SORT_METHOD_BITRATE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_BITRATE, 623, LABEL_MASKS("%T", "%X"));
+        dir->m_listItems->AddSortMethod(SortByBitrate, 623, LABEL_MASKS("%T", "%X"));
         break;
       }             
     case SORT_METHOD_SIZE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%T", "%I"));
+        dir->m_listItems->AddSortMethod(SortBySize, 553, LABEL_MASKS("%T", "%I"));
         break;
       }
     case SORT_METHOD_FILE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByFile, 561, LABEL_MASKS("%T", label2Mask));
         break;
       }
     case SORT_METHOD_TRACKNUM:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS("[%N. ]%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS("[%N. ]%T", label2Mask));
         break;
       }
     case SORT_METHOD_DURATION:
+    case SORT_METHOD_VIDEO_RUNTIME:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_DURATION, 180, LABEL_MASKS("%T", "%D"));
+        dir->m_listItems->AddSortMethod(SortByTime, 180, LABEL_MASKS("%T", "%D"));
         break;
       }
     case SORT_METHOD_VIDEO_RATING:
+    case SORT_METHOD_SONG_RATING:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R"));
+        dir->m_listItems->AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R"));
         break;
       }
     case SORT_METHOD_YEAR:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y"));
-        break;
-      }
-    case SORT_METHOD_SONG_RATING:
-      {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_SONG_RATING, 563, LABEL_MASKS("%T", "%R"));
+        dir->m_listItems->AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));
         break;
       }
     case SORT_METHOD_GENRE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_GENRE, 515, LABEL_MASKS("%T", "%G"));
+        dir->m_listItems->AddSortMethod(SortByGenre, 515, LABEL_MASKS("%T", "%G"));
         break;
       }
     case SORT_METHOD_COUNTRY:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_COUNTRY, 574, LABEL_MASKS("%T", "%G"));
+        dir->m_listItems->AddSortMethod(SortByCountry, 574, LABEL_MASKS("%T", "%G"));
         break;
       }
     case SORT_METHOD_VIDEO_TITLE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_VIDEO_TITLE, 369, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByTitle, 369, LABEL_MASKS("%T", label2Mask));
         break;
       }
     case SORT_METHOD_VIDEO_SORT_TITLE:
     case SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", label2Mask));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%T", label2Mask), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_MPAA_RATING:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
-        break;
-      }
-    case SORT_METHOD_VIDEO_RUNTIME:
-      {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_VIDEO_RUNTIME, 180, LABEL_MASKS("%T", "%D"));
+        dir->m_listItems->AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));
         break;
       }
     case SORT_METHOD_STUDIO:
     case SORT_METHOD_STUDIO_IGNORE_THE:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          dir->m_listItems->AddSortMethod(SORT_METHOD_STUDIO_IGNORE_THE, 572, LABEL_MASKS("%T", "%U"));
-        else
-          dir->m_listItems->AddSortMethod(SORT_METHOD_STUDIO, 572, LABEL_MASKS("%T", "%U"));
+        dir->m_listItems->AddSortMethod(SortByStudio, 572, LABEL_MASKS("%T", "%U"), g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
         break;
       }
     case SORT_METHOD_PROGRAM_COUNT:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_PROGRAM_COUNT, 567, LABEL_MASKS("%T", "%C"));
+        dir->m_listItems->AddSortMethod(SortByProgramCount, 567, LABEL_MASKS("%T", "%C"));
         break;
       }
     case SORT_METHOD_UNSORTED:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_UNSORTED, 571, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByNone, 571, LABEL_MASKS("%T", label2Mask));
         break;
       }
     case SORT_METHOD_NONE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%T", label2Mask));
+        dir->m_listItems->AddSortMethod(SortByNone, 552, LABEL_MASKS("%T", label2Mask));
         break;
       }
     case SORT_METHOD_DRIVE_TYPE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_DRIVE_TYPE, 564, LABEL_MASKS()); // Preformatted
+        dir->m_listItems->AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformatted
         break;
       }
     case SORT_METHOD_PLAYLIST_ORDER:
@@ -379,23 +353,23 @@ void CPluginDirectory::AddSortMethod(int handle, SORT_METHOD sortMethod, const C
         CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
         CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
 
-        dir->m_listItems->AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS(strTrackLeft, strTrackRight));
+        dir->m_listItems->AddSortMethod(SortByPlaylistOrder, 559, LABEL_MASKS(strTrackLeft, strTrackRight));
         break;
       }
     case SORT_METHOD_EPISODE:
       {
-        dir->m_listItems->AddSortMethod(SORT_METHOD_EPISODE,20359,LABEL_MASKS("%E. %T","%R"));
+        dir->m_listItems->AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%E. %T","%R"));
         break;
       }
     case SORT_METHOD_PRODUCTIONCODE:
       {
         //dir->m_listItems.AddSortMethod(SORT_METHOD_PRODUCTIONCODE,20368,LABEL_MASKS("%E. %T","%P", "%E. %T","%P"));
-        dir->m_listItems->AddSortMethod(SORT_METHOD_PRODUCTIONCODE,20368,LABEL_MASKS("%H. %T","%P", "%H. %T","%P"));
+        dir->m_listItems->AddSortMethod(SortByProductionCode, 20368, LABEL_MASKS("%H. %T","%P", "%H. %T","%P"));
         break;
       }
     case SORT_METHOD_LISTENERS:
       {
-       dir->m_listItems->AddSortMethod(SORT_METHOD_LISTENERS,20455,LABEL_MASKS("%T","%W"));
+       dir->m_listItems->AddSortMethod(SortByListeners, 20455, LABEL_MASKS("%T","%W"));
        break;
       }
    

--- a/xbmc/FileSystem/PluginDirectory.cpp
+++ b/xbmc/FileSystem/PluginDirectory.cpp
@@ -107,6 +107,7 @@ bool CPluginDirectory::StartScript(const CStdString& strPath)
   m_fileResult->Reset();
   m_listItems->Clear();
   m_listItems->SetPath(strPath);
+  m_listItems->SetLabel(url.GetShareName());
   m_cancelled = false;
   m_success = false;
   m_totalItems = 0;

--- a/xbmc/FileSystem/PluginDirectory.h
+++ b/xbmc/FileSystem/PluginDirectory.h
@@ -29,6 +29,7 @@
 #include "../utils/CriticalSection.h"
 
 class CURL;
+class CFileItem;
 class CFileItemList;
 
 namespace XFILE

--- a/xbmc/FileSystem/RSSDirectory.cpp
+++ b/xbmc/FileSystem/RSSDirectory.cpp
@@ -629,10 +629,10 @@ bool CRSSDirectory::GetDirectory(const CStdString& path, CFileItemList &items)
       items.Add(item);
   }
 
-  items.AddSortMethod(SORT_METHOD_UNSORTED , 231, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
-  items.AddSortMethod(SORT_METHOD_LABEL    , 551, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
-  items.AddSortMethod(SORT_METHOD_SIZE     , 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // FileName, Size | Foldername, Size
-  items.AddSortMethod(SORT_METHOD_DATE     , 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
+  items.AddSortMethod(SortByNone   , 231, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortByLabel  , 551, LABEL_MASKS("%L", "%D", "%L", ""));    // FileName, Duration | Foldername, empty
+  items.AddSortMethod(SortBySize   , 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // FileName, Size | Foldername, Size
+  items.AddSortMethod(SortByDate   , 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // FileName, Date | Foldername, Date
 
   CDateTime time = CDateTime::GetCurrentDateTime();
   int mins = 60;

--- a/xbmc/FileSystem/RarManager.cpp
+++ b/xbmc/FileSystem/RarManager.cpp
@@ -120,7 +120,7 @@ bool CRarManager::CacheRarredFile(CStdString& strPathInCache, const CStdString& 
     {
       CFileItemList items;
       CDirectory::GetDirectory(g_advancedSettings.m_cachePath,items);
-      items.Sort(SORT_METHOD_SIZE, SortOrderDescending);
+      items.Sort(SortBySize, SortOrderDescending);
       while (items.Size() && CheckFreeSpace(strDir) < iSize)
       {
         CStdString strPath = items[0]->GetPath();

--- a/xbmc/FileSystem/SmartPlaylistDirectory.cpp
+++ b/xbmc/FileSystem/SmartPlaylistDirectory.cpp
@@ -289,7 +289,7 @@ namespace XFILE
 
     // sort grouped list by label
     if (items.Size() > 1 && !group.empty())
-      items.Sort(SORT_METHOD_LABEL_IGNORE_THE, SortOrderAscending);
+      items.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
     // go through and set the playlist order
     for (int i = 0; i < items.Size(); i++)

--- a/xbmc/GUIInfoManager.cpp
+++ b/xbmc/GUIInfoManager.cpp
@@ -979,10 +979,8 @@ int CGUIInfoManager::TranslateSingleString(const CStdString &strCondition)
       }
       else if (prop.name == "sort")
       {
-        SORT_METHOD sort = SORT_METHOD_NONE;
-        if (prop.param().Equals("songrating")) sort = SORT_METHOD_SONG_RATING;
-        if (sort != SORT_METHOD_NONE)
-          return AddMultiInfo(GUIInfo(CONTAINER_SORT_METHOD, sort));
+        if (prop.param().Equals("songrating"))
+          return AddMultiInfo(GUIInfo(CONTAINER_SORT_METHOD, SortByRating));
       }
     }
     else if (cat.name == "listitem")
@@ -2809,7 +2807,7 @@ bool CGUIInfoManager::GetMultiInfoBool(const GUIInfo &info, int contextWindow, c
         {
           const CGUIViewState *viewState = ((CGUIMediaWindow*)window)->GetViewState();
           if (viewState)
-            bReturn = ((unsigned int)viewState->GetSortMethod() == info.GetData1());
+            bReturn = ((unsigned int)viewState->GetSortMethod().sortBy == info.GetData1());
         }
         break;
       }

--- a/xbmc/GUIUserMessages.h
+++ b/xbmc/GUIUserMessages.h
@@ -126,3 +126,6 @@
 
 // Sent from filesystem if a path is known to have changed
 #define GUI_MSG_UPDATE_PATH           GUI_MSG_USER + 33
+
+// Message sent to CGUIWindowSlideshow to show picture
+#define GUI_MSG_SHOW_PICTURE          GUI_MSG_USER + 36

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -148,14 +148,17 @@ SortOrder CGUIViewState::GetDisplaySortOrder() const
   // the one sort order variable to save but it can be ascending usually,
   // and descending for the views which should be usually descending.
   // default sort order for date, size, program count + rating is reversed
-  SORT_METHOD sortMethod = GetSortMethod();
-  if (sortMethod == SORT_METHOD_DATE || sortMethod == SORT_METHOD_SIZE || sortMethod == SORT_METHOD_PLAYCOUNT ||
-      sortMethod == SORT_METHOD_VIDEO_RATING || sortMethod == SORT_METHOD_PROGRAM_COUNT ||
-      sortMethod == SORT_METHOD_SONG_RATING || sortMethod == SORT_METHOD_BITRATE || sortMethod == SORT_METHOD_LISTENERS)
+  SortDescription sorting = GetSortMethod();
+  if (sorting.sortBy == SortByDate || sorting.sortBy == SortBySize || sorting.sortBy == SortByPlaycount ||
+      sorting.sortBy == SortByRating || sorting.sortBy == SortByProgramCount ||
+      sorting.sortBy == SortByBitrate || sorting.sortBy == SortByListeners)
   {
-    if (m_sortOrder == SortOrderAscending) return SortOrderDescending;
-    if (m_sortOrder == SortOrderDescending) return SortOrderAscending;
+    if (m_sortOrder == SortOrderAscending)
+      return SortOrderDescending;
+    if (m_sortOrder == SortOrderDescending)
+      return SortOrderAscending;
   }
+
   return m_sortOrder;
 }
 
@@ -190,12 +193,14 @@ void CGUIViewState::SaveViewAsControl(int viewAsControl)
   SaveViewState();
 }
 
-SORT_METHOD CGUIViewState::GetSortMethod() const
+SortDescription CGUIViewState::GetSortMethod() const
 {
+  SortDescription sorting;
   if (m_currentSortMethod>=0 && m_currentSortMethod<(int)m_sortMethods.size())
-    return m_sortMethods[m_currentSortMethod].m_sortMethod;
+    sorting = m_sortMethods[m_currentSortMethod].m_sortDescription;
+  sorting.sortOrder = m_sortOrder;
 
-  return SORT_METHOD_NONE;
+  return sorting;
 }
 
 int CGUIViewState::GetSortMethodLabel() const
@@ -204,12 +209,6 @@ int CGUIViewState::GetSortMethodLabel() const
     return m_sortMethods[m_currentSortMethod].m_buttonLabel;
 
   return 103; // Sort By: Name
-}
-
-void CGUIViewState::GetSortMethods(vector< pair<int,int> > &sortMethods) const
-{
-  for (unsigned int i = 0; i < m_sortMethods.size(); i++)
-    sortMethods.push_back(make_pair(m_sortMethods[i].m_sortMethod, m_sortMethods[i].m_buttonLabel));
 }
 
 void CGUIViewState::GetSortMethodLabelMasks(LABEL_MASKS& masks) const
@@ -227,54 +226,69 @@ void CGUIViewState::GetSortMethodLabelMasks(LABEL_MASKS& masks) const
   return;
 }
 
-void CGUIViewState::AddSortMethod(SORT_METHOD sortMethod, int buttonLabel, LABEL_MASKS labelmasks)
+void CGUIViewState::AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes /* = SortAttributeNone */)
+{
+  AddSortMethod(sortBy, sortAttributes, buttonLabel, labelMasks);
+}
+
+void CGUIViewState::AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks)
 {
   for (size_t i = 0; i < m_sortMethods.size(); ++i)
-    if (m_sortMethods[i].m_sortMethod == sortMethod)
+    if (m_sortMethods[i].m_sortDescription.sortBy == sortBy)
       return;
 
   SORT_METHOD_DETAILS sort;
-  sort.m_sortMethod=sortMethod;
-  sort.m_buttonLabel=buttonLabel;
-  sort.m_labelMasks=labelmasks;
+  sort.m_sortDescription.sortBy = sortBy;
+  sort.m_sortDescription.sortAttributes = sortAttributes;
+  sort.m_buttonLabel = buttonLabel;
+  sort.m_labelMasks = labelMasks;
   m_sortMethods.push_back(sort);
+}
+
+void CGUIViewState::AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks)
+{
+  AddSortMethod(sortDescription.sortBy, sortDescription.sortAttributes, buttonLabel, labelMasks);
 }
 
 void CGUIViewState::SetCurrentSortMethod(int method)
 {
-  bool ignoreThe = g_guiSettings.GetBool("filelists.ignorethewhensorting");
+  SortBy sortBy = (SortBy)method;
+  SortAttribute sortAttributes = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttributes = SortAttributeIgnoreArticle;
 
-  if (method < SORT_METHOD_NONE || method >= SORT_METHOD_MAX)
+  if (sortBy < SortByNone || sortBy > SortByRandom)
     return; // invalid
 
-  // compensate for "Ignore The" options to make it easier on the skin
-  if (ignoreThe && (method == SORT_METHOD_LABEL || method == SORT_METHOD_TITLE || method == SORT_METHOD_ARTIST || method == SORT_METHOD_ALBUM || method == SORT_METHOD_STUDIO || method == SORT_METHOD_VIDEO_SORT_TITLE))
-    method++;
-  else if (!ignoreThe && (method == SORT_METHOD_LABEL_IGNORE_THE || method == SORT_METHOD_TITLE_IGNORE_THE || method == SORT_METHOD_ARTIST_IGNORE_THE || method==SORT_METHOD_ALBUM_IGNORE_THE || method == SORT_METHOD_STUDIO_IGNORE_THE || method == SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE))
-    method--;
-
-  SetSortMethod((SORT_METHOD)method);
+  SetSortMethod(sortBy, sortAttributes);
   SaveViewState();
 }
 
-void CGUIViewState::SetSortMethod(SORT_METHOD sortMethod)
+void CGUIViewState::SetSortMethod(SortBy sortBy, SortAttribute sortAttributes /* = SortAttributeNone */)
 {
-  for (int i=0; i<(int)m_sortMethods.size(); ++i)
+  for (int i = 0; i < (int)m_sortMethods.size(); ++i)
   {
-    if (m_sortMethods[i].m_sortMethod==sortMethod)
+    if (m_sortMethods[i].m_sortDescription.sortBy == sortBy &&
+       // don't care about SortAttributeIgnoreFolders as it wasn't part of the old sorting comparison
+        m_sortMethods[i].m_sortDescription.sortAttributes == (sortAttributes & ~SortAttributeIgnoreFolders))
     {
-      m_currentSortMethod=i;
+      m_currentSortMethod = i;
       break;
     }
   }
 }
 
-SORT_METHOD CGUIViewState::SetNextSortMethod(int direction /* = 1 */)
+void CGUIViewState::SetSortMethod(SortDescription sortDescription)
+{
+  return SetSortMethod(sortDescription.sortBy, sortDescription.sortAttributes);
+}
+
+SortDescription CGUIViewState::SetNextSortMethod(int direction /* = 1 */)
 {
   m_currentSortMethod += direction;
 
   if (m_currentSortMethod >= (int)m_sortMethods.size())
-    m_currentSortMethod=0;
+    m_currentSortMethod = 0;
   if (m_currentSortMethod < 0)
     m_currentSortMethod = m_sortMethods.size() ? (int)m_sortMethods.size() - 1 : 0;
 
@@ -356,8 +370,8 @@ VECSOURCES& CGUIViewState::GetSources()
 
 CGUIViewStateGeneral::CGUIViewStateGeneral(const CFileItemList& items) : CGUIViewState(items)
 {
-  AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, size | Foldername, empty
-  SetSortMethod(SORT_METHOD_LABEL);
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, size | Foldername, empty
+  SetSortMethod(SortByLabel);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -366,7 +380,7 @@ CGUIViewStateGeneral::CGUIViewStateGeneral(const CFileItemList& items) : CGUIVie
 
 void CGUIViewState::SetSortOrder(SortOrder sortOrder)
 {
-  if (GetSortMethod() == SORT_METHOD_NONE)
+  if (GetSortMethod().sortBy == SortByNone)
     m_sortOrder = SortOrderNone;
   else if (sortOrder == SortOrderNone)
     m_sortOrder = SortOrderAscending;
@@ -384,8 +398,8 @@ void CGUIViewState::LoadViewState(const CStdString &path, int windowID)
         db.GetViewState(path, windowID, state, ""))
     {
       SetViewAsControl(state.m_viewMode);
-      SetSortMethod(state.m_sortMethod);
-      SetSortOrder(state.m_sortOrder);
+      SetSortMethod(state.m_sortDescription);
+      SetSortOrder(state.m_sortDescription.sortOrder);
     }
     db.Close();
   }
@@ -396,7 +410,8 @@ void CGUIViewState::SaveViewToDb(const CStdString &path, int windowID, CViewStat
   CViewDatabase db;
   if (db.Open())
   {
-    CViewState state(m_currentViewAsControl, GetSortMethod(), m_sortOrder);
+    SortDescription sorting = GetSortMethod();
+    CViewState state(m_currentViewAsControl, sorting.sortBy, m_sortOrder, sorting.sortAttributes);
     if (viewState)
       *viewState = state;
     db.SetViewState(path, windowID, state, g_guiSettings.GetString("lookandfeel.skin"));
@@ -408,26 +423,16 @@ void CGUIViewState::SaveViewToDb(const CStdString &path, int windowID, CViewStat
 
 void CGUIViewState::AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks)
 {
-  SORT_METHOD sortMethod = SORT_METHOD_PLAYLIST_ORDER;
+  SortBy sortBy = SortByPlaylistOrder;
   int         sortLabel = 559;
   SortOrder   sortOrder = SortOrderAscending;
   if (items.HasProperty(PROPERTY_SORT_ORDER))
   {
-    SortBy sortBy = (SortBy)items.GetProperty(PROPERTY_SORT_ORDER).asInteger();
-    if (sortBy != SortByNone)
-    {
-      sortMethod = SortUtils::TranslateOldSortMethod(sortBy, g_guiSettings.GetBool("filelists.ignorethewhensorting"));
-      if (sortMethod == SORT_METHOD_NONE)
-        sortMethod = SORT_METHOD_PLAYLIST_ORDER;
-      else
-      {
-        sortLabel = SortUtils::GetSortLabel(sortBy);
-        sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
-      }
-    }
+      sortLabel = SortUtils::GetSortLabel(sortBy);
+      sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
   }
-  AddSortMethod(sortMethod, sortLabel, label_masks);
-  SetSortMethod(sortMethod);
+  AddSortMethod(sortBy, sortLabel, label_masks);
+  SetSortMethod(sortBy);
   SetSortOrder(sortOrder);
 }
 
@@ -437,7 +442,7 @@ CGUIViewStateFromItems::CGUIViewStateFromItems(const CFileItemList &items) : CGU
   for (unsigned int i = 0; i < details.size(); i++)
   {
     const SORT_METHOD_DETAILS sort = details[i];
-    AddSortMethod(sort.m_sortMethod, sort.m_buttonLabel, sort.m_labelMasks);
+    AddSortMethod(sort.m_sortDescription, sort.m_buttonLabel, sort.m_labelMasks);
   }
   // TODO: Should default sort/view mode be specified?
   m_currentSortMethod = 0;
@@ -455,8 +460,8 @@ void CGUIViewStateFromItems::SaveViewState()
 
 CGUIViewStateLibrary::CGUIViewStateLibrary(const CFileItemList &items) : CGUIViewState(items)
 {
-  AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-  SetSortMethod(SORT_METHOD_NONE);
+  AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+  SetSortMethod(SortByNone);
   SetSortOrder(SortOrderNone);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);

--- a/xbmc/GUIViewState.cpp
+++ b/xbmc/GUIViewState.cpp
@@ -380,7 +380,8 @@ void CGUIViewState::LoadViewState(const CStdString &path, int windowID)
   if (db.Open())
   {
     CViewState state;
-    if (db.GetViewState(path, windowID, state))
+    if (db.GetViewState(path, windowID, state, g_guiSettings.GetString("lookandfeel.skin")) ||
+        db.GetViewState(path, windowID, state, ""))
     {
       SetViewAsControl(state.m_viewMode);
       SetSortMethod(state.m_sortMethod);
@@ -398,7 +399,7 @@ void CGUIViewState::SaveViewToDb(const CStdString &path, int windowID, CViewStat
     CViewState state(m_currentViewAsControl, GetSortMethod(), m_sortOrder);
     if (viewState)
       *viewState = state;
-    db.SetViewState(path, windowID, state);
+    db.SetViewState(path, windowID, state, g_guiSettings.GetString("lookandfeel.skin"));
     db.Close();
     if (viewState)
       g_settings.Save();

--- a/xbmc/GUIViewState.h
+++ b/xbmc/GUIViewState.h
@@ -37,12 +37,11 @@ public:
   void SaveViewAsControl(int viewAsControl);
   int GetViewAsControl() const;
 
-  SORT_METHOD SetNextSortMethod(int direction = 1);
+  SortDescription SetNextSortMethod(int direction = 1);
   void SetCurrentSortMethod(int method);
-  SORT_METHOD GetSortMethod() const;
+  SortDescription GetSortMethod() const;
   int GetSortMethodLabel() const;
   void GetSortMethodLabelMasks(LABEL_MASKS& masks) const;
-  void GetSortMethods(std::vector< std::pair<int,int> > &sortMethods) const;
 
   SortOrder SetNextSortOrder();
   SortOrder GetSortOrder() const { return m_sortOrder; };
@@ -73,8 +72,11 @@ protected:
    */
   void AddPlaylistOrder(const CFileItemList &items, LABEL_MASKS label_masks);
 
-  void AddSortMethod(SORT_METHOD sortMethod, int buttonLabel, LABEL_MASKS labelmasks);
-  void SetSortMethod(SORT_METHOD sortMethod);
+  void AddSortMethod(SortBy sortBy, int buttonLabel, const LABEL_MASKS &labelMasks, SortAttribute sortAttributes = SortAttributeNone);
+  void AddSortMethod(SortBy sortBy, SortAttribute sortAttributes, int buttonLabel, const LABEL_MASKS &labelMasks);
+  void AddSortMethod(SortDescription sortDescription, int buttonLabel, const LABEL_MASKS &labelMasks);
+  void SetSortMethod(SortBy sortBy, SortAttribute sortAttributes = SortAttributeNone);
+  void SetSortMethod(SortDescription sortDescription);
   void SetSortOrder(SortOrder sortOrder);
   const CFileItemList& m_items;
 

--- a/xbmc/GUIViewStateGameSaves.cpp
+++ b/xbmc/GUIViewStateGameSaves.cpp
@@ -33,11 +33,11 @@ CGUIViewStateWindowGameSaves::CGUIViewStateWindowGameSaves(const CFileItemList& 
   ///////////////////////////////
   /// NOTE:  GAME ID is saved to %T  (aka TITLE) and t         // Date is %J     %L is Label1
   /////////////
-  AddSortMethod(SORT_METHOD_LABEL, 551,  LABEL_MASKS("%L", "%T", "%L", ""));  // Filename, Size | Foldername, empty
-  AddSortMethod(SORT_METHOD_TITLE, 560, LABEL_MASKS("%L", "%T", "%L", "%T"));  // Filename, TITLE | Foldername, TITLE
-  AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
-  AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
-  SetSortMethod(SORT_METHOD_LABEL);
+  AddSortMethod(SortByLabel, 551,  LABEL_MASKS("%L", "%T", "%L", ""));  // Filename, Size | Foldername, empty
+  AddSortMethod(SortByTitle, 560, LABEL_MASKS("%L", "%T", "%L", "%T"));  // Filename, TITLE | Foldername, TITLE
+  AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
+  AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+  SetSortMethod(SortByLabel);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 

--- a/xbmc/GUIViewStateScripts.cpp
+++ b/xbmc/GUIViewStateScripts.cpp
@@ -29,11 +29,11 @@ using namespace XFILE;
 
 CGUIViewStateWindowScripts::CGUIViewStateWindowScripts(const CFileItemList& items) : CGUIViewState(items)
 {
-  AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-  AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
-  AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
-  AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
-  SetSortMethod(SORT_METHOD_LABEL);
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+  AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
+  AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
+  AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+  SetSortMethod(SortByLabel);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 

--- a/xbmc/PlayListPlayer.cpp
+++ b/xbmc/PlayListPlayer.cpp
@@ -37,8 +37,8 @@ CPlayListPlayer g_playlistPlayer;
 
 CPlayListPlayer::CPlayListPlayer(void)
 {
-  m_PlaylistMusic = new CPlayList;
-  m_PlaylistVideo = new CPlayList;
+  m_PlaylistMusic = new CPlayList(PLAYLIST_MUSIC);
+  m_PlaylistVideo = new CPlayList(PLAYLIST_VIDEO);
   m_PlaylistEmpty = new CPlayList;
   m_iCurrentSong = -1;
   m_bPlayedFirstFile = false;

--- a/xbmc/PlayListPlayer.h
+++ b/xbmc/PlayListPlayer.h
@@ -25,6 +25,7 @@
 #define PLAYLIST_NONE    -1
 #define PLAYLIST_MUSIC   0
 #define PLAYLIST_VIDEO   1
+#define PLAYLIST_PICTURE 2
 
 class CFileItem; typedef boost::shared_ptr<CFileItem> CFileItemPtr;
 class CFileItemList;

--- a/xbmc/SortFileItem.h
+++ b/xbmc/SortFileItem.h
@@ -19,8 +19,6 @@
  *
  */
 
-#include "utils/LabelFormatter.h"
-
 typedef enum {
   SORT_METHOD_NONE=0,
   SORT_METHOD_LABEL,
@@ -63,11 +61,3 @@ typedef enum {
   SORT_METHOD_BITRATE,
   SORT_METHOD_MAX
 } SORT_METHOD;
-
-typedef struct
-{
-  SORT_METHOD m_sortMethod;
-  int m_buttonLabel;
-  LABEL_MASKS m_labelMasks;
-} SORT_METHOD_DETAILS;
-

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -2553,14 +2553,14 @@ void CUtil::SplitParams(const CStdString &paramString, std::vector<CStdString> &
     lastEscaped = escaped;
     if (inQuotes)
     { // if we're in a quote, we accept everything until the closing quote
-      if (ch == '\"' && !escaped)
+      if (ch == '"' && !escaped)
       { // finished a quote - no need to add the end quote to our string
         inQuotes = false;
       }
     }
     else
     { // not in a quote, so check if we should be starting one
-      if (ch == '\"' && !escaped)
+      if (ch == '"' && !escaped)
       { // start of quote - no need to add the quote to our string
         inQuotes = true;
       }
@@ -2577,15 +2577,25 @@ void CUtil::SplitParams(const CStdString &paramString, std::vector<CStdString> &
         if (whiteSpacePos)
           parameter = parameter.Left(whiteSpacePos);
         // trim off start and end quotes
-        if (parameter.GetLength() > 1 && parameter[0] == '\"' && parameter[parameter.GetLength() - 1] == '\"')
+        if (parameter.GetLength() > 1 && parameter[0] == '"' && parameter[parameter.GetLength() - 1] == '"')
           parameter = parameter.Mid(1,parameter.GetLength() - 2);
+        else if (parameter.GetLength() > 3 && parameter[parameter.GetLength() - 1] == '"')
+        {
+          // check name="value" style param.
+          int quotaPos = parameter.Find('"');
+          if (quotaPos > 1 && quotaPos < parameter.GetLength() - 1 && parameter[quotaPos - 1] == '=')
+          {
+            parameter.Delete(parameter.GetLength() - 1);
+            parameter.Delete(quotaPos);
+          }
+        }
         parameters.push_back(parameter);
         parameter.Empty();
         whiteSpacePos = 0;
         continue;
       }
     }
-    if ((ch == '\"' || ch == '\\') && escaped)
+    if ((ch == '"' || ch == '\\') && escaped)
     { // escaped quote or backslash
       parameter[parameter.size()-1] = ch;
       continue;
@@ -2607,8 +2617,18 @@ void CUtil::SplitParams(const CStdString &paramString, std::vector<CStdString> &
   if (whiteSpacePos)
     parameter = parameter.Left(whiteSpacePos);
   // trim off start and end quotes
-  if (parameter.GetLength() > 1 && parameter[0] == '\"' && parameter[parameter.GetLength() - 1] == '\"')
+  if (parameter.GetLength() > 1 && parameter[0] == '"' && parameter[parameter.GetLength() - 1] == '"')
     parameter = parameter.Mid(1,parameter.GetLength() - 2);
+  else if (parameter.GetLength() > 3 && parameter[parameter.GetLength() - 1] == '"')
+  {
+    // check name="value" style param.
+    int quotaPos = parameter.Find('"');
+    if (quotaPos > 1 && quotaPos < parameter.GetLength() - 1 && parameter[quotaPos - 1] == '=')
+    {
+      parameter.Delete(parameter.GetLength() - 1);
+      parameter.Delete(quotaPos);
+    }
+  }
   if (!parameter.IsEmpty() || parameters.size())
     parameters.push_back(parameter);
 }

--- a/xbmc/ViewDatabase.cpp
+++ b/xbmc/ViewDatabase.cpp
@@ -49,7 +49,15 @@ bool CViewDatabase::CreateTables()
     CDatabase::CreateTables();
 
     CLog::Log(LOGINFO, "create view table");
-    m_pDS->exec("CREATE TABLE view ( idView integer primary key, window integer, path text, viewMode integer, sortMethod integer, sortOrder integer, skin text)\n");
+    m_pDS->exec("CREATE TABLE view ("
+                  "idView integer primary key,"
+                  "window integer,"
+                  "path text,"
+                  "viewMode integer,"
+                  "sortMethod integer,"
+                  "sortOrder integer,"
+                  "sortAttributes integer,"
+                  "skin text)\n");
     CLog::Log(LOGINFO, "create view index");
     m_pDS->exec("CREATE INDEX idxViews ON view(path)");
     CLog::Log(LOGINFO, "create view - window index");
@@ -68,6 +76,40 @@ bool CViewDatabase::UpdateOldVersion(int version)
 {
   if (version < 4)
     m_pDS->exec("alter table view add skin text");
+  if (version < 6)
+  {
+    // convert the "path" table
+    m_pDS->exec("CREATE TABLE tmp_view AS SELECT * FROM view");
+    m_pDS->exec("DROP INDEX idxViews");
+    m_pDS->exec("DROP INDEX idxViewsWindow");
+    m_pDS->exec("DROP TABLE view");
+
+    m_pDS->exec("CREATE TABLE view ("
+                "idView integer primary key,"
+                "window integer,"
+                "path text,"
+                "viewMode integer,"
+                "sortMethod integer,"
+                "sortOrder integer,"
+                "sortAttributes integer,"
+                "skin text)\n");
+    m_pDS->exec("CREATE INDEX idxViews ON view(path)");
+    m_pDS->exec("CREATE INDEX idxViewsWindow ON view(window)");
+
+    m_pDS->query("SELECT * FROM tmp_view");
+    while (!m_pDS->eof())
+    {
+      SortDescription sorting = SortUtils::TranslateOldSortMethod((SORT_METHOD)m_pDS->fv(4).get_asInt());
+
+      CStdString sql = PrepareSQL("INSERT INTO view (idView, window, path, viewMode, sortMethod, sortOrder, sortAttributes, skin) VALUES (%i, %i, '%s', %i, %i, %i, %i, '%s')",
+        m_pDS->fv(0).get_asInt(), m_pDS->fv(1).get_asInt(), m_pDS->fv(2).get_asString().c_str(), m_pDS->fv(3).get_asInt(),
+        (int)sorting.sortBy, m_pDS->fv(5).get_asInt(), (int)sorting.sortAttributes, m_pDS->fv(6).get_asString().c_str());
+      m_pDS2->exec(sql);
+
+      m_pDS->next();
+    }
+    m_pDS->exec("DROP TABLE tmp_view");
+  }
   return true;
 }
 
@@ -92,8 +134,9 @@ bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState 
     if (!m_pDS->eof())
     { // have some information
       state.m_viewMode = m_pDS->fv("viewMode").get_asInt();
-      state.m_sortMethod = (SORT_METHOD)m_pDS->fv("sortMethod").get_asInt();
-      state.m_sortOrder = (SortOrder)m_pDS->fv("sortOrder").get_asInt();
+      state.m_sortDescription.sortBy = (SortBy)m_pDS->fv("sortMethod").get_asInt();
+      state.m_sortDescription.sortOrder = (SortOrder)m_pDS->fv("sortOrder").get_asInt();
+      state.m_sortDescription.sortAttributes = (SortAttribute)m_pDS->fv("sortAttributes").get_asInt();
       m_pDS->close();
       return true;
     }
@@ -123,13 +166,15 @@ bool CViewDatabase::SetViewState(const CStdString &path, int window, const CView
     { // update the view
       int idView = m_pDS->fv("idView").get_asInt();
       m_pDS->close();
-      sql = PrepareSQL("update view set viewMode=%i,sortMethod=%i,sortOrder=%i where idView=%i", state.m_viewMode, (int)state.m_sortMethod, (int)state.m_sortOrder, idView);
+      sql = PrepareSQL("update view set viewMode=%i,sortMethod=%i,sortOrder=%i,sortAttributes=%i where idView=%i",
+        state.m_viewMode, (int)state.m_sortDescription.sortBy, (int)state.m_sortDescription.sortOrder, (int)state.m_sortDescription.sortAttributes, idView);
       m_pDS->exec(sql.c_str());
     }
     else
     { // add the view
       m_pDS->close();
-      sql = PrepareSQL("insert into view (idView, path, window, viewMode, sortMethod, sortOrder, skin) values(NULL, '%s', %i, %i, %i, %i, '%s')", path1.c_str(), window, state.m_viewMode, (int)state.m_sortMethod, (int)state.m_sortOrder, skin.c_str());
+      sql = PrepareSQL("insert into view (idView, path, window, viewMode, sortMethod, sortOrder, sortAttributes, skin) values(NULL, '%s', %i, %i, %i, %i, %i, '%s')",
+        path1.c_str(), window, state.m_viewMode, (int)state.m_sortDescription.sortOrder, (int)state.m_sortDescription.sortAttributes, skin.c_str());
       m_pDS->exec(sql.c_str());
     }
   }

--- a/xbmc/ViewDatabase.cpp
+++ b/xbmc/ViewDatabase.cpp
@@ -49,7 +49,7 @@ bool CViewDatabase::CreateTables()
     CDatabase::CreateTables();
 
     CLog::Log(LOGINFO, "create view table");
-    m_pDS->exec("CREATE TABLE view ( idView integer primary key, window integer, path text, viewMode integer, sortMethod integer, sortOrder integer)\n");
+    m_pDS->exec("CREATE TABLE view ( idView integer primary key, window integer, path text, viewMode integer, sortMethod integer, sortOrder integer, skin text)\n");
     CLog::Log(LOGINFO, "create view index");
     m_pDS->exec("CREATE INDEX idxViews ON view(path)");
     CLog::Log(LOGINFO, "create view - window index");
@@ -66,10 +66,12 @@ bool CViewDatabase::CreateTables()
 
 bool CViewDatabase::UpdateOldVersion(int version)
 {
+  if (version < 4)
+    m_pDS->exec("alter table view add skin text");
   return true;
 }
 
-bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState &state)
+bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState &state, const CStdString &skin)
 {
   try
   {
@@ -80,7 +82,11 @@ bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState 
     URIUtils::AddSlashAtEnd(path1);
     if (path1.IsEmpty()) path1 = "root://";
 
-    CStdString sql = PrepareSQL("select * from view where window = %i and path like '%s'", window, path1.c_str());
+    CStdString sql;
+    if (skin.IsEmpty())
+      sql = PrepareSQL("select * from view where window = %i and path like '%s'", window, path1.c_str());
+    else
+      sql = PrepareSQL("select * from view where window = %i and path like '%s' and skin='%s'", window, path1.c_str(), skin.c_str());
     m_pDS->query(sql.c_str());
 
     if (!m_pDS->eof())
@@ -100,7 +106,7 @@ bool CViewDatabase::GetViewState(const CStdString &path, int window, CViewState 
   return false;
 }
 
-bool CViewDatabase::SetViewState(const CStdString &path, int window, const CViewState &state)
+bool CViewDatabase::SetViewState(const CStdString &path, int window, const CViewState &state, const CStdString &skin)
 {
   try
   {
@@ -111,7 +117,7 @@ bool CViewDatabase::SetViewState(const CStdString &path, int window, const CView
     URIUtils::AddSlashAtEnd(path1);
     if (path1.IsEmpty()) path1 = "root://";
 
-    CStdString sql = PrepareSQL("select idView from view where window = %i and path like '%s'", window, path1.c_str());
+    CStdString sql = PrepareSQL("select idView from view where window = %i and path like '%s' and skin='%s'", window, path1.c_str(), skin.c_str());
     m_pDS->query(sql.c_str());
     if (!m_pDS->eof())
     { // update the view
@@ -123,7 +129,7 @@ bool CViewDatabase::SetViewState(const CStdString &path, int window, const CView
     else
     { // add the view
       m_pDS->close();
-      sql = PrepareSQL("insert into view (idView, path, window, viewMode, sortMethod, sortOrder) values(NULL, '%s', %i, %i, %i, %i)", path1.c_str(), window, state.m_viewMode, (int)state.m_sortMethod, (int)state.m_sortOrder);
+      sql = PrepareSQL("insert into view (idView, path, window, viewMode, sortMethod, sortOrder, skin) values(NULL, '%s', %i, %i, %i, %i, '%s')", path1.c_str(), window, state.m_viewMode, (int)state.m_sortMethod, (int)state.m_sortOrder, skin.c_str());
       m_pDS->exec(sql.c_str());
     }
   }

--- a/xbmc/ViewDatabase.h
+++ b/xbmc/ViewDatabase.h
@@ -36,6 +36,6 @@ public:
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 4; };
+  virtual int GetMinVersion() const { return 6; };
   const char *GetDefaultDBName() const { return "ViewModes"; };
 };

--- a/xbmc/ViewDatabase.h
+++ b/xbmc/ViewDatabase.h
@@ -29,13 +29,13 @@ public:
   virtual ~CViewDatabase(void);
   virtual bool Open();
 
-  bool GetViewState(const CStdString &path, int windowID, CViewState &state);
-  bool SetViewState(const CStdString &path, int windowID, const CViewState &state);
+  bool GetViewState(const CStdString &path, int windowID, CViewState &state, const CStdString &skin);
+  bool SetViewState(const CStdString &path, int windowID, const CViewState &state, const CStdString &skin);
   bool ClearViewStates(int windowID);
 
 protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
-  virtual int GetMinVersion() const { return 3; };
+  virtual int GetMinVersion() const { return 4; };
   const char *GetDefaultDBName() const { return "ViewModes"; };
 };

--- a/xbmc/ViewState.h
+++ b/xbmc/ViewState.h
@@ -30,20 +30,20 @@
 class CViewState
 {
 public:
-  CViewState(int viewMode, SORT_METHOD sortMethod, SortOrder sortOrder)
+  CViewState(int viewMode, SortBy sortMethod, SortOrder sortOrder, SortAttribute sortAttributes = SortAttributeNone)
   {
     m_viewMode = viewMode;
-    m_sortMethod = sortMethod;
-    m_sortOrder = sortOrder;
+    m_sortDescription.sortBy = sortMethod;
+    m_sortDescription.sortOrder = sortOrder;
+    m_sortDescription.sortAttributes = sortAttributes;
   };
   CViewState()
   {
     m_viewMode = 0;
-    m_sortMethod = SORT_METHOD_LABEL;
-    m_sortOrder = SortOrderAscending;
+    m_sortDescription.sortBy = SortByLabel;
+    m_sortDescription.sortOrder = SortOrderAscending;
   };
 
   int m_viewMode;
-  SORT_METHOD m_sortMethod;
-  SortOrder m_sortOrder;
+  SortDescription m_sortDescription;
 };

--- a/xbmc/dialogs/GUIDialogFileBrowser.cpp
+++ b/xbmc/dialogs/GUIDialogFileBrowser.cpp
@@ -296,7 +296,7 @@ void CGUIDialogFileBrowser::ClearFileItems()
 void CGUIDialogFileBrowser::OnSort()
 {
   if (!m_singleList)
-    m_vecItems->Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    m_vecItems->Sort(SortByLabel, SortOrderAscending);
 }
 
 void CGUIDialogFileBrowser::Update(const CStdString &strDirectory)

--- a/xbmc/dialogs/GUIDialogMediaFilter.cpp
+++ b/xbmc/dialogs/GUIDialogMediaFilter.cpp
@@ -677,7 +677,7 @@ void CGUIDialogMediaFilter::OnBrowse(const Filter &filter, CFileItemList &items,
   }
 
   // sort the items
-  selectItems.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  selectItems.Sort(SortByLabel, SortOrderAscending);
 
   CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   pDialog->Reset();

--- a/xbmc/dialogs/GUIDialogSelect.cpp
+++ b/xbmc/dialogs/GUIDialogSelect.cpp
@@ -220,7 +220,7 @@ bool CGUIDialogSelect::IsButtonPressed()
 
 void CGUIDialogSelect::Sort(bool bSortOrder /*=true*/)
 {
-  m_vecList->Sort(SORT_METHOD_LABEL, bSortOrder ? SortOrderAscending : SortOrderDescending);
+  m_vecList->Sort(SortByLabel, bSortOrder ? SortOrderAscending : SortOrderDescending);
 }
 
 void CGUIDialogSelect::SetSelected(int iSelected)

--- a/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
+++ b/xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -302,7 +302,7 @@ void CGUIDialogSmartPlaylistRule::OnBrowse()
   }
 
   // sort the items
-  items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrderAscending);
 
   CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
   pDialog->Reset();

--- a/xbmc/input/ButtonTranslator.cpp
+++ b/xbmc/input/ButtonTranslator.cpp
@@ -302,7 +302,7 @@ bool CButtonTranslator::Load()
     CFileItemList files;
     XFILE::CDirectory::GetDirectory(systemKeymapDirPath, files, "*.xml");
     //sort the list for filesystem based prioties, e.g. 01-keymap.xml, 02-keymap-overrides.xml
-    files.Sort(SORT_METHOD_FILE, SortOrderAscending);
+    files.Sort(SortByFile, SortOrderAscending);
     for(int i = 0; i<files.Size(); ++i)
       success |= LoadKeymap(files[i]->GetPath());
   }
@@ -313,7 +313,7 @@ bool CButtonTranslator::Load()
     CFileItemList files;
     XFILE::CDirectory::GetDirectory(userKeymapDirPath, files, "*.xml");
     //sort the list for filesystem based prioties, e.g. 01-keymap.xml, 02-keymap-overrides.xml
-    files.Sort(SORT_METHOD_FILE, SortOrderAscending);
+    files.Sort(SortByFile, SortOrderAscending);
     for(int i = 0; i<files.Size(); ++i)
       success |= LoadKeymap(files[i]->GetPath());
   }

--- a/xbmc/interfaces/AnnouncementManager.cpp
+++ b/xbmc/interfaces/AnnouncementManager.cpp
@@ -185,6 +185,11 @@ void CAnnouncementManager::Announce(AnnouncementFlag flag, const char *sender, c
         object["artist"] = item->GetMusicInfoTag()->GetArtist();
     }
   }
+  else if (item->HasPictureInfoTag())
+  {
+    type = "picture";
+    object["file"] = item->GetPath();
+  }
   else
     type = "unknown";
 

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -486,24 +486,37 @@ int CBuiltins::Execute(const CStdString& execString)
       CLog::Log(LOGERROR, "XBMC.SlideShow called with empty parameter");
       return -2;
     }
+    std::string beginSlidePath;
     // leave RecursiveSlideShow command as-is
     unsigned int flags = 0;
     if (execute.Equals("RecursiveSlideShow"))
       flags |= 1;
 
-    // SlideShow(dir[,recursive][,[not]random])
+    // SlideShow(dir[,recursive][,[not]random][,pause][,beginslide="/path/to/start/slide.jpg"])
+    // the beginslide value need be escaped (for '"' or '\' in it, by backslash)
+    // and then quoted, or not. See CUtil::SplitParams()
     else
     {
-      if ((params.size() > 1 && params[1] == "recursive") || (params.size() > 2 && params[2] == "recursive"))
-        flags |= 1;
-      if ((params.size() > 1 && params[1] == "random") || (params.size() > 2 && params[2] == "random"))
-        flags |= 2;
-      if ((params.size() > 1 && params[1] == "notrandom") || (params.size() > 2 && params[2] == "notrandom"))
-        flags |= 4;
+      for (unsigned int i = 1 ; i < params.size() ; i++)
+      {
+        if (params[i].Equals("recursive"))
+          flags |= 1;
+        else if (params[i].Equals("random")) // set fullscreen or windowed
+          flags |= 2;
+        else if (params[i].Equals("notrandom"))
+          flags |= 4;
+        else if (params[i].Equals("pause"))
+          flags |= 8;
+        else if (params[i].Left(11).Equals("beginslide="))
+          beginSlidePath = params[i].Mid(11);
+      }
     }
 
     CGUIMessage msg(GUI_MSG_START_SLIDESHOW, 0, 0, flags);
-    msg.SetStringParam(params[0]);
+    vector<CStdString> strParams;
+    strParams.push_back(params[0]);
+    strParams.push_back(beginSlidePath);
+    msg.SetStringParams(strParams);
     CGUIWindow *pWindow = g_windowManager.GetWindow(WINDOW_SLIDESHOW);
     if (pWindow) pWindow->OnMessage(msg);
   }

--- a/xbmc/interfaces/Builtins.cpp
+++ b/xbmc/interfaces/Builtins.cpp
@@ -479,6 +479,18 @@ int CBuiltins::Execute(const CStdString& execString)
       }
     }
   }
+  else if (execute.Equals("showPicture"))
+  {
+    if (!params.size())
+    {
+      CLog::Log(LOGERROR, "XBMC.ShowPicture called with empty parameter");
+      return -2;
+    }
+    CGUIMessage msg(GUI_MSG_SHOW_PICTURE, 0, 0);
+    msg.SetStringParam(params[0]);
+    CGUIWindow *pWindow = g_windowManager.GetWindow(WINDOW_SLIDESHOW);
+    if (pWindow) pWindow->OnMessage(msg);
+  }
   else if (execute.Equals("slideShow") || execute.Equals("recursiveslideShow"))
   {
     if (!params.size())

--- a/xbmc/interfaces/IAnnouncer.h
+++ b/xbmc/interfaces/IAnnouncer.h
@@ -25,16 +25,17 @@ namespace ANNOUNCEMENT
   enum AnnouncementFlag
   {
     Player        = 0x01,
-    GUI           = 0x02,
-    System        = 0x04,
-    VideoLibrary  = 0x08,
-    AudioLibrary  = 0x10,
-    Application   = 0x20,
-    Input         = 0x40,
-    Other         = 0x80
+    Playlist      = 0x02,
+    GUI           = 0x04,
+    System        = 0x08,
+    VideoLibrary  = 0x10,
+    AudioLibrary  = 0x20,
+    Application   = 0x40,
+    Input         = 0x80,
+    Other         = 0x100
   };
 
-  #define ANNOUNCE_ALL (Player | GUI | System | VideoLibrary | AudioLibrary | Application | Input | Other)
+  #define ANNOUNCE_ALL (Player | Playlist | GUI | System | VideoLibrary | AudioLibrary | Application | Input | Other)
 
   /*!
     \brief Returns a string representation for the 
@@ -48,6 +49,8 @@ namespace ANNOUNCEMENT
     {
     case Player:
       return "Player";
+    case Playlist:
+      return "Playlist";
     case GUI:
       return "GUI";
     case System:

--- a/xbmc/lib/libGoAhead/XBMChttp.cpp
+++ b/xbmc/lib/libGoAhead/XBMChttp.cpp
@@ -402,7 +402,7 @@ int CXbmcHttp::displayDir(int numParas, CStdString paras[])
     tmp.Format("%i", dirItems.Size());
     return SetResponse(openTag+tmp);
   }
-  dirItems.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  dirItems.Sort(SortByLabel, SortOrderAscending);
   if (lineStart > dirItems.Size() || lineStart < 0)
     return SetResponse(openTag+"Error:Line start value out of range");
   if (numLines == -1)
@@ -489,7 +489,7 @@ void CXbmcHttp::AddItemToPlayList(const CFileItemPtr &pItem, int playList, int s
     CStdString strDirectory=pItem->GetPath();
     CFileItemList items;
     CDirectory::GetDirectory(pItem->GetPath(), items, mask);
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
     for (int i=0; i < items.Size(); ++i)
       if (!(CFileItem*)items[i]->m_bIsFolder || recursive)
         AddItemToPlayList(items[i], playList, sortMethod, mask, recursive);
@@ -760,7 +760,7 @@ int CXbmcHttp::xbmcGetMediaLocation(int numParas, CStdString paras[])
     tmp.Format("%i",items.Size());
     return SetResponse(openTag+tmp);
   }    
-  items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrderAscending);
   CStdString strLine;
   if (lineStart>items.Size() || lineStart<0)
     return SetResponse(openTag+"Error:Line start value out of range");

--- a/xbmc/lib/libGoAhead/XBMCweb.cpp
+++ b/xbmc/lib/libGoAhead/XBMCweb.cpp
@@ -151,7 +151,7 @@ void CXbmcWeb::AddItemToPlayList(const CFileItemPtr &pItem)
     directory->GetDirectory(strDirectory, items);
 
     // sort the items before adding to playlist
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
 
     for (int i=0; i < (int) items.Size(); ++i)
       AddItemToPlayList(items[i]);
@@ -164,7 +164,7 @@ void CXbmcWeb::AddItemToPlayList(const CFileItemPtr &pItem)
     directory->GetDirectory(strDirectory, items);
 
     // sort the items before adding to playlist
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
 
     for (int i=0; i < (int) items.Size(); ++i)
       AddItemToPlayList(items[i]);
@@ -177,7 +177,7 @@ void CXbmcWeb::AddItemToPlayList(const CFileItemPtr &pItem)
     directory->GetDirectory(strDirectory, items);
 
     // sort the items before adding to playlist
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
 
     for (int i=0; i < (int) items.Size(); ++i)
       AddItemToPlayList(items[i]);
@@ -357,7 +357,7 @@ int CXbmcWeb::xbmcNavigate( int eid, webs_t wp, char_t *parameter)
         directory->GetDirectory("",*webDirItems);
 
         //sort items
-        webDirItems->Sort(SORT_METHOD_LABEL, SortOrderAscending);
+        webDirItems->Sort(SortByLabel, SortOrderAscending);
 
         return 0;
       }
@@ -755,7 +755,7 @@ int CXbmcWeb::xbmcCatalog( int eid, webs_t wp, char_t *parameter)
               webDirItems->Add(pItem);
             }
             directory->GetDirectory(strDirectory, *webDirItems);
-            webDirItems->Sort(SORT_METHOD_LABEL, SortOrderAscending);
+            webDirItems->Sort(SortByLabel, SortOrderAscending);
           }
           else
           {

--- a/xbmc/music/GUIViewStateMusic.cpp
+++ b/xbmc/music/GUIViewStateMusic.cpp
@@ -79,20 +79,16 @@ CGUIViewStateMusicSearch::CGUIViewStateMusicSearch(const CFileItemList& items) :
   if (strAlbumRight.IsEmpty())
     strAlbumRight = "%A"; // artist
 
+  SortAttribute sortAttribute = SortAttributeNone;
   if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-  {
-    AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T - %A", "%D", "%L", "%A"));  // Title, Artist, Duration| empty, empty
-    SetSortMethod(SORT_METHOD_TITLE_IGNORE_THE);
-  }
-  else
-  {
-    AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T - %A", "%D", "%L", "%A"));  // Title, Artist, Duration| empty, empty
-    SetSortMethod(SORT_METHOD_TITLE);
-  }
+    sortAttribute = SortAttributeIgnoreArticle;
+
+  AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D", "%L", "%A"));  // Title, Artist, Duration| empty, empty
+  SetSortMethod(SortByTitle, sortAttribute);
 
   SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
 
-  SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortOrder);
+  SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortDescription.sortOrder);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_NAV);
 }
@@ -124,12 +120,16 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   CLog::Log(LOGDEBUG,"Album format left  = [%s]", strAlbumLeft.c_str());
   CLog::Log(LOGDEBUG,"Album format right = [%s]", strAlbumRight.c_str());
 
+  SortAttribute sortAttribute = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttribute = SortAttributeIgnoreArticle;
+
   switch (NodeType)
   {
   case NODE_TYPE_OVERVIEW:
     {
-      AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -138,8 +138,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_TOP100:
     {
-      AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", "%L", ""));  // Filename, empty | Foldername, empty
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -148,8 +148,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_GENRE:
     {
-      AddSortMethod(SORT_METHOD_GENRE, 515, LABEL_MASKS("%F", "", "%G", ""));  // Filename, empty | Genre, empty
-      SetSortMethod(SORT_METHOD_GENRE);
+      AddSortMethod(SortByGenre, 515, LABEL_MASKS("%F", "", "%G", ""));  // Filename, empty | Genre, empty
+      SetSortMethod(SortByGenre);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -158,8 +158,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_YEAR:
     {
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%F", "", "%Y", ""));  // Filename, empty | Year, empty
-      SetSortMethod(SORT_METHOD_LABEL);
+      AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "", "%Y", ""));  // Filename, empty | Year, empty
+      SetSortMethod(SortByLabel);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -168,20 +168,12 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_ARTIST:
     {
-      if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      {
-        AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%F", "", "%A", ""));  // Filename, empty | Artist, empty
-        SetSortMethod(SORT_METHOD_ARTIST_IGNORE_THE);
-      }
-      else
-      {
-        AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%F", "", "%A", ""));  // Filename, empty | Artist, empty
-        SetSortMethod(SORT_METHOD_ARTIST);
-      }
+      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", "%A", ""));  // Filename, empty | Artist, empty
+      SetSortMethod(SortByArtist, sortAttribute);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavArtists.m_viewMode);
 
-      SetSortOrder(g_settings.m_viewStateMusicNavArtists.m_sortOrder);
+      SetSortOrder(g_settings.m_viewStateMusicNavArtists.m_sortDescription.sortOrder);
     }
     break;
   case NODE_TYPE_ALBUM_COMPILATIONS:
@@ -189,31 +181,23 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   case NODE_TYPE_YEAR_ALBUM:
     {
       // album
-      if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-        AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      else
-        AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-
+      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
       // artist
-      if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-        AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      else
-        AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-
+      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
       // year
-      AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
+      AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
 
-      SetSortMethod(g_settings.m_viewStateMusicNavAlbums.m_sortMethod);
+      SetSortMethod(g_settings.m_viewStateMusicNavAlbums.m_sortDescription);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavAlbums.m_viewMode);
 
-      SetSortOrder(g_settings.m_viewStateMusicNavAlbums.m_sortOrder);
+      SetSortOrder(g_settings.m_viewStateMusicNavAlbums.m_sortDescription.sortOrder);
     }
     break;
   case NODE_TYPE_ALBUM_RECENTLY_ADDED:
     {
-      AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 552, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavAlbums.m_viewMode);
 
@@ -222,8 +206,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_ALBUM_RECENTLY_ADDED_SONGS:
     {
-      AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 552, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
 
@@ -232,8 +216,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED:
     {
-      AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavAlbums.m_viewMode);
 
@@ -242,8 +226,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_ALBUM_RECENTLY_PLAYED_SONGS:
     {
-      AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 551, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavAlbums.m_viewMode);
 
@@ -252,8 +236,8 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_ALBUM_TOP100:
     {
-      AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
+      SetSortMethod(SortByNone);
 
       SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -262,26 +246,17 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
     break;
   case NODE_TYPE_SINGLES:
     {
-      if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      {
-        AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-      }
-      else
-      {
-        AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-      }
-      AddSortMethod(SORT_METHOD_DURATION, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_SONG_RATING, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
+      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+      AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
       
-      SetSortMethod(g_settings.m_viewStateMusicNavSongs.m_sortMethod);
+      SetSortMethod(g_settings.m_viewStateMusicNavSongs.m_sortDescription);
       
       SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
       
-      SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortOrder);
+      SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortDescription.sortOrder);
     }
     break;
   case NODE_TYPE_ALBUM_COMPILATIONS_SONGS:
@@ -289,42 +264,33 @@ CGUIViewStateMusicDatabase::CGUIViewStateMusicDatabase(const CFileItemList& item
   case NODE_TYPE_YEAR_SONG:
   case NODE_TYPE_SONG:
     {
-      AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
-      if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      {
-        AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-      }
-      else
-      {
-        AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-      }
-      AddSortMethod(SORT_METHOD_DURATION, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_SONG_RATING, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
+      AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
+      AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Title, Artist, Duration| empty, empty
+      AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Title, Duration| empty, empty
+      AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+      AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+      AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Title - Artist, Rating
+      AddSortMethod(SortByYear, 562, LABEL_MASKS("%T - %A", "%Y")); // Title, Artist, Year
 
-      // the "All Albums" entries always default to SORT_METHOD_ALBUM as this is most logical - user can always
+      // the "All Albums" entries always default to SortByAlbum as this is most logical - user can always
       // change it and the change will be saved for this particular path
       if (dir.IsAllItem(items.GetPath()))
-        SetSortMethod(g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SORT_METHOD_ALBUM_IGNORE_THE : SORT_METHOD_ALBUM);
+        SetSortMethod(SortByAlbum, sortAttribute);
       else
-        SetSortMethod(g_settings.m_viewStateMusicNavSongs.m_sortMethod);
+        SetSortMethod(g_settings.m_viewStateMusicNavSongs.m_sortDescription);
 
-      AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
+      AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T - %A", "%V"));  // Titel - Artist, PlayCount
 
       SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
 
-      SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortOrder);
+      SetSortOrder(g_settings.m_viewStateMusicNavSongs.m_sortDescription.sortOrder);
     }
     break;
   case NODE_TYPE_SONG_TOP100:
     {
-      AddSortMethod(SORT_METHOD_NONE, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
-      SetSortMethod(SORT_METHOD_NONE);
+      AddSortMethod(SortByNone, 576, LABEL_MASKS("%T - %A", "%V"));
+      SetSortMethod(SortByPlaycount);
 
       SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
 
@@ -375,31 +341,24 @@ void CGUIViewStateMusicDatabase::SaveViewState()
 	}
 }
 
-
 CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
+  SortAttribute sortAttribute = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttribute = SortAttributeIgnoreArticle;
+
   if (items.GetContent() == "songs" || items.GetContent() == "mixed") 
   {
     CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
     CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
 
-    AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    {
-      AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-    }
-    else
-    {
-      AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-    }
-    AddSortMethod(SORT_METHOD_DURATION, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_SONG_RATING, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
+    AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
+    AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
+    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
+    AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+    AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+    AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
     AddPlaylistOrder(items, LABEL_MASKS(strTrackLeft, strTrackRight));
 
     SetViewAsControl(g_settings.m_viewStateMusicNavSongs.m_viewMode);
@@ -414,19 +373,11 @@ CGUIViewStateMusicSmartPlaylist::CGUIViewStateMusicSmartPlaylist(const CFileItem
       strAlbumRight = "%A"; // artist
 
     // album
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-    else
-      AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-    
+    AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined    
     // artist
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-    else
-      AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
-    
+    AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));  // Filename, empty | Userdefined, Userdefined
     // year
-    AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
+    AddSortMethod(SortByYear, 562, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
 
     AddPlaylistOrder(items, LABEL_MASKS("%F", "", strAlbumLeft, strAlbumRight));
 
@@ -447,31 +398,25 @@ void CGUIViewStateMusicSmartPlaylist::SaveViewState()
 
 CGUIViewStateMusicPlaylist::CGUIViewStateMusicPlaylist(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
+  SortAttribute sortAttribute = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttribute = SortAttributeIgnoreArticle;
+
   CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
   CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
 
-  AddSortMethod(SORT_METHOD_PLAYLIST_ORDER, 559, LABEL_MASKS(strTrackLeft, strTrackRight));
-  AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-  {
-    AddSortMethod(SORT_METHOD_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-  }
-  else
-  {
-    AddSortMethod(SORT_METHOD_TITLE, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
-  }
-  AddSortMethod(SORT_METHOD_DURATION, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
-  AddSortMethod(SORT_METHOD_SONG_RATING, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
+  AddSortMethod(SortByPlaylistOrder, 559, LABEL_MASKS(strTrackLeft, strTrackRight));
+  AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
+  AddSortMethod(SortByTitle, sortAttribute, 556, LABEL_MASKS("%T - %A", "%D"));  // Title, Artist, Duration| empty, empty
+  AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T - %A", "%D"));  // Album, Titel, Artist, Duration| empty, empty
+  AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%D"));  // Artist, Titel, Duration| empty, empty
+  AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS(strTrackLeft, strTrackRight));
+  AddSortMethod(SortByTime, 180, LABEL_MASKS("%T - %A", "%D"));  // Titel, Artist, Duration| empty, empty
+  AddSortMethod(SortByRating, 563, LABEL_MASKS("%T - %A", "%R"));  // Titel, Artist, Rating| empty, empty
 
-  SetSortMethod(SORT_METHOD_PLAYLIST_ORDER);
+  SetSortMethod(SortByPlaylistOrder);
   SetViewAsControl(g_settings.m_viewStateMusicFiles.m_viewMode);
-  SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortOrder);
+  SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortDescription.sortOrder);
 
   LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
@@ -481,13 +426,16 @@ void CGUIViewStateMusicPlaylist::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_MUSIC_FILES);
 }
 
-
 CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& items) : CGUIViewStateWindowMusic(items)
 {
+  SortAttribute sortAttribute = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttribute = SortAttributeIgnoreArticle;
+
   if (items.IsVirtualDirectoryRoot())
   {
-    AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-    SetSortMethod(SORT_METHOD_NONE);
+    AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+    SetSortMethod(SortByNone);
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -501,35 +449,25 @@ CGUIViewStateWindowMusicNav::CGUIViewStateWindowMusicNav(const CFileItemList& it
       XFILE::CVideoDatabaseDirectory::GetQueryParams(items[!g_guiSettings.GetBool("filelists.showparentdiritems")?0:1]->GetPath(),params);
       if (params.GetMVideoId() != -1)
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T", "%Y"));  // Filename, Duration | Foldername, empty
-        else
-          AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%Y"));  // Filename, Duration | Foldername, empty
-        AddSortMethod(SORT_METHOD_YEAR,562, LABEL_MASKS("%T", "%Y"));
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-        {
-          AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE,557, LABEL_MASKS("%A - %T", "%Y"));
-          AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE,558, LABEL_MASKS("%B - %T", "%Y"));
-        }
-        else
-        {
-          AddSortMethod(SORT_METHOD_ARTIST,557, LABEL_MASKS("%A - %T", "%Y"));
-          AddSortMethod(SORT_METHOD_ALBUM,558, LABEL_MASKS("%B - %T", "%Y"));
-        }
+        AddSortMethod(SortByLabel, sortAttribute, 551, LABEL_MASKS("%T", "%Y"));  // Filename, Duration | Foldername, empty
+        AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));
+        AddSortMethod(SortByArtist, sortAttribute, 557, LABEL_MASKS("%A - %T", "%Y"));
+        AddSortMethod(SortByAlbum, sortAttribute, 558, LABEL_MASKS("%B - %T", "%Y"));
+
         CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
         CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
-        AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
+        AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined| empty, empty
       }
       else
       {
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-        SetSortMethod(SORT_METHOD_LABEL);
+        AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
+        SetSortMethod(SortByLabel);
       }
     }
     else
     {
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-      SetSortMethod(SORT_METHOD_LABEL);
+      AddSortMethod(SortByLabel, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
+      SetSortMethod(SortByLabel);
     }
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -618,9 +556,9 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
 {
   if (items.IsVirtualDirectoryRoot())
   {
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS()); // Preformated
-    AddSortMethod(SORT_METHOD_DRIVE_TYPE, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SORT_METHOD_LABEL);
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
+    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
+    SetSortMethod(SortByLabel);
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -628,26 +566,25 @@ CGUIViewStateWindowMusicSongs::CGUIViewStateWindowMusicSongs(const CFileItemList
   }
   else if (items.GetPath() == "special://musicplaylists/")
   { // playlists list sorts by label only, ignoring folders
-    AddSortMethod(SORT_METHOD_LABEL_IGNORE_FOLDERS, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
-    SetSortMethod(SORT_METHOD_LABEL_IGNORE_FOLDERS);
+    AddSortMethod(SortByLabel, SortAttributeIgnoreFolders, 551, LABEL_MASKS("%F", "%D", "%L", ""));  // Filename, Duration | Foldername, empty
+    SetSortMethod(SortByLabel, SortAttributeIgnoreFolders);
   }
   else
   {
     CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
     CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
 
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-    else
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-    AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS(strTrackLeft, "%I", "%L", "%I"));  // Userdefined, Size | FolderName, Size
-    AddSortMethod(SORT_METHOD_BITRATE, 623, LABEL_MASKS(strTrackLeft, "%X", "%L", "%X"));  // Userdefined, Bitrate | FolderName, Bitrate  
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS(strTrackLeft, "%J", "%L", "%J"));  // Userdefined, Date | FolderName, Date
-    AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-    AddSortMethod(SORT_METHOD_LISTENERS,20455,LABEL_MASKS(strTrackLeft, "%W", "%L", "%W"));
-    SetSortMethod(g_settings.m_viewStateMusicFiles.m_sortMethod);
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""),  // Userdefined, Userdefined | FolderName, empty
+      g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+    AddSortMethod(SortBySize, 553, LABEL_MASKS(strTrackLeft, "%I", "%L", "%I"));  // Userdefined, Size | FolderName, Size
+    AddSortMethod(SortByBitrate, 623, LABEL_MASKS(strTrackLeft, "%X", "%L", "%X"));  // Userdefined, Bitrate | FolderName, Bitrate  
+    AddSortMethod(SortByDate, 552, LABEL_MASKS(strTrackLeft, "%J", "%L", "%J"));  // Userdefined, Date | FolderName, Date
+    AddSortMethod(SortByFile, 561, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
+    AddSortMethod(SortByListeners, 20455,LABEL_MASKS(strTrackLeft, "%W", "%L", "%W"));
+
+    SetSortMethod(g_settings.m_viewStateMusicFiles.m_sortDescription);
     SetViewAsControl(g_settings.m_viewStateMusicFiles.m_viewMode);
-    SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortOrder);
+    SetSortOrder(g_settings.m_viewStateMusicFiles.m_sortDescription.sortOrder);
   }
   LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);
 }
@@ -679,8 +616,8 @@ CGUIViewStateWindowMusicPlaylist::CGUIViewStateWindowMusicPlaylist(const CFileIt
   if (strTrackRight.IsEmpty())
     strTrackRight = g_guiSettings.GetString("musicfiles.trackformatright");
 
-  AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-  SetSortMethod(SORT_METHOD_NONE);
+  AddSortMethod(SortByNone, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
+  SetSortMethod(SortByNone);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -727,17 +664,17 @@ CGUIViewStateMusicShoutcast::CGUIViewStateMusicShoutcast(const CFileItemList& it
   /* and thus this check hardly ever works, so let's just disable it for now */
   if( true || m_items.m_idepth > 1 )
   { /* station list */
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%K", "%B kbps", "%K", ""));  // Title, Bitrate | Title, nothing
-    AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%K", "%A listeners", "%K", ""));  // Titel, Listeners | Titel, nothing
-    AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%K", "%B kbps", "%K", ""));  // Title, Bitrate | Title, nothing
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%K", "%B kbps", "%K", ""));  // Title, Bitrate | Title, nothing
+    AddSortMethod(SortByRating, 563, LABEL_MASKS("%K", "%A listeners", "%K", ""));  // Titel, Listeners | Titel, nothing
+    AddSortMethod(SortBySize, 553, LABEL_MASKS("%K", "%B kbps", "%K", ""));  // Title, Bitrate | Title, nothing
 
-    SetSortMethod(g_settings.m_viewStateMusicShoutcast.m_sortMethod);
-    SetSortOrder(g_settings.m_viewStateMusicShoutcast.m_sortOrder);
+    SetSortMethod(g_settings.m_viewStateMusicShoutcast.m_sortDescription);
+    SetSortOrder(g_settings.m_viewStateMusicShoutcast.m_sortDescription.sortOrder);
   }
   else
   { /* genre list */
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%K", "", "%K", ""));  // Title, nothing | Title, nothing
-    SetSortMethod(SORT_METHOD_LABEL);
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%K", "", "%K", ""));  // Title, nothing | Title, nothing
+    SetSortMethod(SortByLabel);
     SetSortOrder(SortOrderAscending); /* maybe we should have this stored somewhere */
   }
 
@@ -760,12 +697,12 @@ CGUIViewStateMusicLastFM::CGUIViewStateMusicLastFM(const CFileItemList& items) :
   CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
   CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
 
-  AddSortMethod(SORT_METHOD_UNSORTED, 571, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-  AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
-  AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS(strTrackLeft, "%I", "%L", "%I"));  // Userdefined, Size | FolderName, Size
+  AddSortMethod(SortByNone, 571, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS(strTrackLeft, strTrackRight, "%L", ""));  // Userdefined, Userdefined | FolderName, empty
+  AddSortMethod(SortBySize, 553, LABEL_MASKS(strTrackLeft, "%I", "%L", "%I"));  // Userdefined, Size | FolderName, Size
 
-  SetSortMethod(g_settings.m_viewStateMusicLastFM.m_sortMethod);
-  SetSortOrder(g_settings.m_viewStateMusicLastFM.m_sortOrder);
+  SetSortMethod(g_settings.m_viewStateMusicLastFM.m_sortDescription);
+  SetSortOrder(g_settings.m_viewStateMusicLastFM.m_sortDescription.sortOrder);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
   LoadViewState(items.GetPath(), WINDOW_MUSIC_FILES);

--- a/xbmc/music/infoscanner/MusicInfoScanner.cpp
+++ b/xbmc/music/infoscanner/MusicInfoScanner.cpp
@@ -355,7 +355,7 @@ bool CMusicInfoScanner::DoScan(const CStdString& strDirectory)
   // sort and get the path hash.  Note that we don't filter .cue sheet items here as we want
   // to detect changes in the .cue sheet as well.  The .cue sheet items only need filtering
   // if we have a changed hash.
-  items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  items.Sort(SortByLabel, SortOrderAscending);
   CStdString hash;
   GetPathHash(items, hash);
 
@@ -373,7 +373,7 @@ bool CMusicInfoScanner::DoScan(const CStdString& strDirectory)
 
     // filter items in the sub dir (for .cue sheet support)
     items.FilterCueItems();
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
 
     // and then scan in the new information
     if (RetrieveMusicInfo(items, strDirectory) > 0)

--- a/xbmc/network/UPnP.cpp
+++ b/xbmc/network/UPnP.cpp
@@ -1181,7 +1181,7 @@ CUPnPServer::OnBrowseDirectChildren(PLT_ActionReference&          action,
     }
 
     // Always sort by label
-    items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+    items.Sort(SortByLabel, SortOrderAscending);
 
     // Don't pass parent_id if action is Search not BrowseDirectChildren, as
     // we want the engine to determine the best parent id, not necessarily the one

--- a/xbmc/pictures/GUIViewStatePictures.cpp
+++ b/xbmc/pictures/GUIViewStatePictures.cpp
@@ -35,9 +35,9 @@ CGUIViewStateWindowPictures::CGUIViewStateWindowPictures(const CFileItemList& it
 {
   if (items.IsVirtualDirectoryRoot())
   {
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS());
-    AddSortMethod(SORT_METHOD_DRIVE_TYPE, 564, LABEL_MASKS());
-    SetSortMethod(SORT_METHOD_LABEL);
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS());
+    AddSortMethod(SortByDriveType, 564, LABEL_MASKS());
+    SetSortMethod(SortByLabel);
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -45,14 +45,14 @@ CGUIViewStateWindowPictures::CGUIViewStateWindowPictures(const CFileItemList& it
   }
   else
   {
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
-    AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
-    AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | Foldername, empty
+    AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Filename, Size | Foldername, Size
+    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Filename, Date | Foldername, Date
+    AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
 
-    SetSortMethod(g_settings.m_viewStatePictures.m_sortMethod);
+    SetSortMethod(g_settings.m_viewStatePictures.m_sortDescription);
     SetViewAsControl(g_settings.m_viewStatePictures.m_viewMode);
-    SetSortOrder(g_settings.m_viewStatePictures.m_sortOrder);
+    SetSortOrder(g_settings.m_viewStatePictures.m_sortDescription.sortOrder);
   }
   LoadViewState(items.GetPath(), WINDOW_PICTURES);
 }

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -389,6 +389,7 @@ void CGUIWindowPictures::OnSlideShowRecursive(const CStdString &strPicture)
     m_slideShowStarted = true;
     pSlideShow->RunSlideShow(strPicture, true,
                              g_guiSettings.GetBool("slideshow.shuffle"),false,
+                             "", true,
                              m_guiState->GetSortMethod(),
                              m_guiState->GetSortOrder(),
                              strExtensions);
@@ -421,6 +422,7 @@ void CGUIWindowPictures::OnSlideShow(const CStdString &strPicture)
     }
     m_slideShowStarted = true;
     pSlideShow->RunSlideShow(strPicture, false ,false, false,
+                             "", true,
                              m_guiState->GetSortMethod(),
                              m_guiState->GetSortOrder(),
                              strExtensions);

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -58,6 +58,25 @@ CGUIWindowPictures::CGUIWindowPictures(void)
     : CGUIMediaWindow(WINDOW_PICTURES, "MyPics.xml")
 {
   m_thumbLoader.SetObserver(this);
+  m_slideShowStarted = false;
+}
+
+void CGUIWindowPictures::OnInitWindow()
+{
+  CGUIMediaWindow::OnInitWindow();
+  if (m_slideShowStarted)
+  {
+    CGUIWindowSlideShow* wndw = (CGUIWindowSlideShow*)g_windowManager.GetWindow(WINDOW_SLIDESHOW);
+    CStdString path;
+    if (wndw && wndw->GetCurrentSlide())
+      URIUtils::GetDirectory(wndw->GetCurrentSlide()->GetPath(),path);
+    if (path.Equals(m_vecItems->GetPath()))
+    {
+      m_viewControl.SetSelectedItem(wndw->GetCurrentSlide()->GetPath());
+      m_iSelectedItem = m_viewControl.GetSelectedItem();
+    }
+    m_slideShowStarted = false;
+  }
 }
 
 CGUIWindowPictures::~CGUIWindowPictures(void)
@@ -329,6 +348,7 @@ bool CGUIWindowPictures::ShowPicture(int iItem, bool startSlideShow)
   if (startSlideShow)
     pSlideShow->StartSlideShow(false);
 
+  m_slideShowStarted = true;
   g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
 
   return true;
@@ -346,7 +366,10 @@ void CGUIWindowPictures::OnShowPictureRecursive(const CStdString& strPath)
                             m_guiState->GetSortMethod(),
                             m_guiState->GetSortOrder());
     if (pSlideShow->NumSlides())
+    {
+      m_slideShowStarted = true;
       g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
+    }
   }
 }
 
@@ -363,6 +386,7 @@ void CGUIWindowPictures::OnSlideShowRecursive(const CStdString &strPicture)
       strExtensions = viewState->GetExtensions();
       delete viewState;
     }
+    m_slideShowStarted = true;
     pSlideShow->RunSlideShow(strPicture, true,
                              g_guiSettings.GetBool("slideshow.shuffle"),false,
                              m_guiState->GetSortMethod(),
@@ -395,6 +419,7 @@ void CGUIWindowPictures::OnSlideShow(const CStdString &strPicture)
       strExtensions = viewState->GetExtensions();
       delete viewState;
     }
+    m_slideShowStarted = true;
     pSlideShow->RunSlideShow(strPicture, false ,false, false,
                              m_guiState->GetSortMethod(),
                              m_guiState->GetSortOrder(),

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -362,9 +362,10 @@ void CGUIWindowPictures::OnShowPictureRecursive(const CStdString& strPath)
     // stop any video
     if (g_application.IsPlayingVideo())
       g_application.StopPlaying();
+
+    SortDescription sorting = m_guiState->GetSortMethod();
     pSlideShow->AddFromPath(strPath, true,
-                            m_guiState->GetSortMethod(),
-                            m_guiState->GetSortOrder());
+                            sorting.sortBy, sorting.sortOrder, sorting.sortAttributes);
     if (pSlideShow->NumSlides())
     {
       m_slideShowStarted = true;
@@ -387,11 +388,12 @@ void CGUIWindowPictures::OnSlideShowRecursive(const CStdString &strPicture)
       delete viewState;
     }
     m_slideShowStarted = true;
+
+    SortDescription sorting = m_guiState->GetSortMethod();
     pSlideShow->RunSlideShow(strPicture, true,
                              g_guiSettings.GetBool("slideshow.shuffle"),false,
                              "", true,
-                             m_guiState->GetSortMethod(),
-                             m_guiState->GetSortOrder(),
+                             sorting.sortBy, sorting.sortOrder, sorting.sortAttributes,
                              strExtensions);
   }
 }
@@ -421,10 +423,11 @@ void CGUIWindowPictures::OnSlideShow(const CStdString &strPicture)
       delete viewState;
     }
     m_slideShowStarted = true;
+
+    SortDescription sorting = m_guiState->GetSortMethod();
     pSlideShow->RunSlideShow(strPicture, false ,false, false,
                              "", true,
-                             m_guiState->GetSortMethod(),
-                             m_guiState->GetSortOrder(),
+                             sorting.sortBy, sorting.sortOrder, sorting.sortAttributes,
                              strExtensions);
   }
 }
@@ -609,7 +612,7 @@ void CGUIWindowPictures::OnItemLoaded(CFileItem *pItem)
       if (items.Size() < 4 || pItem->IsCBR() || pItem->IsCBZ())
       { // less than 4 items, so just grab the first thumb
         CStdString folderThumb(pItem->GetCachedPictureThumb());
-        items.Sort(SORT_METHOD_LABEL, SortOrderAscending);
+        items.Sort(SortByLabel, SortOrderAscending);
         CPicture pic;
         pic.CreateThumbnail(items[0]->GetPath(), folderThumb);
       }

--- a/xbmc/pictures/GUIWindowPictures.h
+++ b/xbmc/pictures/GUIWindowPictures.h
@@ -35,6 +35,7 @@ public:
   CGUIWindowPictures(void);
   virtual ~CGUIWindowPictures(void);
   virtual bool OnMessage(CGUIMessage& message);
+  virtual void OnInitWindow();
 
 protected:
   virtual bool GetDirectory(const CStdString &strDirectory, CFileItemList& items);
@@ -62,4 +63,5 @@ protected:
   DllImageLib m_ImageLib;
 
   CPictureThumbLoader m_thumbLoader;
+  bool m_slideShowStarted;
 };

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -734,6 +734,17 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
       return true;
     }
     break;
+
+  case GUI_MSG_SHOW_PICTURE:
+    {
+      CStdString strFile = message.GetStringParam();
+      Reset();
+      CFileItem item(strFile, false);
+      Add(&item);
+      RunSlideShow("", false, false, true, "", false);
+    }
+    break;
+
   case GUI_MSG_START_SLIDESHOW:
     {
       CStdString strFolder = message.GetStringParam();
@@ -755,7 +766,7 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
         if ((iParams & 8) == 8)
           bPause = true;
       }
-      RunSlideShow(strFolder, bRecursive, bRandom, bNotRandom, SORT_METHOD_LABEL, SortOrderAscending, "", beginSlidePath, !bPause);
+      RunSlideShow(strFolder, bRecursive, bRandom, bNotRandom, beginSlidePath, !bPause);
     }
     break;
     case GUI_MSG_PLAYLISTPLAYER_STOPPED:
@@ -936,9 +947,9 @@ void CGUIWindowSlideShow::AddFromPath(const CStdString &strPath,
 
 void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath, 
                                        bool bRecursive /* = false */, bool bRandom /* = false */, 
-                                       bool bNotRandom /* = false */, SORT_METHOD method /* = SORT_METHOD_LABEL */, 
-                                       SortOrder order /* = SortOrderAscending */, const CStdString &strExtensions /* = "" */,
-                                       const CStdString &beginSlidePath /* = "" */, bool startSlideShow /* = true */)
+                                       bool bNotRandom /* = false */, const CStdString &beginSlidePath /* = "" */,
+                                       bool startSlideShow /* = true */, SORT_METHOD method /* = SORT_METHOD_LABEL */,
+                                       SortOrder order /* = SortOrderAscending */, const CStdString &strExtensions /* = "" */)
 {
   // stop any video
   if (g_application.IsPlayingVideo())

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -928,7 +928,8 @@ int CGUIWindowSlideShow::CurrentSlide() const
 
 void CGUIWindowSlideShow::AddFromPath(const CStdString &strPath,
                                       bool bRecursive, 
-                                      SORT_METHOD method, SortOrder order, const CStdString &strExtensions)
+                                      SortBy method, SortOrder order, SortAttribute sortAttributes,
+                                      const CStdString &strExtensions)
 {
   if (strPath!="")
   {
@@ -938,24 +939,25 @@ void CGUIWindowSlideShow::AddFromPath(const CStdString &strPath,
     if (bRecursive)
     {
       path_set recursivePaths;
-      AddItems(strPath, &recursivePaths, method, order);
+      AddItems(strPath, &recursivePaths, method, order, sortAttributes);
     }
     else
-      AddItems(strPath, NULL, method, order);
+      AddItems(strPath, NULL, method, order, sortAttributes);
   }
 }
 
 void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath, 
-                                       bool bRecursive /* = false */, bool bRandom /* = false */, 
+                                       bool bRecursive /* = false */, bool bRandom /* = false */,
                                        bool bNotRandom /* = false */, const CStdString &beginSlidePath /* = "" */,
-                                       bool startSlideShow /* = true */, SORT_METHOD method /* = SORT_METHOD_LABEL */,
-                                       SortOrder order /* = SortOrderAscending */, const CStdString &strExtensions /* = "" */)
+                                       bool startSlideShow /* = true */, SortBy method /* = SortByLabel */, 
+                                       SortOrder order /* = SortOrderAscending */, SortAttribute sortAttributes /* = SortAttributeNone */,
+                                       const CStdString &strExtensions)
 {
   // stop any video
   if (g_application.IsPlayingVideo())
     g_application.StopPlaying();
 
-  AddFromPath(strPath, bRecursive, method, order, strExtensions);
+  AddFromPath(strPath, bRecursive, method, order, sortAttributes, strExtensions);
 
   if (!NumSlides())
     return;
@@ -985,7 +987,7 @@ void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath,
   g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
 }
 
-void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursivePaths, SORT_METHOD method, SortOrder order)
+void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursivePaths, SortBy method, SortOrder order, SortAttribute sortAttributes)
 {
   // check whether we've already added this path
   if (recursivePaths)
@@ -1002,7 +1004,7 @@ void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursiv
   if (!CDirectory::GetDirectory(strPath, items, m_strExtensions.IsEmpty()?g_settings.m_pictureExtensions:m_strExtensions,DIR_FLAG_NO_FILE_DIRS,true))
     return;
 
-  items.Sort(method, order);
+  items.Sort(method, order, sortAttributes);
 
   // need to go into all subdirs
   for (int i = 0; i < items.Size(); i++)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -738,10 +738,12 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
     {
       CStdString strFolder = message.GetStringParam();
       unsigned int iParams = message.GetParam1();
+      std::string beginSlidePath = message.GetStringParam(1);
       //decode params
       bool bRecursive = false;
       bool bRandom = false;
       bool bNotRandom = false;
+      bool bPause = false;
       if (iParams > 0)
       {
         if ((iParams & 1) == 1)
@@ -750,8 +752,10 @@ bool CGUIWindowSlideShow::OnMessage(CGUIMessage& message)
           bRandom = true;
         if ((iParams & 4) == 4)
           bNotRandom = true;
+        if ((iParams & 8) == 8)
+          bPause = true;
       }
-      RunSlideShow(strFolder, bRecursive, bRandom, bNotRandom);
+      RunSlideShow(strFolder, bRecursive, bRandom, bNotRandom, SORT_METHOD_LABEL, SortOrderAscending, "", beginSlidePath, !bPause);
     }
     break;
     case GUI_MSG_PLAYLISTPLAYER_STOPPED:
@@ -933,13 +937,17 @@ void CGUIWindowSlideShow::AddFromPath(const CStdString &strPath,
 void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath, 
                                        bool bRecursive /* = false */, bool bRandom /* = false */, 
                                        bool bNotRandom /* = false */, SORT_METHOD method /* = SORT_METHOD_LABEL */, 
-                                       SortOrder order /* = SortOrderAscending */, const CStdString &strExtensions)
+                                       SortOrder order /* = SortOrderAscending */, const CStdString &strExtensions /* = "" */,
+                                       const CStdString &beginSlidePath /* = "" */, bool startSlideShow /* = true */)
 {
   // stop any video
   if (g_application.IsPlayingVideo())
     g_application.StopPlaying();
 
   AddFromPath(strPath, bRecursive, method, order, strExtensions);
+
+  if (!NumSlides())
+    return;
 
   // mutually exclusive options
   // if both are set, clear both and use the gui setting
@@ -950,9 +958,20 @@ void CGUIWindowSlideShow::RunSlideShow(const CStdString &strPath,
   if ((!bNotRandom && g_guiSettings.GetBool("slideshow.shuffle")) || bRandom)
     Shuffle();
 
-  StartSlideShow();
-  if (NumSlides())
-    g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
+  if (!beginSlidePath.IsEmpty())
+    Select(beginSlidePath);
+
+  if (startSlideShow)
+    StartSlideShow();
+  else 
+  {
+    CVariant param;
+    param["player"]["speed"] = 0;
+    param["player"]["playerid"] = PLAYLIST_PICTURE;
+    ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", GetCurrentSlide(), param);
+  }
+
+  g_windowManager.ActivateWindow(WINDOW_SLIDESHOW);
 }
 
 void CGUIWindowSlideShow::AddItems(const CStdString &strPath, path_set *recursivePaths, SORT_METHOD method, SortOrder order)

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -269,6 +269,12 @@ const CFileItemList &CGUIWindowSlideShow::GetSlideShowContents()
   return *m_slides;
 }
 
+void CGUIWindowSlideShow::GetSlideShowContents(CFileItemList &list)
+{
+  for (int index = 0; index < m_slides->Size(); index++)
+    list.Add(CFileItemPtr(new CFileItem(*m_slides->Get(index))));
+}
+
 const CFileItemPtr CGUIWindowSlideShow::GetCurrentSlide()
 {
   if (m_iCurrentSlide >= 0 && m_iCurrentSlide < m_slides->Size())

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -38,6 +38,8 @@
 #include "utils/SingleLock.h"
 #include "utils/log.h"
 #include "playlists/PlayList.h"
+#include "interfaces/AnnouncementManager.h"
+#include "pictures/PictureInfoTag.h"
 
 #ifdef _XBOX
 #define RELOAD_ON_ZOOM
@@ -149,6 +151,52 @@ CGUIWindowSlideShow::~CGUIWindowSlideShow(void)
   delete m_slides;
 }
 
+void CGUIWindowSlideShow::AnnouncePlayerPlay(const CFileItemPtr& item)
+{
+  CVariant param;
+  param["player"]["speed"] = 1;
+  param["player"]["playerid"] = PLAYLIST_PICTURE;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnPlay", item, param);
+}
+
+void CGUIWindowSlideShow::AnnouncePlayerPause(const CFileItemPtr& item)
+{
+  CVariant param;
+  param["player"]["speed"] = 0;
+  param["player"]["playerid"] = PLAYLIST_PICTURE;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnPause", item, param);
+}
+
+void CGUIWindowSlideShow::AnnouncePlayerStop(const CFileItemPtr& item)
+{
+  CVariant param;
+  param["player"]["playerid"] = PLAYLIST_PICTURE;
+  param["end"] = true;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Player, "xbmc", "OnStop", item, param);
+}
+
+void CGUIWindowSlideShow::AnnouncePlaylistRemove(int pos)
+{
+  CVariant data;
+  data["playlistid"] = PLAYLIST_PICTURE;
+  data["position"] = pos;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnRemove", data);
+}
+
+void CGUIWindowSlideShow::AnnouncePlaylistClear()
+{
+  CVariant data;
+  data["playlistid"] = PLAYLIST_PICTURE;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+}
+
+void CGUIWindowSlideShow::AnnouncePlaylistAdd(const CFileItemPtr& item, int pos)
+{
+  CVariant data;
+  data["playlistid"] = PLAYLIST_PICTURE;
+  data["position"] = pos;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
+}
 
 bool CGUIWindowSlideShow::IsPlaying() const
 {
@@ -174,6 +222,7 @@ void CGUIWindowSlideShow::Reset()
   m_iDirection = 1;
   CSingleLock lock(m_slideSection);
   m_slides->Clear();
+  AnnouncePlaylistClear();
   m_Resolution = g_graphicsContext.GetVideoResolution();
 }
 
@@ -218,6 +267,13 @@ void CGUIWindowSlideShow::OnDeinitWindow(int nextWindowID)
 void CGUIWindowSlideShow::Add(const CFileItem *picture)
 {
   CFileItemPtr item(new CFileItem(*picture));
+  if (!item->HasVideoInfoTag() && !item->HasPictureInfoTag())
+  {
+    // item without tag; assume it is a picture and force tag generation
+    item->GetPictureInfoTag();
+  }
+  AnnouncePlaylistAdd(item, m_slides->Size());
+
   m_slides->Add(item);
 }
 
@@ -485,6 +541,7 @@ void CGUIWindowSlideShow::Render()
 
     m_iCurrentSlide = m_iNextSlide;
     m_iNextSlide    = GetNextSlide();
+    AnnouncePlayerPlay(m_slides->Get(m_iCurrentSlide));
 
 //    m_iZoomFactor = 1;
     m_iRotate = 0;
@@ -533,6 +590,8 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
   case ACTION_PREVIOUS_MENU:
   case ACTION_NAV_BACK:
   case ACTION_STOP:
+    if (m_bSlideShow && m_slides->Size())
+      AnnouncePlayerStop(m_slides->Get(m_iCurrentSlide));
     g_windowManager.PreviousWindow();
     break;
   case ACTION_NEXT_PICTURE:
@@ -567,7 +626,16 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
 
   case ACTION_PAUSE:
     if (m_bSlideShow)
+    {
       m_bPause = !m_bPause;
+      if (m_slides->Size())
+      {
+        if (m_bPause)
+          AnnouncePlayerPause(m_slides->Get(m_iCurrentSlide));
+        else
+          AnnouncePlayerPlay(m_slides->Get(m_iCurrentSlide));
+      }
+    }
     break;
 
   case ACTION_PLAYER_PLAY:
@@ -577,7 +645,11 @@ bool CGUIWindowSlideShow::OnAction(const CAction &action)
       m_bPause = false;
     }
     else if (m_bPause)
+    {
       m_bPause = false;
+      if (m_slides->Size())
+        AnnouncePlayerPlay(m_slides->Get(m_iCurrentSlide));
+    }
     break;
 
   case ACTION_ZOOM_OUT:

--- a/xbmc/pictures/GUIWindowSlideShow.cpp
+++ b/xbmc/pictures/GUIWindowSlideShow.cpp
@@ -171,6 +171,7 @@ void CGUIWindowSlideShow::Reset()
   m_iCurrentSlide = 0;
   m_iNextSlide = 1;
   m_iCurrentPic = 0;
+  m_iDirection = 1;
   CSingleLock lock(m_slideSection);
   m_slides->Clear();
   m_Resolution = g_graphicsContext.GetVideoResolution();
@@ -229,6 +230,7 @@ void CGUIWindowSlideShow::ShowNext()
   if (m_iNextSlide >= m_slides->Size())
     m_iNextSlide = 0;
 
+  m_iDirection   = 1;
   m_bLoadNextPic = true;
 }
 
@@ -240,6 +242,7 @@ void CGUIWindowSlideShow::ShowPrevious()
   m_iNextSlide = m_iCurrentSlide - 1;
   if (m_iNextSlide < 0)
     m_iNextSlide = m_slides->Size() - 1;
+  m_iDirection   = -1;
   m_bLoadNextPic = true;
 }
 
@@ -255,6 +258,7 @@ void CGUIWindowSlideShow::Select(const CStdString& strPicture)
       m_iNextSlide = m_iCurrentSlide + 1;
       if (m_iNextSlide >= m_slides->Size())
         m_iNextSlide = 0;
+      m_iDirection    = 1;
       return ;
     }
   }
@@ -280,6 +284,7 @@ bool CGUIWindowSlideShow::InSlideShow() const
 void CGUIWindowSlideShow::StartSlideShow(bool screensaver)
 {
   m_bSlideShow = true;
+  m_iDirection = 1;
   m_bScreensaver = screensaver;
 }
 
@@ -333,12 +338,14 @@ void CGUIWindowSlideShow::Render()
       {
         CLog::Log(LOGERROR, "Error loading the current image %s", m_slides->Get(m_iCurrentSlide)->GetPath().c_str());
         m_iCurrentSlide = m_iNextSlide;
+        m_iNextSlide    = GetNextSlide();
         ShowNext();
         m_bErrorMessage = false;
       }
       else if (m_bLoadNextPic)
       {
         m_iCurrentSlide = m_iNextSlide;
+        m_iNextSlide    = GetNextSlide();
         m_bErrorMessage = false;
       }
       // else just drop through - there's nothing we can do (error message will be displayed)
@@ -397,7 +404,7 @@ void CGUIWindowSlideShow::Render()
   }
   else
   {
-    if ((bSlideShow || m_bLoadNextPic) && m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic)
+    if (m_iNextSlide != m_iCurrentSlide && m_Image[m_iCurrentPic].IsLoaded() && !m_Image[1 - m_iCurrentPic].IsLoaded() && !m_pBackgroundLoader->IsLoading() && !m_bWaitForNextPic)
     { // load the next image
       CLog::Log(LOGDEBUG, "Loading the next image %s", m_slides->Get(m_iNextSlide)->GetPath().c_str());
       int maxWidth, maxHeight;
@@ -429,9 +436,7 @@ void CGUIWindowSlideShow::Render()
     // play movie...
     g_playlistPlayer.Play(0);
     m_iCurrentSlide = m_iNextSlide;
-    m_iNextSlide++;
-    if (m_iNextSlide >= m_slides->Size())
-      m_iNextSlide = 0;
+    m_iNextSlide    = GetNextSlide();
   }
   // Check if we should be transistioning immediately
   if (m_bLoadNextPic)
@@ -471,13 +476,10 @@ void CGUIWindowSlideShow::Render()
     m_Image[m_iCurrentPic].Close();
     if (m_Image[1 - m_iCurrentPic].IsLoaded())
       m_iCurrentPic = 1 - m_iCurrentPic;
+
     m_iCurrentSlide = m_iNextSlide;
-    if (bSlideShow)
-    {
-      m_iNextSlide++;
-      if (m_iNextSlide >= m_slides->Size())
-        m_iNextSlide = 0;
-    }
+    m_iNextSlide    = GetNextSlide();
+
 //    m_iZoomFactor = 1;
     m_iRotate = 0;
   }
@@ -490,6 +492,16 @@ void CGUIWindowSlideShow::Render()
   RenderErrorMessage();
 
   CGUIWindow::Render();
+}
+
+int CGUIWindowSlideShow::GetNextSlide()
+{
+  if(m_slides->Size() <= 1)
+    return m_iCurrentSlide;
+  if(m_bSlideShow || m_iDirection >= 0)
+    return (m_iCurrentSlide + 1                   ) % m_slides->Size();
+  else
+    return (m_iCurrentSlide - 1 + m_slides->Size()) % m_slides->Size();
 }
 
 bool CGUIWindowSlideShow::OnAction(const CAction &action)

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -74,7 +74,8 @@ public:
   void RunSlideShow(const CStdString &strPath, bool bRecursive = false,
                     bool bRandom = false, bool bNotRandom = false,
                     SORT_METHOD method = SORT_METHOD_LABEL,
-                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="");
+                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="",
+                    const CStdString &beginSlidePath="", bool startSlideShow = true);
   void AddFromPath(const CStdString &strPath, bool bRecursive,
                    SORT_METHOD method=SORT_METHOD_LABEL, 
                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="");

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -73,9 +73,9 @@ public:
   const CFileItemPtr GetCurrentSlide();
   void RunSlideShow(const CStdString &strPath, bool bRecursive = false,
                     bool bRandom = false, bool bNotRandom = false,
+                    const CStdString &beginSlidePath="", bool startSlideShow = true,
                     SORT_METHOD method = SORT_METHOD_LABEL,
-                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="",
-                    const CStdString &beginSlidePath="", bool startSlideShow = true);
+                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="");
   void AddFromPath(const CStdString &strPath, bool bRecursive,
                    SORT_METHOD method=SORT_METHOD_LABEL, 
                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="");

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -102,6 +102,13 @@ private:
   void GetCheckedSize(float width, float height, int &maxWidth, int &maxHeight);
   int  GetNextSlide();
 
+  void AnnouncePlayerPlay(const CFileItemPtr& item);
+  void AnnouncePlayerPause(const CFileItemPtr& item);
+  void AnnouncePlayerStop(const CFileItemPtr& item);
+  void AnnouncePlaylistRemove(int pos);
+  void AnnouncePlaylistClear();
+  void AnnouncePlaylistAdd(const CFileItemPtr& item, int pos);
+
   int m_iCurrentSlide;
   int m_iNextSlide;
   int m_iDirection;

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -98,9 +98,11 @@ private:
   void Zoom(int iZoom);
   void Move(float fX, float fY);
   void GetCheckedSize(float width, float height, int &maxWidth, int &maxHeight);
+  int  GetNextSlide();
 
   int m_iCurrentSlide;
   int m_iNextSlide;
+  int m_iDirection;
   int m_iRotate;
   int m_iZoomFactor;
 

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -74,11 +74,15 @@ public:
   void RunSlideShow(const CStdString &strPath, bool bRecursive = false,
                     bool bRandom = false, bool bNotRandom = false,
                     const CStdString &beginSlidePath="", bool startSlideShow = true,
-                    SORT_METHOD method = SORT_METHOD_LABEL,
-                    SortOrder order = SortOrderAscending, const CStdString &strExtensions="");
+                    SortBy method = SortByLabel,
+                    SortOrder order = SortOrderAscending,
+                    SortAttribute sortAttributes = SortAttributeNone,
+                    const CStdString &strExtensions="");
   void AddFromPath(const CStdString &strPath, bool bRecursive,
-                   SORT_METHOD method=SORT_METHOD_LABEL, 
-                   SortOrder order = SortOrderAscending, const CStdString &strExtensions="");
+                   SortBy method = SortByLabel, 
+                   SortOrder order = SortOrderAscending,
+                   SortAttribute sortAttributes = SortAttributeNone,
+                   const CStdString &strExtensions="");
   void StartSlideShow(bool screensaver=false);
   bool InSlideShow() const;
   virtual bool OnMessage(CGUIMessage& message);
@@ -93,8 +97,9 @@ public:
 private:
   typedef std::set<CStdString> path_set;  // set to track which paths we're adding
   void AddItems(const CStdString &strPath, path_set *recursivePaths,
-                SORT_METHOD method = SORT_METHOD_LABEL,
-                SortOrder order = SortOrderAscending);
+                SortBy method = SortByLabel,
+                SortOrder order = SortOrderAscending,
+                SortAttribute sortAttributes = SortAttributeNone);
   void RenderPause();
   void RenderErrorMessage();
   void Rotate();

--- a/xbmc/pictures/GUIWindowSlideShow.h
+++ b/xbmc/pictures/GUIWindowSlideShow.h
@@ -69,6 +69,7 @@ public:
   void ShowPrevious();
   void Select(const CStdString& strPicture);
   const CFileItemList &GetSlideShowContents();
+  void GetSlideShowContents(CFileItemList &list);
   const CFileItemPtr GetCurrentSlide();
   void RunSlideShow(const CStdString &strPath, bool bRecursive = false,
                     bool bRandom = false, bool bNotRandom = false,
@@ -87,6 +88,7 @@ public:
   int NumSlides() const;
   int CurrentSlide() const;
   void Shuffle();
+  int GetDirection() const { return m_iDirection; }
 private:
   typedef std::set<CStdString> path_set;  // set to track which paths we're adding
   void AddItems(const CStdString &strPath, path_set *recursivePaths,

--- a/xbmc/playlists/PlayList.cpp
+++ b/xbmc/playlists/PlayList.cpp
@@ -21,6 +21,7 @@
 #include "playlists/PlayList.h"
 #include "utils/URIUtils.h"
 #include "utils/Variant.h"
+#include "interfaces/AnnouncementManager.h"
 #include "playlists/PlayListFactory.h"
 #include <sstream>
 #include "video/VideoInfoTag.h"
@@ -33,7 +34,8 @@ using namespace MUSIC_INFO;
 using namespace XFILE;
 using namespace PLAYLIST;
 
-CPlayList::CPlayList(void)
+CPlayList::CPlayList(int id)
+  : m_id(id)
 {
   m_strPlayListName = "";
   m_iPlayableItems = -1;
@@ -41,9 +43,36 @@ CPlayList::CPlayList(void)
   m_bWasPlayed = false;
 }
 
-CPlayList::~CPlayList(void)
+void CPlayList::AnnounceRemove(int pos)
 {
-  Clear();
+  if (m_id < 0)
+    return;
+
+  CVariant data;
+  data["playlistid"] = m_id;
+  data["position"] = pos;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnRemove", data);
+}
+
+void CPlayList::AnnounceClear()
+{
+  if (m_id < 0)
+    return;
+
+  CVariant data;
+  data["playlistid"] = m_id;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnClear", data);
+}
+
+void CPlayList::AnnounceAdd(const CFileItemPtr& item, int pos)
+{
+  if (m_id < 0)
+    return;
+
+  CVariant data;
+  data["playlistid"] = m_id;
+  data["position"] = pos;
+  ANNOUNCEMENT::CAnnouncementManager::Announce(ANNOUNCEMENT::Playlist, "xbmc", "OnAdd", item, data);
 }
 
 void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
@@ -78,6 +107,7 @@ void CPlayList::Add(const CFileItemPtr &item, int iPosition, int iOrder)
     if (iOrder < iOldSize)
       IncrementOrder(iPosition + 1, iOrder);
   }
+  AnnounceAdd(item, iPosition);
 }
 
 void CPlayList::Add(const CFileItemPtr &item)
@@ -187,6 +217,8 @@ void CPlayList::Clear()
   m_strPlayListName = "";
   m_iPlayableItems = -1;
   m_bWasPlayed = false;
+
+  AnnounceClear();
 }
 
 int CPlayList::size() const
@@ -260,6 +292,7 @@ const CStdString& CPlayList::GetName() const
 void CPlayList::Remove(const CStdString& strFileName)
 {
   int iOrder = -1;
+  int position = 0;
   ivecItems it;
   it = m_vecItems.begin();
   while (it != m_vecItems.end() )
@@ -269,10 +302,14 @@ void CPlayList::Remove(const CStdString& strFileName)
     {
       iOrder = item->m_iprogramCount;
       it = m_vecItems.erase(it);
+      AnnounceRemove(position);
       //CLog::Log(LOGDEBUG,"PLAYLIST, removing item at order %i", iPos);
     }
     else
+    {
+      ++position;
       ++it;
+    }
   }
   DecrementOrder(iOrder);
 }
@@ -297,6 +334,8 @@ void CPlayList::Remove(int position)
     m_vecItems.erase(m_vecItems.begin() + position);
   }
   DecrementOrder(iOrder);
+
+  AnnounceRemove(position);
 }
 
 int CPlayList::RemoveDVDItems()

--- a/xbmc/playlists/PlayList.h
+++ b/xbmc/playlists/PlayList.h
@@ -26,8 +26,8 @@ namespace PLAYLIST
 class CPlayList
 {
 public:
-  CPlayList(void);
-  virtual ~CPlayList(void);
+  CPlayList(int id = -1);
+  virtual ~CPlayList(void) {};
   virtual bool Load(const CStdString& strFileName);
   virtual bool LoadData(std::istream &stream);
   virtual bool LoadData(const CStdString& strData);
@@ -70,6 +70,7 @@ public:
   const CStdString& ResolveURL(const CFileItemPtr &item) const;
 
 protected:
+  int m_id;
   CStdString m_strPlayListName;
   CStdString m_strBasePath;
   int m_iPlayableItems;
@@ -84,5 +85,9 @@ private:
   void Add(const CFileItemPtr& item, int iPosition, int iOrderOffset);
   void DecrementOrder(int iOrder);
   void IncrementOrder(int iPosition, int iOrder);
+
+  void AnnounceRemove(int pos);
+  void AnnounceClear();
+  void AnnounceAdd(const CFileItemPtr& item, int pos);
 };
 }

--- a/xbmc/programs/GUIViewStatePrograms.cpp
+++ b/xbmc/programs/GUIViewStatePrograms.cpp
@@ -32,18 +32,16 @@ using namespace XFILE;
 
 CGUIViewStateWindowPrograms::CGUIViewStateWindowPrograms(const CFileItemList& items) : CGUIViewState(items)
 {
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%K", "%I", "%L", ""));  // Titel, Size | Foldername, empty
-  else
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%K", "%I", "%L", ""));  // Titel, Size | Foldername, empty
-  AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%K", "%J", "%L", "%J"));  // Titel, Date | Foldername, Date
-  AddSortMethod(SORT_METHOD_PROGRAM_COUNT, 565, LABEL_MASKS("%K", "%C", "%L", ""));  // Titel, Count | Foldername, empty
-  AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%K", "%I", "%K", "%I"));  // Filename, Size | Foldername, Size
-  AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%K", "%I", "%L", ""),  // Titel, Size | Foldername, empty
+    g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  AddSortMethod(SortByDate, 552, LABEL_MASKS("%K", "%J", "%L", "%J"));  // Titel, Date | Foldername, Date
+  AddSortMethod(SortByProgramCount, 565, LABEL_MASKS("%K", "%C", "%L", ""));  // Titel, Count | Foldername, empty
+  AddSortMethod(SortBySize, 553, LABEL_MASKS("%K", "%I", "%K", "%I"));  // Filename, Size | Foldername, Size
+  AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Filename, Size | FolderName, empty
 
-  SetSortMethod(g_settings.m_viewStatePrograms.m_sortMethod);
+  SetSortMethod(g_settings.m_viewStatePrograms.m_sortDescription);
   SetViewAsControl(g_settings.m_viewStatePrograms.m_viewMode);
-  SetSortOrder(g_settings.m_viewStatePrograms.m_sortOrder);
+  SetSortOrder(g_settings.m_viewStatePrograms.m_sortDescription.sortOrder);
 
   LoadViewState(items.GetPath(), WINDOW_PROGRAMS);
 }

--- a/xbmc/settings/GUIWindowSettingsCategory.cpp
+++ b/xbmc/settings/GUIWindowSettingsCategory.cpp
@@ -3198,30 +3198,6 @@ void CGUIWindowSettingsCategory::FillInViewModes(CSetting *pSetting, int windowI
   pControl->SetValue(pSettingInt->GetData());
 }
 
-void CGUIWindowSettingsCategory::FillInSortMethods(CSetting *pSetting, int windowID)
-{
-  CSettingInt *pSettingInt = (CSettingInt*)pSetting;
-  CGUISpinControlEx *pControl = (CGUISpinControlEx *)GetControl(GetSetting(pSetting->GetSetting())->GetID());
-  CFileItemList items("C:");
-  CGUIViewState *state = CGUIViewState::GetViewState(windowID, items);
-  if (state)
-  {
-    bool found(false);
-    vector< pair<int,int> > sortMethods;
-    state->GetSortMethods(sortMethods);
-    for (unsigned int i = 0; i < sortMethods.size(); i++)
-    {
-      pControl->AddLabel(g_localizeStrings.Get(sortMethods[i].second), sortMethods[i].first);
-      if (sortMethods[i].first == pSettingInt->GetData())
-        found = true;
-    }
-    if (!found && sortMethods.size())
-      pSettingInt->SetData(sortMethods[0].first);
-  }
-  pControl->SetValue(pSettingInt->GetData());
-  delete state;
-}
-
 void CGUIWindowSettingsCategory::FillInScrapers(CGUISpinControlEx *pControl, const CStdString& strSelected, const CStdString& strContent)
 {
   CFileItemList items;

--- a/xbmc/settings/GUIWindowSettingsCategory.h
+++ b/xbmc/settings/GUIWindowSettingsCategory.h
@@ -58,7 +58,6 @@ protected:
   void FillInFTPServerUser(CSetting *pSetting);
   void FillInStartupWindow(CSetting *pSetting);
   void FillInViewModes(CSetting *pSetting, int windowID);
-  void FillInSortMethods(CSetting *pSetting, int windowID);
   bool SetFTPServerUserPass();
 
   void FillInSkinThemes(CSetting *pSetting);

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -558,24 +558,24 @@ bool CSettings::GetFloat(const TiXmlElement* pRootElement, const char *tagName, 
   return false;
 }
 
-void CSettings::GetViewState(const TiXmlElement *pRootElement, const CStdString &strTagName, CViewState &viewState, SORT_METHOD defaultSort, int defaultView)
+void CSettings::GetViewState(const TiXmlElement *pRootElement, const CStdString &strTagName, CViewState &viewState, SortBy defaultSort, int defaultView)
 {
   const TiXmlElement* pNode = pRootElement->FirstChildElement(strTagName);
   if (!pNode)
   {
-    viewState.m_sortMethod = defaultSort;
+    viewState.m_sortDescription.sortBy = defaultSort;
     viewState.m_viewMode = defaultView;
     return;
   }
   GetInteger(pNode, "viewmode", viewState.m_viewMode, defaultView, DEFAULT_VIEW_LIST, DEFAULT_VIEW_MAX);
 
   int sortMethod;
-  GetInteger(pNode, "sortmethod", sortMethod, defaultSort, SORT_METHOD_NONE, SORT_METHOD_MAX);
-  viewState.m_sortMethod = (SORT_METHOD)sortMethod;
+  GetInteger(pNode, "sortmethod", sortMethod, defaultSort, SortByNone, SORT_METHOD_MAX);
+  viewState.m_sortDescription.sortBy = (SortBy)sortMethod;
 
   int sortOrder;
   GetInteger(pNode, "sortorder", sortOrder, SortOrderAscending, SortOrderNone, SortOrderDescending);
-  viewState.m_sortOrder = (SortOrder)sortOrder;
+  viewState.m_sortDescription.sortOrder = (SortOrder)sortOrder;
 }
 
 void CSettings::SetViewState(TiXmlNode *pRootNode, const CStdString &strTagName, const CViewState &viewState) const
@@ -585,8 +585,8 @@ void CSettings::SetViewState(TiXmlNode *pRootNode, const CStdString &strTagName,
   if (pNewNode)
   {
     XMLUtils::SetInt(pNewNode, "viewmode", viewState.m_viewMode);
-    XMLUtils::SetInt(pNewNode, "sortmethod", (int)viewState.m_sortMethod);
-    XMLUtils::SetInt(pNewNode, "sortorder", (int)viewState.m_sortOrder);
+    XMLUtils::SetInt(pNewNode, "sortmethod", (int)viewState.m_sortDescription.sortBy);
+    XMLUtils::SetInt(pNewNode, "sortorder", (int)viewState.m_sortDescription.sortOrder);
   }
 }
 
@@ -752,15 +752,15 @@ bool CSettings::LoadSettings(const CStdString& strSettingsFile)
     GetViewState(pElement, "videonavyears", m_viewStateVideoNavYears);
     GetViewState(pElement, "videonavgenres", m_viewStateVideoNavGenres);
     GetViewState(pElement, "videonavtitles", m_viewStateVideoNavTitles);
-    GetViewState(pElement, "videonavepisodes", m_viewStateVideoNavEpisodes, SORT_METHOD_EPISODE);
+    GetViewState(pElement, "videonavepisodes", m_viewStateVideoNavEpisodes, SortByEpisodeNumber);
     GetViewState(pElement, "videonavtvshows", m_viewStateVideoNavTvShows);
     GetViewState(pElement, "videonavseasons", m_viewStateVideoNavSeasons);
     GetViewState(pElement, "videonavmusicvideos", m_viewStateVideoNavMusicVideos);
 
-    GetViewState(pElement, "programs", m_viewStatePrograms, SORT_METHOD_LABEL, DEFAULT_VIEW_AUTO);
-    GetViewState(pElement, "pictures", m_viewStatePictures, SORT_METHOD_LABEL, DEFAULT_VIEW_AUTO);
-    GetViewState(pElement, "videofiles", m_viewStateVideoFiles, SORT_METHOD_LABEL, DEFAULT_VIEW_AUTO);
-    GetViewState(pElement, "musicfiles", m_viewStateMusicFiles, SORT_METHOD_LABEL, DEFAULT_VIEW_AUTO);
+    GetViewState(pElement, "programs", m_viewStatePrograms, SortByLabel, DEFAULT_VIEW_AUTO);
+    GetViewState(pElement, "pictures", m_viewStatePictures, SortByLabel, DEFAULT_VIEW_AUTO);
+    GetViewState(pElement, "videofiles", m_viewStateVideoFiles, SortByLabel, DEFAULT_VIEW_AUTO);
+    GetViewState(pElement, "musicfiles", m_viewStateMusicFiles, SortByLabel, DEFAULT_VIEW_AUTO);
   }
 
   // general settings

--- a/xbmc/settings/Settings.h
+++ b/xbmc/settings/Settings.h
@@ -554,7 +554,7 @@ public:
 protected:
   void GetSources(const TiXmlElement* pRootElement, const CStdString& strTagName, VECSOURCES& items, CStdString& strDefault);
   bool SetSources(TiXmlNode *root, const char *section, const VECSOURCES &shares, const char *defaultPath);
-  void GetViewState(const TiXmlElement* pRootElement, const CStdString& strTagName, CViewState &viewState, SORT_METHOD defaultSort = SORT_METHOD_LABEL, int defaultView = DEFAULT_VIEW_LIST);
+  void GetViewState(const TiXmlElement* pRootElement, const CStdString& strTagName, CViewState &viewState, SortBy defaultSort = SortByLabel, int defaultView = DEFAULT_VIEW_LIST);
 
   void ConvertHomeVar(CStdString& strText);
   // functions for writing xml files

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -95,9 +95,10 @@ using namespace MUSIC_INFO;
  *  %Y - Year
  *  %Z - tvshow title
  *  %a - Date Added
+ *  %p - Last Played
  */
 
-#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWa"
+#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWap"
 
 CLabelFormatter::CLabelFormatter(const CStdString &mask, const CStdString &mask2)
 {
@@ -311,6 +312,10 @@ CStdString CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFileI
   case 'a': // Date Added
     if (movie && movie->m_dateAdded.IsValid())
       value = movie->m_dateAdded.GetAsLocalizedDate();
+    break;
+  case 'p': // Last played
+    if (movie && movie->m_lastPlayed.IsValid())
+      value = movie->m_lastPlayed.GetAsLocalizedDate();
     break;
   }
   if (!value.IsEmpty())

--- a/xbmc/utils/LabelFormatter.cpp
+++ b/xbmc/utils/LabelFormatter.cpp
@@ -94,9 +94,10 @@ using namespace MUSIC_INFO;
  *  %X - Bitrate
  *  %Y - Year
  *  %Z - tvshow title
+ *  %a - Date Added
  */
 
-#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXW"
+#define MASK_CHARS "NSATBGYFLDIJRCKMEPHZOQUVXWa"
 
 CLabelFormatter::CLabelFormatter(const CStdString &mask, const CStdString &mask2)
 {
@@ -306,7 +307,11 @@ CStdString CLabelFormatter::GetMaskContent(const CMaskString &mask, const CFileI
    case 'W': // Listeners
     if( !item->m_bIsFolder && music->GetListeners() != 0 )
      value.Format("%i %s", music->GetListeners(), g_localizeStrings.Get(music->GetListeners() == 1 ? 20454 : 20455));
-    break;    
+    break;
+  case 'a': // Date Added
+    if (movie && movie->m_dateAdded.IsValid())
+      value = movie->m_dateAdded.GetAsLocalizedDate();
+    break;
   }
   if (!value.IsEmpty())
     return mask.m_prefix + value + mask.m_postfix;

--- a/xbmc/utils/SortUtils.h
+++ b/xbmc/utils/SortUtils.h
@@ -24,6 +24,7 @@
 
 #include "DatabaseUtils.h"
 #include "SortFileItem.h"
+#include "LabelFormatter.h"
 
 typedef enum {
   SortOrderNone = 0,
@@ -102,6 +103,13 @@ typedef struct SortDescription {
       limitStart(0), limitEnd(-1)
   { }
 } SortDescription;
+
+typedef struct
+{
+  SortDescription m_sortDescription;
+  int m_buttonLabel;
+  LABEL_MASKS m_labelMasks;
+} SORT_METHOD_DETAILS;
 
 typedef DatabaseResult SortItem;
 typedef DatabaseResults SortItems;

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -174,6 +174,7 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
 
         // NOTE: This uses SORT_METHOD_EPISODE to mean "sort shows by the number of episodes" and uses the label "Episodes"
         AddSortMethod(SORT_METHOD_EPISODE, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
+        AddSortMethod(SORT_METHOD_LASTPLAYED, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
         AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%L","%Y","%L","%Y")); // Label, Year | Label, Year
         SetSortMethod(SORT_METHOD_LABEL);
 

--- a/xbmc/video/GUIViewStateVideo.cpp
+++ b/xbmc/video/GUIViewStateVideo.cpp
@@ -57,9 +57,9 @@ CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList
 {
   if (items.IsVirtualDirectoryRoot())
   {
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS()); // Preformated
-    AddSortMethod(SORT_METHOD_DRIVE_TYPE, 564, LABEL_MASKS()); // Preformated
-    SetSortMethod(SORT_METHOD_LABEL);
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS()); // Preformated
+    AddSortMethod(SortByDriveType, 564, LABEL_MASKS()); // Preformated
+    SetSortMethod(SortByLabel);
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -67,17 +67,15 @@ CGUIViewStateWindowVideoFiles::CGUIViewStateWindowVideoFiles(const CFileItemList
   }
   else
   {
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
-    else
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
-    AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
-    AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
+    AddSortMethod(SortByLabel, 551, LABEL_MASKS("%L", "%I", "%L", ""),  // Label, Size | Label, empty
+      g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+    AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
+    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
+    AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
 
-    SetSortMethod(g_settings.m_viewStateVideoFiles.m_sortMethod);
+    SetSortMethod(g_settings.m_viewStateVideoFiles.m_sortDescription);
     SetViewAsControl(g_settings.m_viewStateVideoFiles.m_viewMode);
-    SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortOrder);
+    SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortDescription.sortOrder);
   }
   LoadViewState(items.GetPath(), WINDOW_VIDEO_FILES);
 }
@@ -103,10 +101,14 @@ VECSOURCES& CGUIViewStateWindowVideoFiles::GetSources()
 
 CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
+  SortAttribute sortAttributes = SortAttributeNone;
+  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
+    sortAttributes = SortAttributeIgnoreArticle;
+
   if (items.IsVirtualDirectoryRoot())
   {
-    AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
-    SetSortMethod(SORT_METHOD_NONE);
+    AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
+    SetSortMethod(SortByNone);
 
     SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -125,9 +127,9 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_MUSICVIDEOS_OVERVIEW:
     case NODE_TYPE_OVERVIEW:
       {
-        AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
+        AddSortMethod(SortByNone, 551, LABEL_MASKS("%F", "%I", "%L", ""));  // Filename, Size | Label, empty
 
-        SetSortMethod(SORT_METHOD_NONE);
+        SetSortMethod(SortByNone);
 
         SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -137,50 +139,47 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_DIRECTOR:
     case NODE_TYPE_ACTOR:
       {
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SORT_METHOD_LABEL);
+        AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
+        SetSortMethod(SortByLabel);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavActors.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavActors.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavActors.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_YEAR:
       {
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SORT_METHOD_LABEL);
+        AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
+        SetSortMethod(SortByLabel);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavYears.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavYears.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavYears.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_SEASONS:
       {
-        AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%L", "","%L",""));  // Label, empty | Label, empty
-        SetSortMethod(SORT_METHOD_VIDEO_SORT_TITLE);
+        AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%L", "","%L",""));  // Label, empty | Label, empty
+        SetSortMethod(SortBySortTitle);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavSeasons.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavSeasons.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavSeasons.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_TITLE_TVSHOWS:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
-        else
-          AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", "%M", "%T", "%M")); // Title, #Episodes | Title, #Episodes
+        AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
 
-        // NOTE: This uses SORT_METHOD_EPISODE to mean "sort shows by the number of episodes" and uses the label "Episodes"
-        AddSortMethod(SORT_METHOD_EPISODE, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
-        AddSortMethod(SORT_METHOD_LASTPLAYED, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
-        AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%L","%Y","%L","%Y")); // Label, Year | Label, Year
-        SetSortMethod(SORT_METHOD_LABEL);
+        // NOTE: This uses SortByEpisodeNumber to mean "sort shows by the number of episodes" and uses the label "Episodes"
+        AddSortMethod(SortByEpisodeNumber, 20360, LABEL_MASKS("%L", "%M", "%L", "%M"));  // Label, #Episodes | Label, #Episodes
+        AddSortMethod(SortByLastPlayed, 568, LABEL_MASKS("%T", "%p", "%T", "%p"));  // Title, #Last played | Title, #Last played
+        AddSortMethod(SortByYear, 562, LABEL_MASKS("%L","%Y","%L","%Y")); // Label, Year | Label, Year
+        SetSortMethod(SortByLabel);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavTvShows.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavTvShows.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavTvShows.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_MUSICVIDEOS_ALBUM:
@@ -188,87 +187,78 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
     case NODE_TYPE_COUNTRY:
     case NODE_TYPE_STUDIO:
       {
-        AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
-        SetSortMethod(SORT_METHOD_LABEL);
+        AddSortMethod(SortByLabel, 551, LABEL_MASKS("%T", "%R", "%L", ""));  // Title, Rating | Label, empty
+        SetSortMethod(SortByLabel);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavGenres.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_SETS:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T","%R", "%T","%R"));  // Title, Rating | Title, Rating
-        else
-          AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%R", "%T","%R"));  // Title, Rating | Title, Rating
+        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","%R", "%T","%R"));  // Title, Rating | Title, Rating
 
-        AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
-        AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-        AddSortMethod(SORT_METHOD_DATEADDED, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
+        AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
+        AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
+        AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
 
         if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
-          AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
+          AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
           
-        SetSortMethod(SORT_METHOD_LABEL_IGNORE_THE);
+        SetSortMethod(SortByLabel, SortAttributeIgnoreArticle);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavGenres.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_TAGS:
       {
-        SORT_METHOD method = SORT_METHOD_LABEL_IGNORE_THE;
-        if (!g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          method = SORT_METHOD_LABEL;
+        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","", "%T",""));  // Title, empty | Title, empty
+        SetSortMethod(SortByLabel, sortAttributes);
 
-        AddSortMethod(method, 551, LABEL_MASKS("%T","", "%T",""));  // Title, empty | Title, empty
-        SetSortMethod(method);
         SetViewAsControl(g_settings.m_viewStateVideoNavGenres.m_viewMode);
-        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavGenres.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_EPISODES:
       {
         if (params.GetSeason() > -1)
         {
-          AddSortMethod(SORT_METHOD_EPISODE, 20359, LABEL_MASKS("%E. %T","%R"));  // Episode. Title, Rating | empty, empty
-          AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%E. %T", "%R"));  // Episode. Title, Rating | empty, empty
-          AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%E. %T", "%O"));  // Episode. Title, MPAA | empty, empty
-          AddSortMethod(SORT_METHOD_PRODUCTIONCODE, 20368, LABEL_MASKS("%E. %T","%P", "%E. %T","%P"));  // Episode. Title, ProductionCode | Episode. Title, ProductionCode
-          AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%E. %T","%J","%E. %T","%J"));  // Episode. Title, Date | Episode. Title, Date
+          AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%E. %T","%R"));  // Episode. Title, Rating | empty, empty
+          AddSortMethod(SortByRating, 563, LABEL_MASKS("%E. %T", "%R"));  // Episode. Title, Rating | empty, empty
+          AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%E. %T", "%O"));  // Episode. Title, MPAA | empty, empty
+          AddSortMethod(SortByProductionCode, 20368, LABEL_MASKS("%E. %T","%P", "%E. %T","%P"));  // Episode. Title, ProductionCode | Episode. Title, ProductionCode
+          AddSortMethod(SortByDate, 552, LABEL_MASKS("%E. %T","%J","%E. %T","%J"));  // Episode. Title, Date | Episode. Title, Date
 
           if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
-            AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%E. %T", "%V"));  // Episode. Title, Playcount | empty, empty
+            AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%E. %T", "%V"));  // Episode. Title, Playcount | empty, empty
         }
         else
         {
-          AddSortMethod(SORT_METHOD_EPISODE, 20359, LABEL_MASKS("%H. %T","%R"));  // Order. Title, Rating | emtpy, empty
-          AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%H. %T", "%R"));  // Order. Title, Rating | emtpy, empty
-          AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%H. %T", "%O"));  // Order. Title, MPAA | emtpy, empty
-          AddSortMethod(SORT_METHOD_PRODUCTIONCODE, 20368, LABEL_MASKS("%H. %T","%P", "%H. %T","%P"));  // Order. Title, ProductionCode | Episode. Title, ProductionCode
-          AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%H. %T","%J","%H. %T","%J"));  // Order. Title, Date | Episode. Title, Date
+          AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%H. %T","%R"));  // Order. Title, Rating | emtpy, empty
+          AddSortMethod(SortByRating, 563, LABEL_MASKS("%H. %T", "%R"));  // Order. Title, Rating | emtpy, empty
+          AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%H. %T", "%O"));  // Order. Title, MPAA | emtpy, empty
+          AddSortMethod(SortByProductionCode, 20368, LABEL_MASKS("%H. %T","%P", "%H. %T","%P"));  // Order. Title, ProductionCode | Episode. Title, ProductionCode
+          AddSortMethod(SortByDate, 552, LABEL_MASKS("%H. %T","%J","%H. %T","%J"));  // Order. Title, Date | Episode. Title, Date
 
           if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
-            AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%H. %T", "%V"));  // Order. Title, Playcount | empty, empty
+            AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%H. %T", "%V"));  // Order. Title, Playcount | empty, empty
         }
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T","%R"));  // Title, Rating | empty, empty
-        else
-          AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
+        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T","%R"));  // Title, Rating | empty, empty
 
-        SetSortMethod(g_settings.m_viewStateVideoNavEpisodes.m_sortMethod);
+        SetSortMethod(g_settings.m_viewStateVideoNavEpisodes.m_sortDescription);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavEpisodes.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavEpisodes.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavEpisodes.m_sortDescription.sortOrder);
         break;
       }
     case NODE_TYPE_RECENTLY_ADDED_EPISODES:
       {
-        AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
-        SetSortMethod(SORT_METHOD_NONE);
+        AddSortMethod(SortByNone, 552, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
+        SetSortMethod(SortByNone);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavEpisodes.m_viewMode);
         SetSortOrder(SortOrderNone);
@@ -279,76 +269,58 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
       {
         if (params.GetSetId() > -1) // Is this a listing within a set?
         {
-          AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-
-          if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-            AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
-          else
-            AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
+          AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+          AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
         }
         else
         {
-          if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-            AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-          else
-            AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-
-          AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
+          AddSortMethod(SortBySortTitle, sortAttributes, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
+          AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
         }
-        AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-        AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));  // Title, MPAA | empty, empty
-        AddSortMethod(SORT_METHOD_VIDEO_RUNTIME, 180, LABEL_MASKS("%T", "%D"));  // Title, Duration | empty, empty
-        AddSortMethod(SORT_METHOD_DATEADDED, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
+        AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
+        AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));  // Title, MPAA | empty, empty
+        AddSortMethod(SortByTime, 180, LABEL_MASKS("%T", "%D"));  // Title, Duration | empty, empty
+        AddSortMethod(SortByDateAdded, 570, LABEL_MASKS("%T", "%a", "%T", "%a"));  // Title, DateAdded | Title, DateAdded
 
         if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
-          AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
+          AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V", "%T", "%V"));  // Title, Playcount | Title, Playcount
 
         if (params.GetSetId() > -1)
-          SetSortMethod(SORT_METHOD_YEAR);
+          SetSortMethod(SortByYear);
         else
-          SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
+          SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortDescription);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavTitles.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavTitles.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavTitles.m_sortDescription.sortOrder);
       }
       break;
       case NODE_TYPE_TITLE_MUSICVIDEOS:
       {
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-          AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-        else
-          AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-        AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-        if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-        {
-          AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-          AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
-        }
-        else
-        {
-          AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-          AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
-        }
+        AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+        AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));
+        AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+        AddSortMethod(SortByArtist, sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
+        AddSortMethod(SortByAlbum, sortAttributes, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
         
         if (g_settings.GetWatchMode(items.GetContent()) == VIDEO_SHOW_ALL)
-          AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T", "%V"));  // Title, Playcount | empty, empty
+          AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V"));  // Title, Playcount | empty, empty
 
         CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
         CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
-        AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
+        AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
 
-        SetSortMethod(g_settings.m_viewStateVideoNavMusicVideos.m_sortMethod);
+        SetSortMethod(g_settings.m_viewStateVideoNavMusicVideos.m_sortDescription);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavMusicVideos.m_viewMode);
 
-        SetSortOrder(g_settings.m_viewStateVideoNavMusicVideos.m_sortOrder);
+        SetSortOrder(g_settings.m_viewStateVideoNavMusicVideos.m_sortDescription.sortOrder);
       }
       break;
     case NODE_TYPE_RECENTLY_ADDED_MOVIES:
       {
-        AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
-        SetSortMethod(SORT_METHOD_NONE);
+        AddSortMethod(SortByNone, 552, LABEL_MASKS("%T", "%R"));  // Title, Rating | empty, empty
+        SetSortMethod(SortByNone);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavTitles.m_viewMode);
 
@@ -357,8 +329,8 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
       break;
     case NODE_TYPE_RECENTLY_ADDED_MUSICVIDEOS:
       {
-        AddSortMethod(SORT_METHOD_NONE, 552, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-        SetSortMethod(SORT_METHOD_NONE);
+        AddSortMethod(SortByNone, 552, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
+        SetSortMethod(SortByNone);
 
         SetViewAsControl(g_settings.m_viewStateVideoNavMusicVideos.m_viewMode);
 
@@ -371,17 +343,14 @@ CGUIViewStateWindowVideoNav::CGUIViewStateWindowVideoNav(const CFileItemList& it
   }
   else
   {
-    if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-      AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
-    else
-      AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
-    AddSortMethod(SORT_METHOD_SIZE, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
-    AddSortMethod(SORT_METHOD_FILE, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
+    AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
+    AddSortMethod(SortBySize, 553, LABEL_MASKS("%L", "%I", "%L", "%I"));  // Label, Size | Label, Size
+    AddSortMethod(SortByDate, 552, LABEL_MASKS("%L", "%J", "%L", "%J"));  // Label, Date | Label, Date
+    AddSortMethod(SortByFile, 561, LABEL_MASKS("%L", "%I", "%L", ""));  // Label, Size | Label, empty
 
-    SetSortMethod(g_settings.m_viewStateVideoFiles.m_sortMethod);
+    SetSortMethod(g_settings.m_viewStateVideoFiles.m_sortDescription);
     SetViewAsControl(g_settings.m_viewStateVideoFiles.m_viewMode);
-    SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortOrder);
+    SetSortOrder(g_settings.m_viewStateVideoFiles.m_sortDescription.sortOrder);
   }
   LoadViewState(items.GetPath(), WINDOW_VIDEO_NAV);
 }
@@ -466,8 +435,8 @@ bool CGUIViewStateWindowVideoNav::AutoPlayNextItem()
 
 CGUIViewStateWindowVideoPlaylist::CGUIViewStateWindowVideoPlaylist(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  AddSortMethod(SORT_METHOD_NONE, 551, LABEL_MASKS("%L", "", "%L", ""));  // Label, empty | Label, empty
-  SetSortMethod(SORT_METHOD_NONE);
+  AddSortMethod(SortByNone, 551, LABEL_MASKS("%L", "", "%L", ""));  // Label, empty | Label, empty
+  SetSortMethod(SortByNone);
 
   SetViewAsControl(DEFAULT_VIEW_LIST);
 
@@ -503,23 +472,20 @@ VECSOURCES& CGUIViewStateWindowVideoPlaylist::GetSources()
   return CGUIViewStateWindowVideo::GetSources();
 }
 
-
 CGUIViewStateVideoMovies::CGUIViewStateVideoMovies(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-  else
-    AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-  AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
-  AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));  // Title, MPAA | empty, empty
-  AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
+  AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%T", "%R", "%T", "%R"),  // Title, Rating | Title, Rating
+    g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  AddSortMethod(SortByRating, 563, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
+  AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));  // Title, MPAA | empty, empty
+  AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   if (items.IsSmartPlayList() || items.IsLibraryFolder())
     AddPlaylistOrder(items, LABEL_MASKS("%T", "%R", "%T", "%R"));  // Title, Rating | Title, Rating
   else
   {
-    SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortMethod);
-    SetSortOrder(g_settings.m_viewStateVideoNavTitles.m_sortOrder);
+    SetSortMethod(g_settings.m_viewStateVideoNavTitles.m_sortDescription);
+    SetSortOrder(g_settings.m_viewStateVideoNavTitles.m_sortDescription.sortOrder);
   }
 
   SetViewAsControl(g_settings.m_viewStateVideoNavTitles.m_viewMode);
@@ -532,38 +498,30 @@ void CGUIViewStateVideoMovies::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTitles);
 }
 
-
 CGUIViewStateVideoMusicVideos::CGUIViewStateVideoMusicVideos(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
+  SortAttribute sortAttributes = SortAttributeNone;
   if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-  else
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-  AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%T", "%O"));
-  AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-  {
-    AddSortMethod(SORT_METHOD_ARTIST_IGNORE_THE, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-    AddSortMethod(SORT_METHOD_ALBUM_IGNORE_THE, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
-  }
-  else
-  {
-    AddSortMethod(SORT_METHOD_ARTIST, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
-    AddSortMethod(SORT_METHOD_ALBUM, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
-  }
+    sortAttributes = SortAttributeIgnoreArticle;
 
-  AddSortMethod(SORT_METHOD_PLAYCOUNT, 567, LABEL_MASKS("%T", "%V"));  // Title, Playcount | empty, empty
+  AddSortMethod(SortByLabel, sortAttributes, 551, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+  AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%T", "%O"));
+  AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y"));  // Title, Year | empty, empty
+  AddSortMethod(SortByArtist, sortAttributes, 557, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
+  AddSortMethod(SortByAlbum, sortAttributes, 558, LABEL_MASKS("%B - %T", "%Y"));  // Album - Title, Year | empty, empty
+
+  AddSortMethod(SortByPlaycount, 567, LABEL_MASKS("%T", "%V"));  // Title, Playcount | empty, empty
 
   CStdString strTrackLeft=g_guiSettings.GetString("musicfiles.trackformat");
   CStdString strTrackRight=g_guiSettings.GetString("musicfiles.trackformatright");
-  AddSortMethod(SORT_METHOD_TRACKNUM, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
+  AddSortMethod(SortByTrackNumber, 554, LABEL_MASKS(strTrackLeft, strTrackRight));  // Userdefined, Userdefined | empty, empty
   
   if (items.IsSmartPlayList() || items.IsLibraryFolder())
     AddPlaylistOrder(items, LABEL_MASKS("%A - %T", "%Y"));  // Artist - Title, Year | empty, empty
   else
   {
-    SetSortMethod(g_settings.m_viewStateVideoNavMusicVideos.m_sortMethod);
-    SetSortOrder(g_settings.m_viewStateVideoNavMusicVideos.m_sortOrder);
+    SetSortMethod(g_settings.m_viewStateVideoNavMusicVideos.m_sortDescription);
+    SetSortOrder(g_settings.m_viewStateVideoNavMusicVideos.m_sortDescription.sortOrder);
   }
 
   SetViewAsControl(g_settings.m_viewStateVideoNavMusicVideos.m_viewMode);
@@ -578,18 +536,16 @@ void CGUIViewStateVideoMusicVideos::SaveViewState()
 
 CGUIViewStateVideoTVShows::CGUIViewStateVideoTVShows(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE_IGNORE_THE, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
-  else
-    AddSortMethod(SORT_METHOD_VIDEO_SORT_TITLE, 556, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
-  AddSortMethod(SORT_METHOD_YEAR, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
+  AddSortMethod(SortBySortTitle, 556, LABEL_MASKS("%T", "%M", "%T", "%M"),  // Title, #Episodes | Title, #Episodes
+    g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
+  AddSortMethod(SortByYear, 562, LABEL_MASKS("%T", "%Y", "%T", "%Y"));  // Title, Year | Title, Year
 
   if (items.IsSmartPlayList() || items.IsLibraryFolder())
     AddPlaylistOrder(items, LABEL_MASKS("%T", "%M", "%T", "%M"));  // Title, #Episodes | Title, #Episodes
   else
   {
-    SetSortMethod(g_settings.m_viewStateVideoNavTvShows.m_sortMethod);
-    SetSortOrder(g_settings.m_viewStateVideoNavTvShows.m_sortOrder);
+    SetSortMethod(g_settings.m_viewStateVideoNavTvShows.m_sortDescription);
+    SetSortOrder(g_settings.m_viewStateVideoNavTvShows.m_sortDescription.sortOrder);
   }
 
   SetViewAsControl(g_settings.m_viewStateVideoNavTvShows.m_viewMode);
@@ -602,36 +558,33 @@ void CGUIViewStateVideoTVShows::SaveViewState()
   SaveViewToDb(m_items.GetPath(), WINDOW_VIDEO_NAV, &g_settings.m_viewStateVideoNavTvShows);
 }
 
-
 CGUIViewStateVideoEpisodes::CGUIViewStateVideoEpisodes(const CFileItemList& items) : CGUIViewStateWindowVideo(items)
 {
-  if (g_guiSettings.GetBool("filelists.ignorethewhensorting"))
-    AddSortMethod(SORT_METHOD_LABEL_IGNORE_THE, 551, LABEL_MASKS("%Z - %H. %T","%R"));  // TvShow - Order. Title, Rating | empty, empty
-  else
-    AddSortMethod(SORT_METHOD_LABEL, 551, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
+  AddSortMethod(SortByLabel, 551, LABEL_MASKS("%Z - %H. %T","%R"),  // TvShow - Order. Title, Rating | empty, empty
+    g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
   if (0)//params.GetSeason() > -1)
   {
-    AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%E. %T", "%R"));  // Episode. Title, Rating | empty, empty
-    AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%E. %T", "%O"));  // Episode. Title, MPAA | empty, empty
-    AddSortMethod(SORT_METHOD_EPISODE, 20359, LABEL_MASKS("%E. %T","%R"));  // Episode. Title, Rating | empty, empty
-    AddSortMethod(SORT_METHOD_PRODUCTIONCODE, 20368, LABEL_MASKS("%E. %T","%P", "%E. %T","%P"));  // Episode. Title, Production Code | Episode. Title, Production Code
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%E. %T","%J","E. %T","%J"));  // Episode. Title, Date | Episode. Title, Date
+    AddSortMethod(SortByRating, 563, LABEL_MASKS("%E. %T", "%R"));  // Episode. Title, Rating | empty, empty
+    AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%E. %T", "%O"));  // Episode. Title, MPAA | empty, empty
+    AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%E. %T","%R"));  // Episode. Title, Rating | empty, empty
+    AddSortMethod(SortByProductionCode, 20368, LABEL_MASKS("%E. %T","%P", "%E. %T","%P"));  // Episode. Title, Production Code | Episode. Title, Production Code
+    AddSortMethod(SortByDate, 552, LABEL_MASKS("%E. %T","%J","E. %T","%J"));  // Episode. Title, Date | Episode. Title, Date
   }
   else
   { // format here is tvshowtitle - season/episode number. episode title
-    AddSortMethod(SORT_METHOD_VIDEO_RATING, 563, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
-    AddSortMethod(SORT_METHOD_MPAA_RATING, 20074, LABEL_MASKS("%Z - %H. %T", "%O"));  // TvShow - Order. Title, MPAA | empty, empty
-    AddSortMethod(SORT_METHOD_EPISODE, 20359, LABEL_MASKS("%Z - %H. %T","%R"));  // TvShow - Order. Title, Rating | empty, empty
-    AddSortMethod(SORT_METHOD_PRODUCTIONCODE, 20368, LABEL_MASKS("%Z - %H. %T","%P"));  // TvShow - Order. Title, Production Code | empty, empty
-    AddSortMethod(SORT_METHOD_DATE, 552, LABEL_MASKS("%Z - %H. %T","%J"));  // TvShow - Order. Title, Date | empty, empty
+    AddSortMethod(SortByRating, 563, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
+    AddSortMethod(SortByMPAA, 20074, LABEL_MASKS("%Z - %H. %T", "%O"));  // TvShow - Order. Title, MPAA | empty, empty
+    AddSortMethod(SortByEpisodeNumber, 20359, LABEL_MASKS("%Z - %H. %T","%R"));  // TvShow - Order. Title, Rating | empty, empty
+    AddSortMethod(SortByProductionCode, 20368, LABEL_MASKS("%Z - %H. %T","%P"));  // TvShow - Order. Title, Production Code | empty, empty
+    AddSortMethod(SortByDate, 552, LABEL_MASKS("%Z - %H. %T","%J"));  // TvShow - Order. Title, Date | empty, empty
   }
 
   if (items.IsSmartPlayList() || items.IsLibraryFolder())
     AddPlaylistOrder(items, LABEL_MASKS("%Z - %H. %T", "%R"));  // TvShow - Order. Title, Rating | empty, empty
   else
   {
-    SetSortMethod(g_settings.m_viewStateVideoNavEpisodes.m_sortMethod);
-    SetSortOrder(g_settings.m_viewStateVideoNavEpisodes.m_sortOrder);
+    SetSortMethod(g_settings.m_viewStateVideoNavEpisodes.m_sortDescription);
+    SetSortOrder(g_settings.m_viewStateVideoNavEpisodes.m_sortDescription.sortOrder);
   }
 
   SetViewAsControl(g_settings.m_viewStateVideoNavEpisodes.m_viewMode);

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -5999,7 +5999,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
     case VIDEODB_CONTENT_TVSHOWS:
     {
       // sort by Title
-      items.Sort(SORT_METHOD_VIDEO_TITLE, SortOrderAscending);
+      items.Sort(SortBySortTitle, SortOrderAscending);
 
       int i = 0;
       while (i < items.Size())
@@ -6062,7 +6062,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
     case VIDEODB_CONTENT_EPISODES:
     {
       // sort by ShowTitle, Episode, Filename
-      items.Sort(SORT_METHOD_EPISODE, SortOrderAscending);
+      items.Sort(SortByEpisodeNumber, SortOrderAscending);
 
       int i = 0;
       while (i < items.Size())
@@ -6157,7 +6157,7 @@ void CVideoDatabase::Stack(CFileItemList& items, VIDEODB_CONTENT_TYPE type, bool
   if (maintainSortOrder)
   {
     // restore original sort order - essential for smartplaylists
-    items.Sort(SORT_METHOD_PROGRAM_COUNT, SortOrderAscending);
+    items.Sort(SortByProgramCount, SortOrderAscending);
   }
 }
 

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -678,7 +678,7 @@ namespace VIDEO
     */
 
     // since we're doing this now anyway, should other items be stacked?
-    items.Sort(SORT_METHOD_FULLPATH, SortOrderAscending);
+    items.Sort(SortByPath, SortOrderAscending);
     int x = 0;
     while (x < items.Size())
     {

--- a/xbmc/video/windows/GUIWindowVideoBase.cpp
+++ b/xbmc/video/windows/GUIWindowVideoBase.cpp
@@ -2018,7 +2018,7 @@ void CGUIWindowVideoBase::AppendAndClearSearchItems(CFileItemList &searchItems, 
   if (!searchItems.Size())
     return;
 
-  searchItems.Sort(g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SORT_METHOD_LABEL_IGNORE_THE : SORT_METHOD_LABEL, SortOrderAscending);
+  searchItems.Sort(SortByLabel, SortOrderAscending, g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
   for (int i = 0; i < searchItems.Size(); i++)
     searchItems[i]->SetLabel(prependLabel + searchItems[i]->GetLabel());
   results.Append(searchItems);

--- a/xbmc/video/windows/GUIWindowVideoNav.cpp
+++ b/xbmc/video/windows/GUIWindowVideoNav.cpp
@@ -1595,7 +1595,7 @@ void CGUIWindowVideoNav::OnLinkMovieToTvShow(int itemnumber, bool bRemove)
   int iSelectedLabel = 0;
   if (list.Size() > 1)
   {
-    list.Sort(g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SORT_METHOD_LABEL_IGNORE_THE : SORT_METHOD_LABEL, SortOrderAscending);
+    list.Sort(SortByLabel, SortOrderAscending, g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone);
     CGUIDialogSelect* pDialog = (CGUIDialogSelect*)g_windowManager.GetWindow(WINDOW_DIALOG_SELECT);
     pDialog->Reset();
     pDialog->SetItems(&list);
@@ -1793,7 +1793,7 @@ bool CGUIWindowVideoNav::GetItemsForTag(const CStdString &strHeading, const std:
   if (dialog == NULL)
     return false;
 
-  listItems.Sort(SORT_METHOD_LABEL_IGNORE_THE, SortOrderAscending);
+  listItems.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
@@ -1827,7 +1827,7 @@ bool CGUIWindowVideoNav::GetMoviesForSet(CFileItemPtr &setItem, CFileItemList &o
   if (dialog == NULL)
     return false;
 
-  listItems.Sort(SORT_METHOD_LABEL_IGNORE_THE, SortOrderAscending);
+  listItems.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
   dialog->Reset();
   dialog->SetMultiSelection(true);
@@ -1868,7 +1868,7 @@ bool CGUIWindowVideoNav::GetSetForMovie(CFileItemPtr &movieItem, CFileItemPtr &s
   CStdString baseDir = "videodb://movies/sets/";
   if (!CDirectory::GetDirectory(baseDir, listItems) || listItems.Size() <= 0)
     return false;
-  listItems.Sort(SORT_METHOD_LABEL_IGNORE_THE, SortOrderAscending);
+  listItems.Sort(SortByLabel, SortOrderAscending, SortAttributeIgnoreArticle);
 
   int currentSetId = 0;
   CStdString currentSetLabel;

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -536,14 +536,11 @@ void CGUIMediaWindow::UpdateButtons()
     m_viewControl.SetCurrentView(m_guiState->GetViewAsControl());
 
     // Update sort by button
-    if (m_guiState->GetSortMethod()==SORT_METHOD_NONE)
-    {
+    if (m_guiState->GetSortMethod().sortBy == SortByNone)
       CONTROL_DISABLE(CONTROL_BTNSORTBY);
-    }
     else
-    {
       CONTROL_ENABLE(CONTROL_BTNSORTBY);
-    }
+
     CStdString sortLabel;
     sortLabel.Format(g_localizeStrings.Get(550).c_str(), g_localizeStrings.Get(m_guiState->GetSortMethodLabel()).c_str());
     SET_CONTROL_LABEL(CONTROL_BTNSORTBY, sortLabel);
@@ -571,35 +568,30 @@ void CGUIMediaWindow::SortItems(CFileItemList &items)
 
   if (guiState.get())
   {
-    bool sorted = false;
-    SORT_METHOD sortMethod = guiState->GetSortMethod();
+    SortDescription sorting = guiState->GetSortMethod();
+    sorting.sortOrder = guiState->GetDisplaySortOrder();
     // If the sort method is "sort by playlist" and we have a specific
     // sort order available we can use the specified sort order to do the sorting
     // We do this as the new SortBy methods are a superset of the SORT_METHOD methods, thus
     // not all are available. This may be removed once SORT_METHOD_* have been replaced by
     // SortBy.
-    if ((sortMethod == SORT_METHOD_PLAYLIST_ORDER) && items.HasProperty(PROPERTY_SORT_ORDER))
+    if ((sorting.sortBy == SortByPlaylistOrder) && items.HasProperty(PROPERTY_SORT_ORDER))
     {
       SortBy sortBy = (SortBy)items.GetProperty(PROPERTY_SORT_ORDER).asInteger();
       if (sortBy != SortByNone && sortBy != SortByPlaylistOrder && sortBy != SortByProgramCount)
       {
-        SortDescription sorting;
         sorting.sortBy = sortBy;
         sorting.sortOrder = items.GetProperty(PROPERTY_SORT_ASCENDING).asBoolean() ? SortOrderAscending : SortOrderDescending;
         sorting.sortAttributes = g_guiSettings.GetBool("filelists.ignorethewhensorting") ? SortAttributeIgnoreArticle : SortAttributeNone;
 
         // if the sort order is descending, we need to switch the original sort order, as we assume
-        // in CGUIViewState::AddPlaylistOrder that SORT_METHOD_PLAYLIST_ORDER is ascending.
+        // in CGUIViewState::AddPlaylistOrder that SortByPlaylistOrder is ascending.
         if (guiState->GetDisplaySortOrder() == SortOrderDescending)
           sorting.sortOrder = sorting.sortOrder == SortOrderDescending ? SortOrderAscending : SortOrderDescending;
-
-        items.Sort(sorting);
-        sorted = true;
       }
     }
 
-    if (!sorted)
-      items.Sort(sortMethod, guiState->GetDisplaySortOrder());
+    items.Sort(sorting);
   }
 }
 
@@ -621,8 +613,7 @@ void CGUIMediaWindow::FormatItemLabels(CFileItemList &items, const LABEL_MASKS &
       fileFormatter.FormatLabels(pItem.get());
   }
 
-  if(items.GetSortMethod() == SORT_METHOD_LABEL_IGNORE_THE 
-  || items.GetSortMethod() == SORT_METHOD_LABEL)
+  if (items.GetSortMethod() == SortByLabel)
     items.ClearSortState();
 }
 
@@ -637,7 +628,7 @@ void CGUIMediaWindow::FormatAndSort(CFileItemList &items)
     viewState->GetSortMethodLabelMasks(labelMasks);
     FormatItemLabels(items, labelMasks);
   
-    items.Sort(viewState->GetSortMethod(), viewState->GetDisplaySortOrder());
+    items.Sort(viewState->GetSortMethod().sortBy, viewState->GetDisplaySortOrder(), viewState->GetSortMethod().sortAttributes);
   }
 }
 

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -336,7 +336,7 @@ void CGUIWindowFileManager::OnSort(int iList)
 
   }
 
-  m_vecItems[iList]->Sort(SORT_METHOD_LABEL, SortOrderAscending);
+  m_vecItems[iList]->Sort(SortByLabel, SortOrderAscending);
 }
 
 void CGUIWindowFileManager::ClearFileItems(int iList)


### PR DESCRIPTION
- This is backport of [#2959](https://github.com/xbmc/xbmc/pull/2959)
- First 12 commits are preparation for [#2959](https://github.com/xbmc/xbmc/pull/2959)
- Commit 4c8261dec1b04ea178754cf1d5ff83485cb772d9 is actual [#2959](https://github.com/xbmc/xbmc/pull/2959) PR
- Last commit a5921c0fa33070756a7e98691c3999f1de681567 is specific to Xbox because we didn't do Settings refactoring

**NOTICE:** Keep in mind commit a5921c0fa33070756a7e98691c3999f1de681567 when backporting following PRs:
1. [#2190](https://github.com/xbmc/xbmc/pull/2190)
2. [#2258](https://github.com/xbmc/xbmc/pull/2258)
3. [#2445](https://github.com/xbmc/xbmc/pull/2445)
