### PR TITLE
 Separate db update from CDatabase::Open() #1128 

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -1233,6 +1233,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					RelativePath=".\xbmc\Database.h">
 				</File>
 				<File
+					RelativePath=".\xbmc\DatabaseManager.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\DatabaseManager.h">
+				</File>
+				<File
 					RelativePath=".\xbmc\music\MusicDatabase.cpp">
 				</File>
 				<File

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -87,6 +87,7 @@
 #include "LocalizeStrings.h"
 #include "utils/CharsetConverter.h"
 #include "utils/StringUtils.h"
+#include "DatabaseManager.h"
 #ifdef HAS_FILESYSTEM
 #include "filesystem/DAAPFile.h"
 #endif
@@ -974,6 +975,9 @@ HRESULT CApplication::Create(HWND hWnd)
 
   update_emu_environ();//apply the GUI settings
 
+  // initialize the addon database (must be before the addon manager is init'd)
+  CDatabaseManager::Get().Initialize(true);
+
   // start-up Addons Framework
   // currently bails out if either cpluff Dll is unavailable or system dir can not be scanned
   if (!CAddonMgr::Get().Init())
@@ -1254,6 +1258,9 @@ HRESULT CApplication::Initialize()
   /* setup network based on our settings */
   /* network will start it's init procedure */
   m_network.SetupNetwork();
+
+  // initialize (and update as needed) our databases
+  CDatabaseManager::Get().Initialize();
 
   StartServices();
 

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -18,17 +18,17 @@
  *
  */
 
-#include "utils/log.h"
-#include "utils/SortUtils.h"
-#include "AutoPtrHandle.h"
 #include "Database.h"
-#include "utils/URIUtils.h"
 #include "settings/Settings.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/Crc32.h"
 #include "filesystem/SpecialProtocol.h"
-#include "AutoPtrHandle.h"
+#include "filesystem/File.h"
 #include "utils/SingleLock.h"
+#include "utils/AutoPtrHandle.h"
+#include "utils/log.h"
+#include "utils/URIUtils.h"
+#include "utils/SortUtils.h"
 #include "DbUrl.h"
 
 using namespace AUTOPTR;
@@ -99,8 +99,7 @@ void CDatabase::Filter::AppendGroup(const std::string &strGroup)
 
 CDatabase::CDatabase(void)
 {
-  m_bOpen = false;
-  m_iRefCount = 0;
+  m_openCount = 0;
   m_sqlite = true;
   m_bMultiWrite = false;
 }
@@ -309,9 +308,10 @@ bool CDatabase::Open(const DatabaseSettings &settings)
 {
   // take a copy - we're gonna be messing with it and we don't want to touch the original
   DatabaseSettings dbSettings = settings;
+
   if (IsOpen())
   {
-    m_iRefCount++;
+    m_openCount++;
     return true;
   }
 
@@ -320,25 +320,92 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   if ( dbSettings.type.Equals("mysql") )
   {
     // check we have all information before we cancel the fallback
-    if ( ! (dbSettings.host.IsEmpty() || dbSettings.user.IsEmpty() || dbSettings.pass.IsEmpty()) )
+    if ( ! (dbSettings.host.IsEmpty() ||
+            dbSettings.user.IsEmpty() || dbSettings.pass.IsEmpty()) )
       m_sqlite = false;
     else
-      CLog::Log(LOGINFO, "essential mysql database information is missing (eg. host, user, pass)");
+      CLog::Log(LOGINFO, "Essential mysql database information is missing. Require at least host, user and pass defined.");
   }
-
-  // set default database name if appropriate
-  if ( dbSettings.name.IsEmpty() )
-    dbSettings.name = GetDefaultDBName();
-
-  // always safely fallback to sqlite3
-  if (m_sqlite)
+  else
   {
     dbSettings.type = "sqlite3";
     dbSettings.host = CSpecialProtocol::TranslatePath(g_settings.GetDatabaseFolder());
+    dbSettings.name = GetBaseDBName();
   }
 
+  // use separate, versioned database
+  int version = GetMinVersion();
+  CStdString baseDBName = (dbSettings.name.IsEmpty() ? GetBaseDBName() : dbSettings.name.c_str());
+  CStdString latestDb;
+  latestDb.Format("%s%d", GetBaseDBName(), version);
+
+  while (version >= 0)
+  {
+    if (version)
+      dbSettings.name.Format("%s%d", GetBaseDBName(), version);
+    else
+      dbSettings.name.Format("%s", baseDBName);
+
+    if (Connect(dbSettings, false))
+    {
+      // Database exists, take a copy for our current version (if needed) and reopen that one
+      if (version < GetMinVersion())
+      {
+        CLog::Log(LOGNOTICE, "Old database found - updating from version %i to %i", version, GetMinVersion());
+
+        bool copy_fail = false;
+
+        try
+        {
+          m_pDB->copy(latestDb);
+        }
+        catch(...)
+        {
+          CLog::Log(LOGERROR, "Unable to copy old database %s to new version %s", dbSettings.name.c_str(), latestDb.c_str());
+          copy_fail = true;
+        }
+
+        Close();
+
+        if ( copy_fail )
+          return false;
+
+        dbSettings.name = latestDb;
+        if (!Connect(dbSettings, false))
+        {
+          CLog::Log(LOGERROR, "Unable to open freshly copied database %s", dbSettings.name.c_str());
+          return false;
+        }
+      }
+
+      // yay - we have a copy of our db, now do our worst with it
+      if (UpdateVersion(dbSettings.name))
+        return true;
+
+      // update failed - loop around and see if we have another one available
+      Close();
+    }
+
+    // drop back to the previous version and try that
+    version--;
+  }
+
+  // unable to open any version fall through to create a new one
+  dbSettings.name = latestDb;
+
   if (Connect(dbSettings, true) && UpdateVersion(dbSettings.name))
+  {
     return true;
+  }
+  // safely fall back to sqlite as appropriate
+  else if ( ! m_sqlite )
+  {
+    CLog::Log(LOGDEBUG, "Falling back to sqlite.");
+    dbSettings = settings;
+    dbSettings.type = "sqlite3";
+    return Open(dbSettings);
+  }
+
   // failed to update or open the database
   Close();
   CLog::Log(LOGERROR, "Unable to open database %s", dbSettings.name.c_str());
@@ -384,9 +451,6 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
   m_pDS.reset(m_pDB->CreateDataset());
   m_pDS2.reset(m_pDB->CreateDataset());
 
-  CLog::Log(LOGDEBUG, "CDatabase: Connecting to database %s at %s:%s",
-            dbSettings.name.c_str(), dbSettings.host.c_str(), dbSettings.port.c_str());
-
   if (m_pDB->connect(create) != DB_CONNECTION_OK)
     return false;
   
@@ -408,9 +472,6 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
     CreateTables();
   }
 
