### PR TITLE
 Plugins drop progress dialog #1281 

### DIFF
--- a/addons/skin.confluence.lite/720p/DialogBusy.xml
+++ b/addons/skin.confluence.lite/720p/DialogBusy.xml
@@ -39,6 +39,14 @@
 				<label>$LOCALIZE[31004]</label>
 				<font>font12</font>
 			</control>
+      <control type="progress" id="10">
+				<description>Progressbar</description>
+				<posx>20</posx>
+				<posy>65</posy>
+				<width>160</width>
+				<height>10</height>
+				<!-- <info>System.Progressbar</info> -->
+			</control>
 		</control>
 	</controls>
 </window>

--- a/xbmc/FileSystem/Directory.cpp
+++ b/xbmc/FileSystem/Directory.cpp
@@ -170,6 +170,7 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
               if(dialog->IsCanceled())
               {
                 cancel = true;
+                pDirectory->CancelDirectory();
                 break;
               }
               g_windowManager.ProcessRenderLoop(false);

--- a/xbmc/FileSystem/Directory.cpp
+++ b/xbmc/FileSystem/Directory.cpp
@@ -127,10 +127,6 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
 
 bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, const CHints &hints, bool allowThreads)
 {
-#ifdef _XBOX
-  if(URIUtils::IsPlugin(strPath))
-    allowThreads = false;
-#endif
   try
   {
     CStdString realPath = URIUtils::SubstitutePath(strPath);
@@ -178,6 +174,8 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
                 pDirectory->CancelDirectory();
                 break;
               }
+
+              lock.Leave(); // prevent an occasional deadlock on exit
               g_windowManager.ProcessRenderLoop(false);
             }
             if(dialog)

--- a/xbmc/FileSystem/Directory.cpp
+++ b/xbmc/FileSystem/Directory.cpp
@@ -167,6 +167,11 @@ bool CDirectory::GetDirectory(const CStdString& strPath, CFileItemList &items, c
             {
               CSingleLock lock(g_graphicsContext);
 
+              // update progress
+              float progress = pDirectory->GetProgress();
+              if (progress > 0)
+                dialog->SetProgress(progress);
+
               if(dialog->IsCanceled())
               {
                 cancel = true;

--- a/xbmc/FileSystem/IDirectory.h
+++ b/xbmc/FileSystem/IDirectory.h
@@ -69,6 +69,11 @@ public:
    */
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items) = 0;
   /*!
+   \brief Cancel the current directory fetch (if possible).
+   \sa GetDirectory
+   */
+  virtual void CancelDirectory() { };
+  /*!
   \brief Create the directory
   \param strPath Directory to create.
   \return Returns \e true, if directory is created or if it already exists

--- a/xbmc/FileSystem/IDirectory.h
+++ b/xbmc/FileSystem/IDirectory.h
@@ -69,6 +69,12 @@ public:
    */
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList &items) = 0;
   /*!
+   \brief Retrieve the progress of the current directory fetch (if possible).
+   \return the progress as a float in the range 0..100.
+   \sa GetDirectory, CancelDirectory
+   */
+  virtual float GetProgress() const { return 0.0f; };
+  /*!
    \brief Cancel the current directory fetch (if possible).
    \sa GetDirectory
    */

--- a/xbmc/FileSystem/PluginDirectory.cpp
+++ b/xbmc/FileSystem/PluginDirectory.cpp
@@ -435,7 +435,8 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
 
   DWORD startTime = timeGetTime();
   CGUIDialogProgress *progressBar = NULL;
-  
+  bool cancelled = false;
+
   CLog::Log(LOGDEBUG, "%s - waiting on the %s plugin...", __FUNCTION__, scriptName.c_str());
   while (true)
   {
@@ -463,7 +464,7 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
     }
 
     // check whether we should pop up the progress dialog
-    if (!progressBar && timeGetTime() - startTime > timeBeforeProgressBar)
+    if (!retrievingDir && !progressBar && timeGetTime() - startTime > timeBeforeProgressBar)
     { // loading takes more then 1.5 secs, show a progress dialog
       progressBar = (CGUIDialogProgress *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRESS);
 
@@ -503,30 +504,32 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
       progressBar->Progress();
       if (progressBar->IsCanceled())
       { // user has cancelled our process - cancel our process
-        if (!m_cancelled)
-        {
-          m_cancelled = true;
-          startTime = timeGetTime();
-        }
-        if (m_cancelled && timeGetTime() - startTime > timeToKillScript)
-        { // cancel our script
-#ifdef HAS_PYTHON
-          int id = g_pythonParser.getScriptId(scriptPath.c_str());
-          if (id != -1 && g_pythonParser.isRunning(id))
-          {
-            CLog::Log(LOGDEBUG, "%s- cancelling plugin %s", __FUNCTION__, scriptName.c_str());
-            g_pythonParser.stopScript(id);
-            break;
-          }
-#endif
-        }
+        m_cancelled = true;
       }
     }
+    if (!cancelled && m_cancelled)
+    {
+      cancelled = true;
+      startTime = timeGetTime();
+    }
+    if (cancelled && timeGetTime() - startTime > timeToKillScript)
+    { // cancel our script
+#ifdef HAS_PYTHON
+      int id = g_pythonParser.getScriptId(scriptPath.c_str());
+      if (id != -1 && g_pythonParser.isRunning(id))
+      {
+        CLog::Log(LOGDEBUG, "%s- cancelling plugin %s", __FUNCTION__, scriptName.c_str());
+        g_pythonParser.stopScript(id);
+        break;
+      }
+#endif
+    }
   }
