### PR TITLE
Generic CFileItemList modifiers #3415 

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -1759,6 +1759,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					RelativePath=".\xbmc\FileItem.h">
 				</File>
 				<File
+					RelativePath=".\xbmc\FileItemListModification.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\FileItemListModification.h">
+				</File>
+				<File
 					RelativePath=".\xbmc\FileSystem\FileReaderFile.cpp">
 				</File>
 				<File

--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -625,6 +625,9 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 				<File
 					RelativePath=".\xbmc\playlists\PlayListXML.cpp">
 				</File>
+				<File
+					RelativePath=".\xbmc\playlists\SmartPlaylistFileItemListModifier.cpp">
+				</File>
 			</Filter>
 			<Filter
 				Name="infoTagReaders"
@@ -3131,6 +3134,9 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 				RelativePath=".\xbmc\FileSystem\IFileDirectory.h">
 			</File>
 			<File
+				RelativePath=".\xbmc\IFileItemListModifier.h">
+			</File>
+			<File
 				RelativePath=".\xbmc\utils\IMDB.h">
 			</File>
 			<File
@@ -3303,6 +3309,9 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 			</File>
 			<File
 				RelativePath=".\xbmc\utils\SingleLock.h">
+			</File>
+			<File
+				RelativePath=".\xbmc\playlists\SmartPlaylistFileItemListModifier.h">
 			</File>
 			<File
 				RelativePath=".\xbmc\utils\Sntp.h">

--- a/xbmc/FileItemListModification.cpp
+++ b/xbmc/FileItemListModification.cpp
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "FileItemListModification.h"
+
+#include "playlists/SmartPlaylistFileItemListModifier.h"
+
+using namespace std;
+
+CFileItemListModification::CFileItemListModification()
+{
+  m_modifiers.insert(new CSmartPlaylistFileItemListModifier());
+}
+
+CFileItemListModification::~CFileItemListModification()
+{
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+    delete *modifier;
+
+  m_modifiers.clear();
+}
+
+CFileItemListModification& CFileItemListModification::Get()
+{
+  static CFileItemListModification instance;
+  return instance;
+}
+
+bool CFileItemListModification::CanModify(const CFileItemList &items) const
+{
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+  {
+    if ((*modifier)->CanModify(items))
+      return true;
+  }
+
+  return false;
+}
+
+bool CFileItemListModification::Modify(CFileItemList &items) const
+{
+  bool result = false;
+  for (set<IFileItemListModifier*>::const_iterator modifier = m_modifiers.begin(); modifier != m_modifiers.end(); ++modifier)
+    result |= (*modifier)->Modify(items);
+
+  return result;
+}

--- a/xbmc/FileItemListModification.h
+++ b/xbmc/FileItemListModification.h
@@ -1,0 +1,42 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <set>
+
+#include "IFileItemListModifier.h"
+
+class CFileItemListModification : public IFileItemListModifier
+{
+public:
+  ~CFileItemListModification();
+
+  static CFileItemListModification& Get();
+
+  virtual bool CanModify(const CFileItemList &items) const;
+  virtual bool Modify(CFileItemList &items) const;
+
+private:
+  CFileItemListModification();
+  CFileItemListModification(const CFileItemListModification&);
+  CFileItemListModification const& operator=(CFileItemListModification const&);
+
+  std::set<IFileItemListModifier*> m_modifiers;
+};

--- a/xbmc/IFileItemListModifier.h
+++ b/xbmc/IFileItemListModifier.h
@@ -1,0 +1,32 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+class CFileItemList;
+
+class IFileItemListModifier
+{
+public:
+  IFileItemListModifier() { }
+  virtual ~IFileItemListModifier() { }
+
+  virtual bool CanModify(const CFileItemList &items) const = 0;
+  virtual bool Modify(CFileItemList &items) const = 0;
+};