-  // Mark our db as open here to make our destructor to properly close the file handle
-  m_bOpen = true;
-
   // sqlite3 post connection operations
   if (dbSettings.type.Equals("sqlite3"))
   {
@@ -421,7 +482,7 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
     m_pDS->exec("PRAGMA count_changes='OFF'\n");
   }
 
-  m_iRefCount++;
+  m_openCount = 1; // our database is open
   return true;
 }
 
@@ -459,22 +520,21 @@ bool CDatabase::UpdateVersion(const CStdString &dbName)
 
 bool CDatabase::IsOpen()
 {
-  return m_bOpen;
+  return m_openCount > 0;
 }
 
 void CDatabase::Close()
 {
-  if (!m_bOpen)
-    return ;
+  if (m_openCount == 0)
+    return;
 
-  if (m_iRefCount > 1)
+  if (m_openCount > 1)
   {
-    m_iRefCount--;
-    return ;
+    m_openCount--;
+    return;
   }
 
-  m_iRefCount--;
-  m_bOpen = false;
+  m_openCount = 0;
 
   if (NULL == m_pDB.get() ) return ;
   if (NULL != m_pDS.get()) m_pDS->close();
@@ -588,6 +648,8 @@ bool CDatabase::UpdateVersionNumber()
   {
     CStdString strSQL=PrepareSQL("UPDATE version SET idVersion=%i\n", GetMinVersion());
     m_pDS->exec(strSQL.c_str());
+
+    CommitTransaction();
   }
   catch(...)
   {

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -316,7 +316,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   dbName.AppendFormat("%d", GetMinVersion());
   if (!Connect(dbName, dbSettings, false) || GetDBVersion() != GetMinVersion())
   {
-    if (!Update(dbSettings))
+    if (!Update(settings))
       return false;
   }
   return true;
@@ -346,8 +346,11 @@ void CDatabase::InitSettings(DatabaseSettings &dbSettings)
     dbSettings.name = GetBaseDBName();
 }
 
-bool CDatabase::Update(const DatabaseSettings &dbSettings)
+bool CDatabase::Update(const DatabaseSettings &settings)
 {
+  DatabaseSettings dbSettings = settings;
+  InitSettings(dbSettings);
+
   int version = GetMinVersion();
   CStdString latestDb = dbSettings.name;
   latestDb.AppendFormat("%d", version);

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -26,8 +26,9 @@
 #include "filesystem/File.h"
 #include "utils/AutoPtrHandle.h"
 #include "utils/log.h"
-#include "utils/URIUtils.h"
 #include "utils/SortUtils.h"
+#include "utils/URIUtils.h"
+#include "DatabaseManager.h"
 #include "DbUrl.h"
 
 using namespace AUTOPTR;
@@ -309,17 +310,16 @@ bool CDatabase::Open(const DatabaseSettings &settings)
     return true;
   }
 
+  // check our database manager to see if this database can be opened
+  if (!CDatabaseManager::Get().CanOpen(GetBaseDBName()))
+    return false;
+
   DatabaseSettings dbSettings = settings;
   InitSettings(dbSettings);
 
   CStdString dbName = dbSettings.name;
   dbName.AppendFormat("%d", GetMinVersion());
-  if (!Connect(dbName, dbSettings, false) || GetDBVersion() != GetMinVersion())
-  {
-    if (!Update(settings))
-      return false;
-  }
-  return true;
+  return Connect(dbName, dbSettings, false);
 }
 
 void CDatabase::InitSettings(DatabaseSettings &dbSettings)

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -469,13 +469,17 @@ bool CDatabase::Connect(const CStdString &dbName, const DatabaseSettings &dbSett
   return true;
 }
 
-bool CDatabase::UpdateVersion(const CStdString &dbName)
+int CDatabase::GetDBVersion()
 {
-  int version = 0;
   m_pDS->query("SELECT idVersion FROM version\n");
   if (m_pDS->num_rows() > 0)
-    version = m_pDS->fv("idVersion").get_asInt();
+    return m_pDS->fv("idVersion").get_asInt();
+  return 0;
+}
 