+
   if (progressBar)
     progressBar->Close();
 
-  return !m_cancelled && m_success;
+  return !cancelled && m_success;
 }
 
 void CPluginDirectory::SetResolvedUrl(int handle, bool success, const CFileItem *resultItem)
@@ -597,4 +600,9 @@ void CPluginDirectory::SetProperty(int handle, const CStdString &strProperty, co
 
   CPluginDirectory *dir = globalHandles[handle];
   dir->m_listItems->SetProperty(strProperty, strValue);
+}
+
+void CPluginDirectory::CancelDirectory()
+{
+  m_cancelled = true;
 }

--- a/xbmc/FileSystem/PluginDirectory.cpp
+++ b/xbmc/FileSystem/PluginDirectory.cpp
@@ -488,19 +488,6 @@ bool CPluginDirectory::WaitOnScriptResult(const CStdString &scriptPath, const CS
 
     if (progressBar)
     { // update the progress bar and check for user cancel
-      if (retrievingDir)
-      {
-        CStdString label;
-        if (m_totalItems > 0)
-        {
-          label.Format(g_localizeStrings.Get(1042).c_str(), m_listItems->Size(), m_totalItems);
-          progressBar->SetPercentage((int)((m_listItems->Size() * 100 ) / m_totalItems));
-          progressBar->ShowProgressBar(true);
-        }
-        else
-          label.Format(g_localizeStrings.Get(1041).c_str(), m_listItems->Size());
-        progressBar->SetLine(2, label);
-      }
       progressBar->Progress();
       if (progressBar->IsCanceled())
       { // user has cancelled our process - cancel our process

--- a/xbmc/FileSystem/PluginDirectory.cpp
+++ b/xbmc/FileSystem/PluginDirectory.cpp
@@ -606,3 +606,10 @@ void CPluginDirectory::CancelDirectory()
 {
   m_cancelled = true;
 }
+
+float CPluginDirectory::GetProgress() const
+{
+  if (m_totalItems > 0)
+    return (m_listItems->Size() * 100.0f) / m_totalItems;
+  return 0.0f;
+}

--- a/xbmc/FileSystem/PluginDirectory.h
+++ b/xbmc/FileSystem/PluginDirectory.h
@@ -43,6 +43,7 @@ public:
   ~CPluginDirectory(void);
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
   virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual void CancelDirectory();
   static bool RunScriptWithParams(const CStdString& strPath);
   static bool GetPluginResult(const CStdString& strPath, CFileItem &resultItem);
 

--- a/xbmc/FileSystem/PluginDirectory.h
+++ b/xbmc/FileSystem/PluginDirectory.h
@@ -43,6 +43,7 @@ public:
   ~CPluginDirectory(void);
   virtual bool GetDirectory(const CStdString& strPath, CFileItemList& items);
   virtual bool IsAllowed(const CStdString &strFile) const { return true; };
+  virtual float GetProgress() const;
   virtual void CancelDirectory();
   static bool RunScriptWithParams(const CStdString& strPath);
   static bool GetPluginResult(const CStdString& strPath, CFileItem &resultItem);

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -22,6 +22,8 @@
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 
+#define PROGRESS_CONTROL 10
+
 CGUIDialogBusy::CGUIDialogBusy(void)
   : CGUIDialog(WINDOW_DIALOG_BUSY, "DialogBusy.xml"), m_bLastVisible(false)
 {

--- a/xbmc/dialogs/GUIDialogBusy.cpp
+++ b/xbmc/dialogs/GUIDialogBusy.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "dialogs/GUIDialogBusy.h"
+#include "guilib/GUIProgressControl.h"
 #include "guilib/GUIWindowManager.h"
 
 CGUIDialogBusy::CGUIDialogBusy(void)
@@ -26,6 +27,7 @@ CGUIDialogBusy::CGUIDialogBusy(void)
 {
   m_loadType = LOAD_ON_GUI_INIT;
   m_bModal = true;
+  m_progress = 0;
 }
 
 CGUIDialogBusy::~CGUIDialogBusy(void)
@@ -39,6 +41,7 @@ void CGUIDialogBusy::Show_Internal()
   m_bModal = true;
   m_bLastVisible = true;
   m_dialogClosing = false;
+  m_progress = 0;
   g_windowManager.RouteToWindow(this);
 
   // active this window...
@@ -50,6 +53,16 @@ void CGUIDialogBusy::DoRender(unsigned int currentTime)
 {
   bool visible = g_windowManager.GetTopMostModalDialogID() == WINDOW_DIALOG_BUSY;
   m_bLastVisible = visible;
+
+  // update the progress control if available
+  const CGUIControl *control = GetControl(PROGRESS_CONTROL);
+  if (control && control->GetControlType() == CGUIControl::GUICONTROL_PROGRESS)
+  {
+    CGUIProgressControl *progress = (CGUIProgressControl *)control;
+    progress->SetPercentage(m_progress);
+    progress->SetVisible(m_progress > 0);
+  }
+
   CGUIDialog::DoRender(currentTime);
 }
 
@@ -70,4 +83,9 @@ bool CGUIDialogBusy::OnAction(const CAction &action)
   }
   else
     return CGUIDialog::OnAction(action);
+}
+
+void CGUIDialogBusy::SetProgress(float percent)
+{
+  m_progress = percent;
 }

--- a/xbmc/dialogs/GUIDialogBusy.h
+++ b/xbmc/dialogs/GUIDialogBusy.h
@@ -31,10 +31,15 @@ public:
   virtual bool OnAction(const CAction &action);
   virtual void DoRender(unsigned int currentTime);
   virtual void Render();
+  /*! \brief set the current progress of the busy operation
+   \param progress a percentage of progress
+   */
+  void SetProgress(float progress);
 
   bool IsCanceled() { return m_bCanceled; }
 protected:
   virtual void Show_Internal(); // modeless'ish
   bool m_bCanceled;
   bool m_bLastVisible;
+  float m_progress; ///< current progress
 };


### PR DESCRIPTION
- This is backport of [#1281](https://github.com/xbmc/xbmc/pull/1281)

Finally, after Addons Framework we can run two Python scripts at the same time. There are still some issues, but at least we can enable threading on plugin VFS paths :)