--- a/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
+++ b/xbmc/music/windows/GUIWindowMusicPlaylistEditor.cpp
@@ -168,6 +168,8 @@ bool CGUIWindowMusicPlaylistEditor::GetDirectory(const CStdString &strDirectory,
 
 void CGUIWindowMusicPlaylistEditor::OnPrepareFileItems(CFileItemList &items)
 {
+  CGUIWindowMusicBase::OnPrepareFileItems(items);
+
   RetrieveMusicInfo();
 
   items.SetCachedMusicThumbs();

--- a/xbmc/music/windows/GUIWindowMusicSongs.cpp
+++ b/xbmc/music/windows/GUIWindowMusicSongs.cpp
@@ -208,6 +208,8 @@ bool CGUIWindowMusicSongs::GetDirectory(const CStdString &strDirectory, CFileIte
 
 void CGUIWindowMusicSongs::OnPrepareFileItems(CFileItemList &items)
 {
+  CGUIWindowMusicBase::OnPrepareFileItems(items);
+
   RetrieveMusicInfo();
 
   items.SetCachedMusicThumbs();

--- a/xbmc/pictures/GUIWindowPictures.cpp
+++ b/xbmc/pictures/GUIWindowPictures.cpp
@@ -206,6 +206,8 @@ void CGUIWindowPictures::UpdateButtons()
 
 void CGUIWindowPictures::OnPrepareFileItems(CFileItemList& items)
 {
+  CGUIMediaWindow::OnPrepareFileItems(items);
+
   for (int i=0;i<items.Size();++i )
     if (items[i]->GetLabel().Equals("folder.jpg"))
       items.Remove(i);

--- a/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
+++ b/xbmc/playlists/SmartPlaylistFileItemListModifier.cpp
@@ -1,0 +1,66 @@
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <map>
+
+#include "SmartPlaylistFileItemListModifier.h"
+#include "FileItem.h"
+#include "URL.h"
+#include "SmartPlayList.h"
+#include "utils/StringUtils2.h"
+
+#define URL_OPTION_XSP              "xsp"
+#define PROPERTY_SORT_ORDER         "sort.order"
+#define PROPERTY_SORT_ASCENDING     "sort.ascending"
+using namespace std;
+
+bool CSmartPlaylistFileItemListModifier::CanModify(const CFileItemList &items) const
+{
+  return !GetUrlOption(items.GetPath(), URL_OPTION_XSP).empty();
+}
+
+bool CSmartPlaylistFileItemListModifier::Modify(CFileItemList &items) const
+{
+  if (items.HasProperty(PROPERTY_SORT_ORDER))
+    return false;
+
+  std::string xspOption = GetUrlOption(items.GetPath(), URL_OPTION_XSP);
+  if (xspOption.empty())
+    return false;
+
+  // check for smartplaylist-specific sorting information
+  CSmartPlaylist xsp;
+  if (!xsp.LoadFromJson(xspOption))
+    return false;
+
+  items.SetProperty(PROPERTY_SORT_ORDER, (int)xsp.GetOrder());
+  items.SetProperty(PROPERTY_SORT_ASCENDING, xsp.GetOrderDirection() == SortOrderAscending);
+
+  return true;
+}
+
+std::string CSmartPlaylistFileItemListModifier::GetUrlOption(const std::string &path, const std::string &option)
+{
+  if (path.empty() || option.empty())
+    return StringUtils2::Empty;
+
+  CURL url(path);
+  return url.GetOption(option);
+}

--- a/xbmc/playlists/SmartPlaylistFileItemListModifier.h
+++ b/xbmc/playlists/SmartPlaylistFileItemListModifier.h
@@ -1,0 +1,37 @@
+#pragma once
+/*
+ *      Copyright (C) 2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <string>
+
+#include "IFileItemListModifier.h"
+
+class CSmartPlaylistFileItemListModifier : public IFileItemListModifier
+{
+public:
+  CSmartPlaylistFileItemListModifier() { }
+  virtual ~CSmartPlaylistFileItemListModifier() { }
+
+  virtual bool CanModify(const CFileItemList &items) const;
+  virtual bool Modify(CFileItemList &items) const;
+
+private:
+  static std::string GetUrlOption(const std::string &path, const std::string &option);
+};

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -735,10 +735,7 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
   CStdString filter;
   CURL url(directory);
   if (canfilter && url.HasOption("filter"))
-  {
-    filter = url.GetOption("filter");
     directory = RemoveParameterFromPath(directory, "filter");
-  }
 
   CFileItemList items;
   if (!GetDirectory(directory, items))
@@ -760,44 +757,8 @@ bool CGUIMediaWindow::Update(const CStdString &strDirectory, bool updateFilterPa
   ClearFileItems();
   m_vecItems->Copy(items);
 
-  // only set the filter path if it hasn't been marked
-  // as preset or if it's empty
-  if (updateFilterPath || m_strFilterPath.empty())
-  {
-    if (items.HasProperty(PROPERTY_PATH_DB))
-      m_strFilterPath = items.GetProperty(PROPERTY_PATH_DB).asString();
-    else
-      m_strFilterPath = items.GetPath();
-  }
-
-  // maybe the filter path can contain a filter
-  if (!canfilter && CanContainFilter(m_strFilterPath))
-    canfilter = true;
-
-  // check if the filter path contains a filter
-  CURL filterPathUrl(m_strFilterPath);
-  if (canfilter && filter.empty())
-  {
-    if (filterPathUrl.HasOption("filter"))
-      filter = filterPathUrl.GetOption("filter");
-  }
-
-  // check if there is a filter and re-apply it
-  if (canfilter && !filter.empty())
-  {
-    if (!m_filter.LoadFromJson(filter))
-    {
-      CLog::Log(LOGWARNING, "CGUIMediaWindow::Update: unable to load existing filter (%s)", filter.c_str());
-      m_filter.Reset();
-      m_strFilterPath = m_vecItems->GetPath();
-    }
-    else
-    {
-      // add the filter to the filter path
-      filterPathUrl.SetOption("filter", filter);
-      m_strFilterPath = filterPathUrl.Get();
-    }
-  }
+  // check the given path for filter data
+  UpdateFilterPath(strDirectory, items, updateFilterPath);
 
   // if we're getting the root source listing
   // make sure the path history is clean
@@ -1622,6 +1583,55 @@ bool CGUIMediaWindow::WaitForNetwork() const
   }
   progress->Close();
   return true;
+}
+
+void CGUIMediaWindow::UpdateFilterPath(const CStdString &strDirectory, const CFileItemList &items, bool updateFilterPath)
+{
+  bool canfilter = CanContainFilter(strDirectory);
+
+  CStdString filter;
+  CURL url(strDirectory);
+  if (canfilter && url.HasOption("filter"))
+    filter = url.GetOption("filter");
+
+  // only set the filter path if it hasn't been marked
+  // as preset or if it's empty
+  if (updateFilterPath || m_strFilterPath.empty())
+  {
+    if (items.HasProperty(PROPERTY_PATH_DB))
+      m_strFilterPath = items.GetProperty(PROPERTY_PATH_DB).asString();
+    else
+      m_strFilterPath = items.GetPath();
+  }
+
+  // maybe the filter path can contain a filter
+  if (!canfilter && CanContainFilter(m_strFilterPath))
+    canfilter = true;
+
+  // check if the filter path contains a filter
+  CURL filterPathUrl(m_strFilterPath);
+  if (canfilter && filter.empty())
+  {
+    if (filterPathUrl.HasOption("filter"))
+      filter = filterPathUrl.GetOption("filter");
+  }
+
+  // check if there is a filter and re-apply it
+  if (canfilter && !filter.empty())
+  {
+    if (!m_filter.LoadFromJson(filter))
+    {
+      CLog::Log(LOGWARNING, "CGUIMediaWindow::UpdateFilterPath(): unable to load existing filter (%s)", filter.c_str());
+      m_filter.Reset();
+      m_strFilterPath = m_vecItems->GetPath();
+    }
+    else
+    {
+      // add the filter to the filter path
+      filterPathUrl.SetOption("filter", filter);
+      m_strFilterPath = filterPathUrl.Get();
+    }
+  }
 }
 
 void CGUIMediaWindow::OnFilterItems(const CStdString &filter)

--- a/xbmc/windows/GUIMediaWindow.cpp
+++ b/xbmc/windows/GUIMediaWindow.cpp
@@ -57,6 +57,7 @@
 #include "dialogs/GUIDialogKaiToast.h"
 #include "dialogs/GUIDialogMediaFilter.h"
 #include "filesystem/SmartPlaylistDirectory.h"
+#include "FileItemListModification.h"
 
 #define CONTROL_BTNVIEWASICONS       2
 #define CONTROL_BTNSORTBY            3
@@ -893,7 +894,7 @@ bool CGUIMediaWindow::Refresh(bool clearCache /* = false */)
 // It's used to load tag info for music.
 void CGUIMediaWindow::OnPrepareFileItems(CFileItemList &items)
 {
-
+  CFileItemListModification::Get().Modify(items);
 }
 
 // \brief This function will be called by Update() before

--- a/xbmc/windows/GUIMediaWindow.h
+++ b/xbmc/windows/GUIMediaWindow.h
@@ -99,6 +99,7 @@ protected:
    \return true if the given path can contain a "filter" parameter otherwise false
    */
   virtual bool CanContainFilter(const CStdString &strDirectory) const { return false; }
+  virtual void UpdateFilterPath(const CStdString &strDirector, const CFileItemList &items, bool updateFilterPath);
   virtual bool Filter(bool advanced = true);
 
   /* \brief Called on response to a GUI_MSG_FILTER_ITEMS message


### PR DESCRIPTION
- This is backport of [#3415](https://github.com/xbmc/xbmc/pull/3415)

**NOTICE:** Commit 1e01fed8963232008e1393a72f57a6063b6fefea is not fully backported since our ```*::OnPrepareItems``` methods are somehow different. It probably has to do something with PRs 798, 919, 1109 etc. 