+bool CDatabase::UpdateVersion(const CStdString &dbName)
+{
+  int version = GetDBVersion();
   if (version < GetMinVersion())
   {
     CLog::Log(LOGNOTICE, "Attempting to update the database %s from version %i to %i", dbName.c_str(), version, GetMinVersion());

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -327,23 +327,23 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   {
     dbSettings.type = "sqlite3";
     dbSettings.host = CSpecialProtocol::TranslatePath(g_settings.GetDatabaseFolder());
-    dbSettings.name = GetBaseDBName();
   }
 
   // use separate, versioned database
+  if (dbSettings.name.IsEmpty())
+    dbSettings.name = GetBaseDBName();
+
   int version = GetMinVersion();
-  CStdString baseDBName = (dbSettings.name.IsEmpty() ? GetBaseDBName() : dbSettings.name.c_str());
-  CStdString latestDb;
-  latestDb.Format("%s%d", GetBaseDBName(), version);
+  CStdString latestDb = dbSettings.name;
+  latestDb.AppendFormat("%d", version);
 
   while (version >= 0)
   {
+    CStdString dbName = dbSettings.name;
     if (version)
-      dbSettings.name.Format("%s%d", GetBaseDBName(), version);
-    else
-      dbSettings.name.Format("%s", baseDBName);
+      dbName.AppendFormat("%d", version);
 
-    if (Connect(dbSettings, false))
+    if (Connect(dbName, dbSettings, false))
     {
       // Database exists, take a copy for our current version (if needed) and reopen that one
       if (version < GetMinVersion())
@@ -358,7 +358,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
         }
         catch(...)
         {
-          CLog::Log(LOGERROR, "Unable to copy old database %s to new version %s", dbSettings.name.c_str(), latestDb.c_str());
+          CLog::Log(LOGERROR, "Unable to copy old database %s to new version %s", dbName.c_str(), latestDb.c_str());
           copy_fail = true;
         }
 
@@ -367,16 +367,15 @@ bool CDatabase::Open(const DatabaseSettings &settings)
         if ( copy_fail )
           return false;
 
-        dbSettings.name = latestDb;
-        if (!Connect(dbSettings, false))
+        if (!Connect(latestDb, dbSettings, false))
         {
-          CLog::Log(LOGERROR, "Unable to open freshly copied database %s", dbSettings.name.c_str());
+          CLog::Log(LOGERROR, "Unable to open freshly copied database %s", latestDb.c_str());
           return false;
         }
       }
 
       // yay - we have a copy of our db, now do our worst with it
-      if (UpdateVersion(dbSettings.name))
+      if (UpdateVersion(latestDb))
         return true;
 
       // update failed - loop around and see if we have another one available
@@ -388,9 +387,7 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   }
 
   // unable to open any version fall through to create a new one
-  dbSettings.name = latestDb;
-
-  if (Connect(dbSettings, true) && UpdateVersion(dbSettings.name))
+  if (Connect(latestDb, dbSettings, true) && UpdateVersion(latestDb))
   {
     return true;
   }
@@ -405,11 +402,11 @@ bool CDatabase::Open(const DatabaseSettings &settings)
 
   // failed to update or open the database
   Close();
-  CLog::Log(LOGERROR, "Unable to open database %s", dbSettings.name.c_str());
+  CLog::Log(LOGERROR, "Unable to create new database");
   return false;
 }
 
-bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
+bool CDatabase::Connect(const CStdString &dbName, const DatabaseSettings &dbSettings, bool create)
 {
   // create the appropriate database structure
   if (dbSettings.type.Equals("sqlite3"))
@@ -442,7 +439,7 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
     m_pDB->setPasswd(dbSettings.pass.c_str());
 
   // database name is always required
-  m_pDB->setDatabase(dbSettings.name.c_str());
+  m_pDB->setDatabase(dbName.c_str());
 
   // create the datasets
   m_pDS.reset(m_pDB->CreateDataset());

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -303,15 +303,27 @@ bool CDatabase::Open()
 
 bool CDatabase::Open(const DatabaseSettings &settings)
 {
-  // take a copy - we're gonna be messing with it and we don't want to touch the original
-  DatabaseSettings dbSettings = settings;
-
   if (IsOpen())
   {
     m_openCount++;
     return true;
   }
 
+  DatabaseSettings dbSettings = settings;
+  InitSettings(dbSettings);
+
+  CStdString dbName = dbSettings.name;
+  dbName.AppendFormat("%d", GetMinVersion());
+  if (!Connect(dbName, dbSettings, false) || GetDBVersion() != GetMinVersion())
+  {
+    if (!Update(dbSettings))
+      return false;
+  }
+  return true;
+}
+
+void CDatabase::InitSettings(DatabaseSettings &dbSettings)
+{
   m_sqlite = true;
 
   if ( dbSettings.type.Equals("mysql") )
@@ -332,15 +344,6 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   // use separate, versioned database
   if (dbSettings.name.IsEmpty())
     dbSettings.name = GetBaseDBName();
-
-  CStdString dbName = dbSettings.name;
-  dbName.AppendFormat("%d", GetMinVersion());
-  if (!Connect(dbName, dbSettings, false) || GetDBVersion() != GetMinVersion())
-  {
-    if (!Update(dbSettings))
-      return false;
-  }
-  return true;
 }
 
 bool CDatabase::Update(const DatabaseSettings &dbSettings)

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -385,20 +385,9 @@ bool CDatabase::Open(const DatabaseSettings &settings)
     // drop back to the previous version and try that
     version--;
   }
-
-  // unable to open any version fall through to create a new one
-  if (Connect(latestDb, dbSettings, true) && UpdateVersion(latestDb))
-  {
+  // try creating a new one
+  if (Connect(latestDb, dbSettings, true))
     return true;
-  }
-  // safely fall back to sqlite as appropriate
-  else if ( ! m_sqlite )
-  {
-    CLog::Log(LOGDEBUG, "Falling back to sqlite.");
-    dbSettings = settings;
-    dbSettings.type = "sqlite3";
-    return Open(dbSettings);
-  }
 
   // failed to update or open the database
   Close();

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -333,6 +333,18 @@ bool CDatabase::Open(const DatabaseSettings &settings)
   if (dbSettings.name.IsEmpty())
     dbSettings.name = GetBaseDBName();
 
+  CStdString dbName = dbSettings.name;
+  dbName.AppendFormat("%d", GetMinVersion());
+  if (!Connect(dbName, dbSettings, false) || GetDBVersion() != GetMinVersion())
+  {
+    if (!Update(dbSettings))
+      return false;
+  }
+  return true;
+}
+
+bool CDatabase::Update(const DatabaseSettings &dbSettings)
+{
   int version = GetMinVersion();
   CStdString latestDb = dbSettings.name;
   latestDb.AppendFormat("%d", version);

--- a/xbmc/Database.cpp
+++ b/xbmc/Database.cpp
@@ -24,7 +24,6 @@
 #include "utils/Crc32.h"
 #include "filesystem/SpecialProtocol.h"
 #include "filesystem/File.h"
-#include "utils/SingleLock.h"
 #include "utils/AutoPtrHandle.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
@@ -35,8 +34,6 @@ using namespace AUTOPTR;
 using namespace dbiplus;
 
 #define MAX_COMPRESS_COUNT 20
-
-std::map<std::string, bool> CDatabase::m_updated;
 
 void CDatabase::Filter::AppendField(const std::string &strField)
 {
@@ -488,10 +485,6 @@ bool CDatabase::Connect(const DatabaseSettings &dbSettings, bool create)
 
 bool CDatabase::UpdateVersion(const CStdString &dbName)
 {
-  CSingleLock lock(m_critSect);
-  if (m_updated[dbName])
-    return true;
-
   int version = 0;
   m_pDS->query("SELECT idVersion FROM version\n");
   if (m_pDS->num_rows() > 0)
@@ -513,8 +506,6 @@ bool CDatabase::UpdateVersion(const CStdString &dbName)
     CLog::Log(LOGERROR, "Can't open the database %s as it is a NEWER version than what we were expecting?", dbName.c_str());
     return false;
   }
-
-  m_updated[dbName] = true;
   return true;
 }
 

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -138,6 +138,7 @@ public:
   virtual bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, Filter &filter, CStdString &strSQL, CDbUrl &dbUrl, SortDescription &sorting);
 
 protected:
+  friend class CDatabaseManager;
   bool Update(const DatabaseSettings &db);
 
   void Split(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -19,15 +19,14 @@
  *  <http://www.gnu.org/licenses/>.
  *
  */
-#include <map>
-#include <memory>
 
-#include "utils/CriticalSection.h"
 #include "utils/StdString.h"
 // #include "lib/sqLite/mysqldataset.h"
 #include "lib/sqLite/sqlitedataset.h"
 
-struct DatabaseSettings; // forward
+#include <memory>
+
+class DatabaseSettings; // forward
 class CDbUrl;
 struct SortDescription;
 
@@ -166,7 +165,4 @@ private:
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
 
   unsigned int m_openCount;
-
-  CCriticalSection m_critSect;
-  static std::map<std::string, bool> m_updated;
 };

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -162,6 +162,7 @@ protected:
   std::auto_ptr<dbiplus::Dataset> m_pDS2;
 
 private:
+  void InitSettings(DatabaseSettings &dbSettings);
   bool Connect(const CStdString &dbName, const DatabaseSettings &db, bool create);
   bool UpdateVersionNumber();
 

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -148,6 +148,7 @@ protected:
   virtual int GetMinVersion() const=0;
   virtual const char *GetBaseDBName() const=0;
 
+  int GetDBVersion();
   bool UpdateVersion(const CStdString &dbName);
 
   bool BuildSQL(const CStdString &strQuery, const Filter &filter, CStdString &strSQL);

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -147,12 +147,9 @@ protected:
   virtual bool UpdateOldVersion(int version) { return true; };
 
   virtual int GetMinVersion() const=0;
-  virtual const char *GetDefaultDBName() const=0;
+  virtual const char *GetBaseDBName() const=0;
 
   bool UpdateVersion(const CStdString &dbName);
-
-  bool m_bOpen;
-  CStdString m_strDatabaseFile;
 
   bool BuildSQL(const CStdString &strQuery, const Filter &filter, CStdString &strSQL);
 
@@ -168,7 +165,7 @@ private:
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */
 
-  int m_iRefCount;
+  unsigned int m_openCount;
 
   CCriticalSection m_critSect;
   static std::map<std::string, bool> m_updated;

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -159,7 +159,7 @@ protected:
   std::auto_ptr<dbiplus::Dataset> m_pDS2;
 
 private:
-  bool Connect(const DatabaseSettings &db, bool create);
+  bool Connect(const CStdString &dbName, const DatabaseSettings &db, bool create);
   bool UpdateVersionNumber();
 
   bool m_bMultiWrite; /*!< True if there are any queries in the queue, false otherwise */

--- a/xbmc/Database.h
+++ b/xbmc/Database.h
@@ -138,6 +138,8 @@ public:
   virtual bool BuildSQL(const CStdString &strBaseDir, const CStdString &strQuery, Filter &filter, CStdString &strSQL, CDbUrl &dbUrl, SortDescription &sorting);
 
 protected:
+  bool Update(const DatabaseSettings &db);
+
   void Split(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);
   DWORD ComputeCRC(const CStdString &text);
 

--- a/xbmc/DatabaseManager.cpp
+++ b/xbmc/DatabaseManager.cpp
@@ -1,0 +1,91 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "DatabaseManager.h"
+#include "utils/log.h"
+#include "addons/AddonDatabase.h"
+#include "ViewDatabase.h"
+#include "ProgramDatabase.h"
+#include "music/MusicDatabase.h"
+#include "video/VideoDatabase.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/SingleLock.h" // this include should be removed after PR209
+
+using namespace std;
+
+CDatabaseManager &CDatabaseManager::Get()
+{
+  static CDatabaseManager s_manager;
+  return s_manager;
+}
+
+CDatabaseManager::CDatabaseManager()
+{
+}
+
+CDatabaseManager::~CDatabaseManager()
+{
+}
+
+void CDatabaseManager::Initialize(bool addonsOnly)
+{
+  Deinitialize();
+  { CAddonDatabase db; UpdateDatabase(db); }
+  if (addonsOnly)
+    return;
+  CLog::Log(LOGDEBUG, "%s, updating databases...", __FUNCTION__);
+  { CViewDatabase db; UpdateDatabase(db); }
+  { CProgramDatabase db; UpdateDatabase(db); }
+  { CMusicDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseMusic); }
+  { CVideoDatabase db; UpdateDatabase(db, &g_advancedSettings.m_databaseVideo); }
+  CLog::Log(LOGDEBUG, "%s, updating databases... DONE", __FUNCTION__);
+}
+
+void CDatabaseManager::Deinitialize()
+{
+  CSingleLock lock(m_section);
+  m_dbStatus.clear();
+}
+
+bool CDatabaseManager::CanOpen(const std::string &name)
+{
+  CSingleLock lock(m_section);
+  map<string, DB_STATUS>::const_iterator i = m_dbStatus.find(name);
+  if (i != m_dbStatus.end())
+    return i->second == DB_READY;
+  return false; // db isn't even attempted to update yet
+}
+
+void CDatabaseManager::UpdateDatabase(CDatabase &db, DatabaseSettings *settings)
+{
+  std::string name = db.GetBaseDBName();
+  UpdateStatus(name, DB_UPDATING);
+  if (db.Update(settings ? *settings : DatabaseSettings()))
+    UpdateStatus(name, DB_READY);
+  else
+    UpdateStatus(name, DB_FAILED);
+}
+
+void CDatabaseManager::UpdateStatus(const std::string &name, DB_STATUS status)
+{
+  CSingleLock lock(m_section);
+  m_dbStatus[name] = status;
+}

--- a/xbmc/DatabaseManager.h
+++ b/xbmc/DatabaseManager.h
@@ -1,0 +1,78 @@
+/*
+ *      Copyright (C) 2012 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#pragma once
+
+#include <map>
+#include <string>
+#include "utils/CriticalSection.h"
+#include "utils/Event.h"
+
+class CDatabase;
+class DatabaseSettings;
+
+/*!
+ \ingroup database
+ \brief Database manager class for handling database updating
+ Ensures that databases used in XBMC are up to date, and if a database can't be
+ opened, ensures we don't continuously try it.
+ */
+class CDatabaseManager
+{
+public:
+  /*!
+   \brief The only way through which the global instance of the CDatabaseManager should be accessed.
+   \return the global instance.
+   */
+  static CDatabaseManager &Get();
+
+  /*! \brief Initalize the database manager
+   Checks that all databases are up to date, otherwise updates them.
+   */
+  void Initialize(bool addonsOnly = false);
+
+  /*! \brief Deinitialize the database manager
+   */
+  void Deinitialize();
+
+  /*! \brief Check whether we can open a database.
+   Checks whether the database has been updated correctly, if so returns true.
+   If the database update failed, returns false immediately.
+   If the database update is in progress, returns false.
+   \param name the name of the database to check.
+   \return true if the database can be opened, false otherwise.
+   */ 
+  bool CanOpen(const std::string &name);
+
+private:
+  // private construction, and no assignements; use the provided singleton methods
+  CDatabaseManager();
+  CDatabaseManager(const CDatabaseManager&);
+  CDatabaseManager const& operator=(CDatabaseManager const&);
+  virtual ~CDatabaseManager();
+
+  enum DB_STATUS { DB_CLOSED, DB_UPDATING, DB_READY, DB_FAILED };
+  void UpdateStatus(const std::string &name, DB_STATUS status);
+  void UpdateDatabase(CDatabase &db, DatabaseSettings *settings = NULL);
+
+  CCriticalSection            m_section;     ///< Critical section protecting m_dbStatus.
+  std::map<std::string, DB_STATUS> m_dbStatus;    ///< Our database status map.
+};

--- a/xbmc/ProgramDatabase.h
+++ b/xbmc/ProgramDatabase.h
@@ -64,7 +64,7 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 3; };
-  const char *GetDefaultDBName() const { return "MyPrograms6"; };
+  const char *GetBaseDBName() const { return "MyPrograms"; };
 
   FILETIME TimeStampToLocalTime( unsigned __int64 timeStamp );
 };

--- a/xbmc/ViewDatabase.h
+++ b/xbmc/ViewDatabase.h
@@ -37,5 +37,5 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 6; };
-  const char *GetDefaultDBName() const { return "ViewModes"; };
+  const char *GetBaseDBName() const { return "ViewModes"; };
 };

--- a/xbmc/addons/AddonDatabase.h
+++ b/xbmc/addons/AddonDatabase.h
@@ -102,5 +102,5 @@ protected:
   virtual bool CreateTables();
   virtual bool UpdateOldVersion(int version);
   virtual int GetMinVersion() const { return 15; }
-  const char *GetDefaultDBName() const { return "Addons"; }
+  const char *GetBaseDBName() const { return "Addons"; }
 };

--- a/xbmc/lib/sqLite/dataset.h
+++ b/xbmc/lib/sqLite/dataset.h
@@ -79,7 +79,7 @@ public:
   virtual ~Database();
   virtual Dataset *CreateDataset() const = 0;
 /* sets a new host name */
-  void setHostName(const char *newHost) { host = newHost; }
+  virtual void setHostName(const char *newHost) { host = newHost; }
 /* gets a host name */
   const char *getHostName(void) const { return host.c_str(); }
 /* sets a new port */
@@ -87,7 +87,7 @@ public:
 /* gets a port */
   const char *getPort(void) const { return port.c_str(); }
 /* sets a new database name */
-  void setDatabase(const char *newDb) { db = newDb; }
+  virtual void setDatabase(const char *newDb) { db = newDb; }
 /* gets a database name */
   const char *getDatabase(void) const { return db.c_str(); }
 /* sets a new login to database */
@@ -121,6 +121,9 @@ public:
   virtual int create(void) { return DB_COMMAND_OK; }
   virtual int drop(void) { return DB_COMMAND_OK; }
   virtual long nextid(const char* seq_name)=0;
+
+/* \brief copy database */
+  virtual int copy(const char *new_name) { return -1; }
 
   virtual bool exists(void) { return false; }
 

--- a/xbmc/lib/sqLite/sqlitedataset.cpp
+++ b/xbmc/lib/sqLite/sqlitedataset.cpp
@@ -29,11 +29,17 @@
 
 #include "system.h"
 #include <iostream>
+#ifdef _XBOX
+#include <fstream>
+#endif
 #include <string>
 
 #include "sqlitedataset.h"
 #include "utils/log.h"
 #include "utils/URIUtils.h"
+#ifdef _XBOX
+#include "filesystem/File.h"
+#endif
 
 using namespace std;
 
@@ -213,13 +219,15 @@ int SqliteDatabase::connect(bool create) {
   try
   {
     disconnect();
-#ifndef _XBOX
     // TODO: sqLite 3.5 added sqlite3_open_v2 function. Try porting it and then use this block
+#ifndef _XBOX
     int flags = SQLITE_OPEN_READWRITE;
     if (create)
       flags |= SQLITE_OPEN_CREATE;
     if (sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL)==SQLITE_OK)
 #else
+    if (!create && !XFILE::CFile::Exists(db_fullpath))
+      return DB_CONNECTION_NONE;
     if (sqlite3_open(db_fullpath.c_str(), &conn)==SQLITE_OK)
 #endif
     {
@@ -311,7 +319,24 @@ int SqliteDatabase::copy(const char *backup_name) {
 
   (void)sqlite3_close(pFile);
 #else
-  // TODO: manually duplicate original DB file
+  if (backup_name[0] == '/' || backup_name[0] == '\\')
+    backup_db = backup_db.substr(1);
+
+  // ensure the ".db" extension is appended to the end
+  if ( backup_db.find(".db") != (backup_db.length()-3) )
+    backup_db += ".db";
+
+  string backup_path = URIUtils::AddFileToFolder(host, backup_db);
+  string original_path = URIUtils::AddFileToFolder(host, db);
+
+  ifstream original_file(original_path.c_str(), ios::binary);
+  ofstream destination_file(backup_path.c_str(), ios::binary);
+
+  if (!original_file.is_open() || !destination_file.is_open())
+    throw exception();
+
+  destination_file << original_file.rdbuf();
+  rc = 1;
 #endif
   return rc;
 }

--- a/xbmc/lib/sqLite/sqlitedataset.cpp
+++ b/xbmc/lib/sqLite/sqlitedataset.cpp
@@ -33,6 +33,7 @@
 
 #include "sqlitedataset.h"
 #include "utils/log.h"
+#include "utils/URIUtils.h"
 
 using namespace std;
 
@@ -106,6 +107,40 @@ Dataset* SqliteDatabase::CreateDataset() const {
 	return new SqliteDataset((SqliteDatabase*)this); 
 }
 
+void SqliteDatabase::setHostName(const char *newHost) {
+  host = newHost;
+
+  // hostname is the relative folder to the database, ensure it's slash terminated
+  if (host[host.length()-1] != '/' && host[host.length()-1] != '\\')
+    host += "/";
+
+  // ensure the fully qualified path has slashes in the correct direction
+  if ( (host[1] == ':') && isalpha(host[0]))
+  {
+    size_t pos = 0;
+    while ( (pos = host.find("/", pos)) != string::npos )
+      host.replace(pos++, 1, "\\");
+  }
+  else
+  {
+    size_t pos = 0;
+    while ( (pos = host.find("\\", pos)) != string::npos )
+      host.replace(pos++, 1, "/");
+  }
+}
+
+void SqliteDatabase::setDatabase(const char *newDb) {
+  db = newDb;
+
+  // db is the filename for the database, ensure it's not slash prefixed
+  if (newDb[0] == '/' || newDb[0] == '\\')
+    db = db.substr(1);
+
+  // ensure the ".db" extension is appended to the end
+  if ( db.find(".db") != (db.length()-3) )
+    db += ".db";
+}
+
 int SqliteDatabase::status(void) {
   if (active == false) return DB_CONNECTION_NONE;
   return DB_CONNECTION_OK;
@@ -171,46 +206,22 @@ int SqliteDatabase::connect(bool create) {
   if (host.empty() || db.empty())
     return DB_CONNECTION_NONE;
 
-  string db_fullpath;
-  // hostname is the relative folder to the database, ensure it's slash terminated
-  if (host[host.length()-1] != '/' && host[host.length()-1] != '\\')
-    db_fullpath = host + "/";
-  else
-    db_fullpath = host;
+  CLog::Log(LOGDEBUG, "Connecting to sqlite:%s:%s", host.c_str(), db.c_str());
 
-  // db is the filename for the database, ensure it's not slash prefixed
-  if (db[0] == '/' || db[0] == '\\')
-    db_fullpath += db.substr(1);
-  else
-    db_fullpath += db;
-
-  // ensure the fully qualified path has slashes in the correct direction
-  if ( (db_fullpath[1] == ':') && isalpha(db_fullpath[0]))
-  {
-    size_t pos = 0;
-    while ( (pos = db_fullpath.find("/", pos)) != string::npos )
-      db_fullpath.replace(pos++, 1, "\\");
-  }
-  else
-  {
-    size_t pos = 0;
-    while ( (pos = db_fullpath.find("\\", pos)) != string::npos )
-      db_fullpath.replace(pos++, 1, "/");
-  }
-
-  // ensure the ".db" extension is appended to the end
-  if ( db_fullpath.find(".db") != (db_fullpath.length()-3) )
-    db_fullpath += ".db";
+  string db_fullpath = URIUtils::AddFileToFolder(host, db);
 
   try
   {
     disconnect();
-    if (sqlite3_open(db_fullpath.c_str(), &conn)==SQLITE_OK)
-    // TODO: sqLite 3.5 added sqlite3_open_v2 function. Try porting it and then uncomment this code
-    /*int flags = SQLITE_OPEN_READWRITE;
+#ifndef _XBOX
+    // TODO: sqLite 3.5 added sqlite3_open_v2 function. Try porting it and then use this block
+    int flags = SQLITE_OPEN_READWRITE;
     if (create)
       flags |= SQLITE_OPEN_CREATE;
-    if (sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL)==SQLITE_OK)*/
+    if (sqlite3_open_v2(db_fullpath.c_str(), &conn, flags, NULL)==SQLITE_OK)
+#else
+    if (sqlite3_open(db_fullpath.c_str(), &conn)==SQLITE_OK)
+#endif
     {
       sqlite3_busy_handler(conn, busy_callback, NULL);
       char* err=NULL;
@@ -257,6 +268,52 @@ void SqliteDatabase::disconnect(void) {
 
 int SqliteDatabase::create() {
   return connect(true);
+}
+
+int SqliteDatabase::copy(const char *backup_name) {
+  if (active == false) throw DbErrors("Can't copy database: no active connection...");
+
+  CLog::Log(LOGDEBUG, "Copying from %s to %s at %s", backup_name, db.c_str(), host.c_str());
+
+  int rc;
+  string backup_db = backup_name;
+
+  // Our SQLite currently doesn't support 'sqlite3_backup'. When we get SQLite 3.6.11 compiled for Xbox use code inside this block
+#ifndef _XBOX
+  sqlite3 *pFile;           /* Database connection opened on zFilename */
+  sqlite3_backup *pBackup;  /* Backup object used to copy data */
+
+  //
+  if (backup_name[0] == '/' || backup_name[0] == '\\')
+    backup_db = backup_db.substr(1);
+
+  // ensure the ".db" extension is appended to the end
+  if ( backup_db.find(".db") != (backup_db.length()-3) )
+    backup_db += ".db";
+
+  string backup_path = host + backup_db;
+
+  /* Open the database file identified by zFilename. Exit early if this fails
+  ** for any reason. */
+  rc = sqlite3_open(backup_path.c_str(), &pFile);
+  if( rc==SQLITE_OK )
+  {
+    pBackup = sqlite3_backup_init(pFile, "main", getHandle(), "main");
+
+    if( pBackup )
+    {
+      (void)sqlite3_backup_step(pBackup, -1);
+      (void)sqlite3_backup_finish(pBackup);
+    }
+
+    rc = sqlite3_errcode(pFile);
+  }
+
+  (void)sqlite3_close(pFile);
+#else
+  // TODO: manually duplicate original DB file
+#endif
+  return rc;
 }
 
 int SqliteDatabase::drop() {

--- a/xbmc/lib/sqLite/sqlitedataset.h
+++ b/xbmc/lib/sqLite/sqlitedataset.h
@@ -61,8 +61,13 @@ public:
   virtual int setErr(int err_code,const char * qry);
 /* func. returns error message if error occurs */
   virtual const char *getErrorMsg();
-  
+/* sets a new host name */
+  virtual void setHostName(const char *newHost);
+/* sets a database name */
+  virtual void setDatabase(const char *newDb);
+
 /* func. connects to database-server */
+
   virtual int connect(bool create);
 /* func. disconnects from database-server */
   virtual void disconnect();
@@ -72,6 +77,9 @@ public:
   virtual int drop();
 /* check if database exists (ie has tables/views defined) */
   virtual bool exists();
+
+/* \brief copy database */
+  virtual int copy(const char *backup_name);
 
   virtual long nextid(const char* seq_name);
 

--- a/xbmc/music/MusicDatabase.cpp
+++ b/xbmc/music/MusicDatabase.cpp
@@ -3416,6 +3416,8 @@ bool CMusicDatabase::UpdateOldVersion(int version)
   if (NULL == m_pDS.get()) return false;
   if (NULL == m_pDS2.get()) return false;
 
+  BeginTransaction();
+
   try
   {
     if (version < 6)
@@ -3559,9 +3561,12 @@ bool CMusicDatabase::UpdateOldVersion(int version)
       m_pDS->exec("CREATE INDEX idxSong4 ON song(idArtist)");
       m_pDS->exec("CREATE INDEX idxSong5 ON song(idGenre)");
       m_pDS->exec("CREATE INDEX idxSong6 ON song(idPath)");
-
-      CreateViews();
     }
+
+    // always recreate the views after any table change
+    CreateViews();
+
+    CommitTransaction();
   }
   catch (...)
   {

--- a/xbmc/music/MusicDatabase.h
+++ b/xbmc/music/MusicDatabase.h
@@ -210,7 +210,7 @@ protected:
   std::map<CStdString, int> m_pathCache;
   std::map<CStdString, int> m_thumbCache;
   std::map<CStdString, CAlbum> m_albumCache;
-  const char *GetDefaultDBName() const { return "MyMusic7"; };
+  const char *GetBaseDBName() const { return "MyMusic"; };
 
   virtual bool CreateTables();
   virtual int GetMinVersion() const { return 16; };

--- a/xbmc/settings/AdvancedSettings.h
+++ b/xbmc/settings/AdvancedSettings.h
@@ -25,8 +25,9 @@
 #include "utils/StdString.h"
 #include "utils/StringUtils.h"
 
-struct DatabaseSettings
+class DatabaseSettings
 {
+public:
   CStdString type;
   CStdString host;
   CStdString port;

--- a/xbmc/settings/Settings.cpp
+++ b/xbmc/settings/Settings.cpp
@@ -61,6 +61,7 @@
 #include "utils/log.h"
 #include "utils/FileUtils.h"
 #include "addons/AddonManager.h"
+#include "DatabaseManager.h"
 
 using namespace std;
 using namespace XFILE;
@@ -1232,6 +1233,8 @@ bool CSettings::LoadProfile(unsigned int index)
 
     CButtonTranslator::GetInstance().Load();
     g_localizeStrings.Load("special://xbmc/language/", strLanguage);
+
+    CDatabaseManager::Get().Initialize();
 
     g_infoManager.ResetCache();
     g_infoManager.ResetLibraryBools();

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -58,7 +58,6 @@ using namespace ADDON;
 //********************************************************************************************************************************
 CVideoDatabase::CVideoDatabase(void)
 {
-  m_strDatabaseFile=GetDefaultDBName(); 
 }
 
 //********************************************************************************************************************************
@@ -3634,9 +3633,6 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
 {
   BeginTransaction();
 
-  // when adding/removing an index or altering the table ensure that you call
-  // CreateViews() after all modifications.
-
   try
   {
     if (iVersion < 4)
@@ -4170,10 +4166,6 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("DROP INDEX ix_bookmark");
       m_pDS->exec("CREATE INDEX ix_bookmark ON bookmark (idFile, type)");
     }
-    if (iVersion < 40)
-    {
-      CreateViews();
-    }
     if (iVersion < 41)
     {
       // Add iOrder fields to actorlink* tables to be able to list
@@ -4181,10 +4173,6 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("ALTER TABLE actorlinkmovie ADD iOrder integer");
       m_pDS->exec("ALTER TABLE actorlinktvshow ADD iOrder integer");
       m_pDS->exec("ALTER TABLE actorlinkepisode ADD iOrder integer");
-    }
-    if ( iVersion < 42 )
-    {
-      CreateViews();
     }
     if (iVersion < 43)
     {
@@ -4210,6 +4198,9 @@ bool CVideoDatabase::UpdateOldVersion(int iVersion)
       m_pDS->exec("ALTER TABLE path ADD dateAdded text");
       m_pDS->exec("ALTER TABLE files ADD dateAdded text");
     }
+
+    // always recreate the view after any table change
+    CreateViews();
   }
   catch (...)
   {

--- a/xbmc/video/VideoDatabase.h
+++ b/xbmc/video/VideoDatabase.h
@@ -812,7 +812,7 @@ private:
   bool LookupByFolders(const CStdString &path, bool shows = false);
   
   virtual int GetMinVersion() const { return 69; };
-  const char *GetDefaultDBName() const { return "MyVideos34.db"; };
+  const char *GetBaseDBName() const { return "MyVideos"; };
 
   void ConstructPath(CStdString& strDest, const CStdString& strPath, const CStdString& strFileName);
   void SplitPath(const CStdString& strFileNameAndPath, CStdString& strPath, CStdString& strFileName);


### PR DESCRIPTION
- This is backport of [#1128](https://github.com/xbmc/xbmc/pull/1128)

This PR slightly refactors a way how databases are created, updated etc. Since we are using really outdated SQLite (3.2.7) which doesn't support read-only access to DB file and it's missing support for creating backups, commit bb826ca2d920031f1cc86f07e9618b1e0b3395e1 added some workarounds for those missing features.

- SqliteDatabase::connect(bool create) -> this method is using sqlite3_open_v2 function which is introduced in **SQLite 3.5**. From my understanding, based on input parameter **create* this function will do:
  -  create = true -> check for existance of database. if it doesn't exists it will create new database and open connection to it
  - create = false -> check for existance of database. if it exists it will open connection else it will return DB_CONNECTION_NONE
- SqliteDatabase::copy(const char *backup_name) -> this method will copy current connected database to new database. This will result in new .db file on HDD. This method is using **sqlite3_backup** which was added in SQLite 3.6.11. Since we don't have this version of SQLite I added workaround which will copy current database file to new database file (backup_name.db)