### PR TITLE
[Threading] added CTimer threading class from xbmc mainline

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -3069,6 +3069,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 				<File
 					RelativePath=".\xbmc\threads\Thread.h">
 				</File>
+				<File
+					RelativePath=".\xbmc\threads\Timer.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\threads\Timer.h">
+				</File>
 			</Filter>
 			<Filter
 				Name="view"

--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -3058,6 +3058,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					RelativePath=".\xbmc\threads\SingleLock.h">
 				</File>
 				<File
+					RelativePath=".\xbmc\threads\SystemClock.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\threads\SystemClock.h">
+				</File>
+				<File
 					RelativePath=".\xbmc\threads\Thread.cpp">
 				</File>
 				<File

--- a/xbmc/BackgroundInfoLoader.cpp
+++ b/xbmc/BackgroundInfoLoader.cpp
@@ -139,10 +139,9 @@ void CBackgroundInfoLoader::Load(CFileItemList& items)
   m_nActiveThreads = nThreads;
   for (int i=0; i < nThreads; i++)
   {
-    CThread *pThread = new CThread(this); 
+    CThread *pThread = new CThread(this, "Background Loader");
     pThread->Create();
     pThread->SetPriority(THREAD_PRIORITY_BELOW_NORMAL);
-    pThread->SetName("Background Loader");
     m_workers.push_back(pThread);
   }
       

--- a/xbmc/addons/AddonStatusHandler.cpp
+++ b/xbmc/addons/AddonStatusHandler.cpp
@@ -42,6 +42,7 @@ namespace ADDON
 CCriticalSection CAddonStatusHandler::m_critSection;
 
 CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS status, CStdString message, bool sameThread)
+  : CThread("CAddonStatusHandler:" + addonID)
 {
   if (!CAddonMgr::Get().GetAddon(addonID, m_addon))
     return;
@@ -57,11 +58,7 @@ CAddonStatusHandler::CAddonStatusHandler(const CStdString &addonID, ADDON_STATUS
   }
   else
   {
-    CStdString ThreadName;
-    ThreadName.Format("Addon Status: %s", m_addon->Name().c_str());
-
     Create(true, THREAD_MINSTACKSIZE);
-    SetName(ThreadName.c_str());
     SetPriority(-15);
   }
 }

--- a/xbmc/cores/VideoRenderers/RenderManager.cpp
+++ b/xbmc/cores/VideoRenderers/RenderManager.cpp
@@ -50,7 +50,7 @@ void VBlankCallback(D3DVBLANKDATA *pData)
 }
 
 
-CXBoxRenderManager::CXBoxRenderManager()
+CXBoxRenderManager::CXBoxRenderManager() : CThread("AsyncRenderer")
 {
   m_pRenderer = NULL;
   m_bPauseDrawing = false;
@@ -441,7 +441,6 @@ void CXBoxRenderManager::Process()
   float actualdelay = (float)m_presentdelay;
 
   SetPriority(THREAD_PRIORITY_TIME_CRITICAL);
-  SetName("AsyncRenderer");
   while( !m_bStop )
   {
     //Wait for new frame or an stop event

--- a/xbmc/cores/dvdplayer/DVDFileInfo.cpp
+++ b/xbmc/cores/dvdplayer/DVDFileInfo.cpp
@@ -18,13 +18,13 @@
  *
  */
 
-#include "utils/log.h"
+#include "threads/SystemClock.h"
 #include "FileItem.h"
 #include "settings/AdvancedSettings.h"
 #include "pictures/Picture.h"
 #include "video/VideoInfoTag.h"
-#include "Util.h"
 #include "filesystem/StackDirectory.h"
+#include "utils/log.h"
 
 #include "DVDFileInfo.h"
 #include "DVDStreamInfo.h"
@@ -246,7 +246,7 @@ bool CDVDFileInfo::ExtractThumb(const CStdString &strPath, const CStdString &str
       file.Close();
   }
 
-  int nTotalTime = CTimeUtils::GetTimeMS() - nTime;
+  int nTotalTime = XbmcThreads::SystemClockMillis() - nTime;
   CLog::Log(LOGDEBUG,"%s - measured %d ms to extract thumb from file <%s> ", __FUNCTION__, nTotalTime, strPath.c_str());
   return bOk;
 }

--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
@@ -337,7 +337,7 @@ void CSelectionStreams::Update(CDVDInputStream* input, CDVDDemux* demuxer)
 
 CDVDPlayer::CDVDPlayer(IPlayerCallback& callback)
     : IPlayer(callback),
-      CThread(),
+      CThread("CDVDPlayer"),
       m_CurrentAudio(STREAM_AUDIO, DVDPLAYER_AUDIO),
       m_CurrentVideo(STREAM_VIDEO, DVDPLAYER_VIDEO),
       m_CurrentSubtitle(STREAM_SUBTITLE, DVDPLAYER_SUBTITLE),
@@ -471,7 +471,6 @@ bool CDVDPlayer::IsPlaying() const
 
 void CDVDPlayer::OnStartup()
 {
-  CThread::SetName("CDVDPlayer");
   m_CurrentVideo.Clear();
   m_CurrentAudio.Clear();
   m_CurrentSubtitle.Clear();

--- a/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerAudio.cpp
@@ -90,7 +90,7 @@ public:
 
 
 CDVDPlayerAudio::CDVDPlayerAudio(CDVDClock* pClock, CDVDMessageQueue& parent)
-: CThread()
+: CThread("CDVDPlayerAudio")
 , m_messageQueue("audio")
 , m_messageParent(parent)
 , m_dvdAudio((bool&)m_bStop)
@@ -437,8 +437,6 @@ int CDVDPlayerAudio::DecodeFrame(DVDAudioFrame &audioframe, bool bDropPacket)
 
 void CDVDPlayerAudio::OnStartup()
 {
-  CThread::SetName("CDVDPlayerAudio");
-
   m_decode.msg = NULL;
   m_decode.Release();
 

--- a/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
+++ b/xbmc/cores/dvdplayer/DVDPlayerVideo.cpp
@@ -61,7 +61,7 @@ public:
 CDVDPlayerVideo::CDVDPlayerVideo( CDVDClock* pClock
                                 , CDVDOverlayContainer* pOverlayContainer
                                 , CDVDMessageQueue& parent)
-: CThread()
+: CThread("CDVDPlayerVideo")
 , m_messageQueue("video")
 , m_messageParent(parent)
 {
@@ -216,7 +216,6 @@ void CDVDPlayerVideo::CloseStream(bool bWaitForBuffers)
 
 void CDVDPlayerVideo::OnStartup()
 {
-  CThread::SetName("CDVDPlayerVideo");
   m_iDroppedFrames = 0;
   
   m_iCurrentPts = DVD_NOPTS_VALUE;

--- a/xbmc/cores/mplayer/mplayer.cpp
+++ b/xbmc/cores/mplayer/mplayer.cpp
@@ -685,7 +685,8 @@ void CMPlayer::Options::GetOptions(int& argc, char* argv[])
 
 
 CMPlayer::CMPlayer(IPlayerCallback& callback)
-    : IPlayer(callback)
+    : IPlayer(callback),
+      CThread("MPlayer")
 {
   m_pDLL = NULL;
   m_bIsPlaying = false;
@@ -1352,7 +1353,6 @@ void CMPlayer::Process()
 {
   bool bHasVideo = HasVideo();
   bool bWaitingRestart = false;
-  CThread::SetName("MPlayer");
 
   if (!m_pDLL || !m_bIsPlaying) return;
 

--- a/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
+++ b/xbmc/dialogs/GUIDialogExtendedProgressBar.cpp
@@ -22,7 +22,7 @@
 #include "guilib/GUIProgressControl.h"
 #include "guilib/GUISliderControl.h"
 #include "threads/SingleLock.h"
-#include "utils/TimeUtils.h"
+#include "threads/SystemClock.h"
 
 #define CONTROL_LABELHEADER       30
 #define CONTROL_LABELTITLE        31
@@ -87,7 +87,7 @@ bool CGUIDialogExtendedProgressBar::OnMessage(CGUIMessage& message)
   {
   case GUI_MSG_WINDOW_INIT:
     {
-      m_iLastSwitchTime = CTimeUtils::GetTimeMS();
+      m_iLastSwitchTime = XbmcThreads::SystemClockMillis();
       CGUIDialog::OnMessage(message);
 
       UpdateState(0);
@@ -102,7 +102,7 @@ bool CGUIDialogExtendedProgressBar::OnMessage(CGUIMessage& message)
 void CGUIDialogExtendedProgressBar::Render()
 {
   if (m_bRunning)
-    UpdateState(CTimeUtils::GetTimeMS());
+    UpdateState(XbmcThreads::SystemClockMillis());
 
   CGUIDialog::Render();
 }

--- a/xbmc/filesystem/CircularCache.cpp
+++ b/xbmc/filesystem/CircularCache.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "threads/SystemClock.h"
 #include "utils/log.h"
 #include "threads/SingleLock.h"
 #include "utils/TimeUtils.h"
@@ -159,8 +160,8 @@ int64_t CCircularCache::WaitForData(unsigned int minumum, unsigned int millis)
   if(minumum > m_size - m_size_back)
     minumum = m_size - m_size_back;
 
-  unsigned int time = CTimeUtils::GetTimeMS() + millis;
-  while (!IsEndOfInput() && avail < minumum && CTimeUtils::GetTimeMS() < time )
+  unsigned int time = XbmcThreads::SystemClockMillis() + millis;
+  while (!IsEndOfInput() && avail < minumum && XbmcThreads::SystemClockMillis() < time )
   {
     lock.Leave();
     m_written.WaitMSec(50); // may miss the deadline. shouldn't be a problem.

--- a/xbmc/filesystem/DllLibCurl.cpp
+++ b/xbmc/filesystem/DllLibCurl.cpp
@@ -18,10 +18,11 @@
  *
  */
 
+#include "threads/SystemClock.h"
 #include "system.h"
-#include "utils/log.h"
 #include "DllLibCurl.h"
-#include "TimeUtils.h"
+#include "utils/log.h"
+#include "utils/TimeUtils.h"
 
 #include <assert.h>
 
@@ -75,7 +76,7 @@ void DllLibCurlGlobal::Unload()
 
   /* CheckIdle will clear this one up */
   if(g_curlReferences == 1)
-    g_curlTimeout = CTimeUtils::GetTimeMS();
+    g_curlTimeout = XbmcThreads::SystemClockMillis();
 }
 
 void DllLibCurlGlobal::CheckIdle()
@@ -115,7 +116,7 @@ void DllLibCurlGlobal::CheckIdle()
   }
 
   /* check if we should unload the dll */
-  if(g_curlReferences == 1 && CTimeUtils::GetTimeMS() > g_curlTimeout + idletime)
+  if(g_curlReferences == 1 && XbmcThreads::SystemClockMillis() > g_curlTimeout + idletime)
     Unload();
 }
 

--- a/xbmc/filesystem/FileCache.cpp
+++ b/xbmc/filesystem/FileCache.cpp
@@ -18,19 +18,20 @@
  *
  */
 
-#include "utils/log.h" 
-
-#include "AutoPtrHandle.h"
+#include "threads/SystemClock.h"
+#include "utils/AutoPtrHandle.h"
 #include "FileCache.h"
 #include "threads/Thread.h"
 #include "File.h"
 #include "URL.h"
+
+#include "CircularCache.h"
+#include "threads/SingleLock.h"
+#include "utils/log.h" 
 #include "utils/TimeUtils.h"
 #include "settings/AdvancedSettings.h"
 
 #include "MemBufferCache.h"
-#include "CircularCache.h"
-#include "threads/SingleLock.h"
 
 using namespace AUTOPTR;
 using namespace XFILE;
@@ -42,20 +43,20 @@ class CWriteRate
 public:
   CWriteRate()
   {
-    m_stamp = CTimeUtils::GetTimeMS();
+    m_stamp = XbmcThreads::SystemClockMillis();
     m_pos   = 0;
     m_pause = 0;
   }
 
   void Reset(int64_t pos)
   {
-    m_stamp = CTimeUtils::GetTimeMS();
+    m_stamp = XbmcThreads::SystemClockMillis();
     m_pos   = pos;
   }
 
   unsigned Rate(int64_t pos, unsigned int time_bias = 0)
   {
-    const unsigned ts = CTimeUtils::GetTimeMS() + time_bias;
+    const unsigned ts = XbmcThreads::SystemClockMillis() + time_bias;
     if (ts == m_stamp)
       return 0;
     return (unsigned)(1000 * (pos - m_pos) / (ts - m_stamp));
@@ -63,12 +64,12 @@ public:
 
   void Pause()
   {
-    m_pause = CTimeUtils::GetTimeMS();
+    m_pause = XbmcThreads::SystemClockMillis();
   }
 
   void Resume()
   {
-    m_stamp += CTimeUtils::GetTimeMS() - m_pause;
+    m_stamp += XbmcThreads::SystemClockMillis() - m_pause;
     m_pause  = 0;
   }
 

--- a/xbmc/filesystem/MythFile.cpp
+++ b/xbmc/filesystem/MythFile.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "utils/log.h"
+#include "threads/SystemClock.h"
 #include "inttypes.h"
 #include "MythFile.h"
 #include "DateTime.h"
@@ -27,6 +27,7 @@
 #include "DllLibCMyth.h"
 #include "URL.h"
 #include "DirectoryCache.h"
+#include "utils/log.h"
 #include "utils/TimeUtils.h"
 #include "threads/SingleLock.h"
 
@@ -255,7 +256,7 @@ bool CMythFile::SetupLiveTV(const CURL& url)
   }
 
   m_program = m_dll->recorder_get_cur_proginfo(m_recorder);
-  m_timestamp = CTimeUtils::GetTimeMS();
+  m_timestamp = XbmcThreads::SystemClockMillis();
 
   if(m_recording)
   {
@@ -545,9 +546,9 @@ bool CMythFile::UpdateItem(CFileItem& item)
 
 int CMythFile::GetTotalTime()
 {
-  if(m_recorder && (CTimeUtils::GetTimeMS() - m_timestamp) > 5000 )
+  if(m_recorder && (XbmcThreads::SystemClockMillis() - m_timestamp) > 5000 )
   {
-    m_timestamp = CTimeUtils::GetTimeMS();
+    m_timestamp = XbmcThreads::SystemClockMillis();
     if(m_program)
       m_dll->ref_release(m_program);
     m_program = m_dll->recorder_get_cur_proginfo(m_recorder);

--- a/xbmc/filesystem/MythSession.cpp
+++ b/xbmc/filesystem/MythSession.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "threads/SystemClock.h"
 #include "utils/log.h"
 #include "DllLibCMyth.h"
 #include "MythSession.h"
@@ -26,11 +27,10 @@
 #include "DateTime.h"
 #include "FileItem.h"
 #include "URL.h"
-#include "Util.h"
-#include "utils/TimeUtils.h"
-#include "utils/StringUtils.h"
 #include "utils/URIUtils.h"
+#include "utils/StringUtils.h"
 #include "threads/SingleLock.h"
+#include "utils/TimeUtils.h"
 
 extern "C"
 {
@@ -59,7 +59,7 @@ void CMythSession::CheckIdle()
   for (it = m_sessions.begin(); it != m_sessions.end(); )
   {
     CMythSession* session = *it;
-    if ((CTimeUtils::GetTimeMS() - session->m_timestamp) > (MYTH_IDLE_TIMEOUT * 1000) )
+    if ((XbmcThreads::SystemClockMillis() - session->m_timestamp) > (MYTH_IDLE_TIMEOUT * 1000) )
     {
       CLog::Log(LOGINFO, "%s - closing idle connection to MythTV backend: %s", __FUNCTION__, session->m_hostname.c_str());
       delete session;
@@ -97,7 +97,7 @@ void CMythSession::ReleaseSession(CMythSession* session)
 {
   CLog::Log(LOGDEBUG, "%s - Releasing MythTV session: %p", __FUNCTION__, session);
   session->SetListener(NULL);
-  session->m_timestamp = CTimeUtils::GetTimeMS();
+  session->m_timestamp = XbmcThreads::SystemClockMillis();
   CSingleLock lock(m_section_session);
   m_sessions.push_back(session);
 }
@@ -367,7 +367,7 @@ CMythSession::CMythSession(const CURL& url)
   m_username  = url.GetUserName() == "" ? MYTH_DEFAULT_USERNAME : url.GetUserName();
   m_password  = url.GetPassWord() == "" ? MYTH_DEFAULT_PASSWORD : url.GetPassWord();
   m_port      = url.HasPort() ? url.GetPort() : MYTH_DEFAULT_PORT;
-  m_timestamp = CTimeUtils::GetTimeMS();
+  m_timestamp = XbmcThreads::SystemClockMillis();
   m_dll = new DllLibCMyth;
   m_dll->Load();
   if (m_dll->IsLoaded())

--- a/xbmc/filesystem/ShoutcastFile.cpp
+++ b/xbmc/filesystem/ShoutcastFile.cpp
@@ -23,6 +23,7 @@
 //
 //////////////////////////////////////////////////////////////////////
 
+#include "threads/SystemClock.h"
 #include "system.h"
 #include "Application.h"
 #include "ShoutcastFile.h"
@@ -40,7 +41,7 @@ using namespace MUSIC_INFO;
 
 CShoutcastFile::CShoutcastFile()
 {
-  m_lastTime = CTimeUtils::GetTimeMS();
+  m_lastTime = XbmcThreads::SystemClockMillis();
   m_discarded = 0;
   m_currint = 0;
   m_buffer = NULL;
@@ -95,9 +96,9 @@ unsigned int CShoutcastFile::Read(void* lpBuf, int64_t uiBufSize)
     m_discarded += header*16+1;
     m_currint = 0;
   }
-  if (CTimeUtils::GetTimeMS() - m_lastTime > 500)
+  if (XbmcThreads::SystemClockMillis() - m_lastTime > 500)
   {
-    m_lastTime = CTimeUtils::GetTimeMS();
+    m_lastTime = XbmcThreads::SystemClockMillis();
     g_infoManager.SetCurrentSongTag(m_tag);
   }
 

--- a/xbmc/lib/libGoAhead/WebServer.cpp
+++ b/xbmc/lib/libGoAhead/WebServer.cpp
@@ -65,7 +65,7 @@ extern void		dbZero(int did);
 // Construction/Destruction
 //////////////////////////////////////////////////////////////////////
 
-CWebServer::CWebServer()
+CWebServer::CWebServer() : CThread("Webserver")
 {
   pXbmcWeb = new CXbmcWeb();
   if (!pXbmcWebConfig)
@@ -149,7 +149,6 @@ bool CWebServer::Start(const char *szLocalAddress, int port, const char_t* web, 
   Create(false, THREAD_MINSTACKSIZE);
   if (m_ThreadHandle == NULL) return false;  
 
-  CThread::SetName("Webserver");
   if( wait )
   {    
     // wait until the webserver is ready

--- a/xbmc/lib/libPython/XBPyThread.cpp
+++ b/xbmc/lib/libPython/XBPyThread.cpp
@@ -53,7 +53,7 @@ extern "C"
   char* dll_getenv(const char* szKey);
 }
 
-XBPyThread::XBPyThread(XBPython *pExecuter, int id)
+XBPyThread::XBPyThread(XBPython *pExecuter, int id) : CThread("XBPyThread")
 {
   CLog::Log(LOGDEBUG,"new python thread created. id=%d", id);
   m_pExecuter   = pExecuter;
@@ -108,11 +108,6 @@ int XBPyThread::setArgv(const std::vector<CStdString> &argv)
     strcpy(m_argv[i], argv[i].c_str());
   }
   return 0;
-}
-
-void XBPyThread::OnStartup()
-{
-  CThread::SetName("Python Thread");
 }
 
 void XBPyThread::Process()

--- a/xbmc/lib/libPython/XBPyThread.h
+++ b/xbmc/lib/libPython/XBPyThread.h
@@ -53,7 +53,6 @@ protected:
   int  m_id;
   ADDON::AddonPtr addon;
 
-  virtual void OnStartup();
   virtual void Process();
   virtual void OnExit();
   virtual void OnException();

--- a/xbmc/lib/libPython/XBPython.cpp
+++ b/xbmc/lib/libPython/XBPython.cpp
@@ -44,6 +44,7 @@ XBPython g_pythonParser;
 
 #define PYTHON_DLL "special://xbmc/system/python/python27.dll"
 
+#include "threads/SystemClock.h"
 #include "addons/Addon.h"
 #include "interfaces/AnnouncementManager.h"
 #include "xbmcmodule/PythonMonitor.h"
@@ -510,7 +511,7 @@ void XBPython::FinalizeScript()
     m_iDllScriptCounter--;
   else
     CLog::Log(LOGERROR, "Python script counter attempted to become negative");
-  m_endtime = CTimeUtils::GetTimeMS();
+  m_endtime = XbmcThreads::SystemClockMillis();
 }
 void XBPython::Finalize()
 {
@@ -589,7 +590,7 @@ void XBPython::Process()
       else ++it;
     }
 
-    if(m_iDllScriptCounter == 0 && m_endtime + 10000 < CTimeUtils::GetTimeMS())
+    if(m_iDllScriptCounter == 0 && m_endtime + 10000 < XbmcThreads::SystemClockMillis())
       Finalize();
   }
 }

--- a/xbmc/network/EventServer.cpp
+++ b/xbmc/network/EventServer.cpp
@@ -48,7 +48,7 @@ using namespace std;
 /* CEventServer                                                         */
 /************************************************************************/
 CEventServer* CEventServer::m_pInstance = NULL;
-CEventServer::CEventServer()
+CEventServer::CEventServer() : CThread("CEventServer")
 {
   m_pSocket       = NULL;
   m_pPacketBuffer = NULL;
@@ -110,7 +110,6 @@ void CEventServer::StartServer()
   }
 
   CThread::Create();
-  CThread::SetName("EventServer");
 }
 
 void CEventServer::StopServer()

--- a/xbmc/threads/SystemClock.cpp
+++ b/xbmc/threads/SystemClock.cpp
@@ -1,0 +1,57 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <stdint.h>
+
+#if   defined(TARGET_DARWIN)
+#include <mach/mach_time.h>
+#include <CoreVideo/CVHostTime.h>
+#elif defined(TARGET_WINDOWS)
+#include <windows.h>
+#elif defined(_XBOX)
+#include <xtl.h>
+#else
+#include <time.h>
+#endif
+
+namespace XbmcThreads
+{
+  unsigned int SystemClockMillis()
+  {
+    uint64_t now_time;
+    static uint64_t start_time = 0;
+    static bool start_time_set = false;
+#if defined(TARGET_DARWIN)
+    now_time = CVGetCurrentHostTime() *  1000 / CVGetHostClockFrequency();
+#elif defined(TARGET_WINDOWS) || defined(_XBOX)
+    now_time = (uint64_t)timeGetTime();
+#else
+    struct timespec ts = {};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    now_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+#endif
+    if (!start_time_set)
+    {
+      start_time = now_time;
+      start_time_set = true;
+    }
+    return (unsigned int)(now_time - start_time);
+  }
+}

--- a/xbmc/threads/SystemClock.h
+++ b/xbmc/threads/SystemClock.h
@@ -1,0 +1,64 @@
+/*
+ *      Copyright (C) 2005-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+#include <limits>
+
+namespace XbmcThreads
+{
+  /**
+   * This function returns the system clock's number of milliseconds but with
+   *  an arbitrary reference point. It handles the wrapping of any underlying
+   *  system clock by setting a starting point at the first call. It should
+   *  only be used for measuring time durations.
+   *
+   * Of course, on windows it just calls timeGetTime, so you're on your own.
+   */
+  unsigned int SystemClockMillis();
+
+  /**
+   * DO NOT compare the results from SystemClockMillis() to an expected end time
+   *  that was calculated by adding a number of milliseconds to some start time.
+   *  The reason is becuse the SystemClockMillis could wrap. Instead use this
+   *  class which uses differences (which are safe accross a wrap).
+   */
+  class EndTime
+  {
+    unsigned int startTime;
+    unsigned int totalWaitTime;
+  public:
+    inline EndTime() : startTime(0), totalWaitTime(0) {}
+    inline EndTime(unsigned int millisecondsIntoTheFuture) : startTime(SystemClockMillis()), totalWaitTime(millisecondsIntoTheFuture) {}
+
+    inline void Set(unsigned int millisecondsIntoTheFuture) { startTime = SystemClockMillis(); totalWaitTime = millisecondsIntoTheFuture; }
+
+    inline bool IsTimePast() { return totalWaitTime == 0 ? true : (SystemClockMillis() - startTime) >= totalWaitTime; }
+
+    inline unsigned int MillisLeft()
+    {
+      unsigned int timeWaitedAlready = (SystemClockMillis() - startTime);
+      return (timeWaitedAlready >= totalWaitTime) ? 0 : (totalWaitTime - timeWaitedAlready);
+    }
+
+    inline void SetExpired() { totalWaitTime = 0; }
+    inline void SetInfinite() { totalWaitTime = std::numeric_limits<unsigned int>::max(); }
+  };
+}

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -41,7 +41,7 @@ typedef struct tagTHREADNAME_INFO
   DWORD dwFlags; // reserved for future use, most be zero
 } THREADNAME_INFO;
 
-CThread::CThread()
+CThread::CThread(const char* ThreadName)
 {
   m_bStop = false;
 
@@ -54,9 +54,11 @@ CThread::CThread()
   m_StopEvent = CreateEvent(NULL, TRUE, TRUE, NULL);
 
   m_pRunnable=NULL;
+
+  m_ThreadName = ThreadName;
 }
 
-CThread::CThread(IRunnable* pRunnable)
+CThread::CThread(IRunnable* pRunnable, const char* ThreadName)
 {
   m_bStop = false;
 
@@ -69,6 +71,8 @@ CThread::CThread(IRunnable* pRunnable)
   m_StopEvent = CreateEvent(NULL, TRUE, TRUE, NULL);
 
   m_pRunnable=pRunnable;
+
+  m_ThreadName = ThreadName;
 }
 
 CThread::~CThread()

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -55,7 +55,8 @@ CThread::CThread(const char* ThreadName)
 
   m_pRunnable=NULL;
 
-  m_ThreadName = ThreadName;
+  if (ThreadName)
+    m_ThreadName = ThreadName;
 }
 
 CThread::CThread(IRunnable* pRunnable, const char* ThreadName)
@@ -72,7 +73,8 @@ CThread::CThread(IRunnable* pRunnable, const char* ThreadName)
 
   m_pRunnable=pRunnable;
 
-  m_ThreadName = ThreadName;
+  if (ThreadName)
+    m_ThreadName = ThreadName;
 }
 
 CThread::~CThread()
@@ -100,7 +102,10 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
   CUtil::InitRandomSeed();
 #endif
 
-//  CLog::Log(LOGDEBUG,"thread start, auto delete: %d",pThread->IsAutoDelete());
+  if (pThread->m_ThreadName.IsEmpty())
+    pThread->SetName(pThread->GetTypeName().c_str());
+
+  CLog::Log(LOGDEBUG,"Thread %s start, auto delete: %d", pThread->m_ThreadName.c_str(), pThread->IsAutoDelete());
 
   /* install win32 exception translator */
   win32_exception::install_handler();
@@ -123,7 +128,7 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
 #endif
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s - Unhandled exception caught in thread startup, aborting. auto delete: %d", __FUNCTION__, pThread->IsAutoDelete());
+    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread startup, aborting. auto delete: %d", __FUNCTION__, pThread->m_ThreadName.c_str(), pThread->IsAutoDelete());
     if( pThread->IsAutoDelete() )
     {
       delete pThread;
@@ -150,7 +155,7 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
 #endif
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s - Unhandled exception caught in thread process, attemping cleanup in OnExit", __FUNCTION__);
+    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread process, attemping cleanup in OnExit", __FUNCTION__, pThread->m_ThreadName.c_str());
   }
 
   try
@@ -169,17 +174,17 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
 #endif
   catch(...)
   {
-    CLog::Log(LOGERROR, "%s - Unhandled exception caught in thread exit", __FUNCTION__);
+    CLog::Log(LOGERROR, "%s - thread %s, Unhandled exception caught in thread exit", __FUNCTION__, pThread->m_ThreadName.c_str());
   }
 
   if ( pThread->IsAutoDelete() )
   {
-//    CLog::Log(LOGDEBUG,"Thread %"PRIu64" terminating (autodelete)", (uint64_t)CThread::GetCurrentThreadId());
+    // CLog::Log(LOGDEBUG,"Thread %s %"PRIu64" terminating (autodelete)", pThread->m_ThreadName.c_str(), (uint64_t)CThread::GetCurrentThreadId());
     delete pThread;
     pThread = NULL;
   }
 //  else
-//    CLog::Log(LOGDEBUG,"Thread %"PRIu64" terminating", (uint64_t)CThread::GetCurrentThreadId());  
+    // CLog::Log(LOGDEBUG,"Thread %s %"PRIu64" terminating", pThread->m_ThreadName.c_str(), (uint64_t)CThread::GetCurrentThreadId());
 #ifndef _LINUX
   _endthreadex(123);
 #endif
@@ -252,6 +257,8 @@ bool CThread::SetPriority(const int iPriority)
 
 void CThread::SetName( LPCTSTR szThreadName )
 {
+  m_ThreadName = szThreadName;
+
   THREADNAME_INFO info;
   info.dwType = 0x1000;
   info.szName = szThreadName;
@@ -266,6 +273,34 @@ void CThread::SetName( LPCTSTR szThreadName )
   {
   }
 #endif
+}
+
+// Get the thread name using the implementation dependant typeid() class
+// and attempt to clean it.
+CStdString CThread::GetTypeName(void)
+{
+  CStdString name = typeid(*this).name();
+
+#if defined(_MSC_VER)
+  // Visual Studio 2010 returns the name as "class CThread" etc
+  if (name.substr(0, 6) == "class ")
+    name = name.Right(name.length() - 6);
+#elif defined(__GNUC__) && !defined(__clang__)
+  // gcc provides __cxa_demangle to demangle the name
+  char* demangled = NULL;
+  int   status;
+
+  demangled = __cxa_demangle(name.c_str(), NULL, 0, &status);
+  if (status == 0)
+    name = demangled;
+  else
+    CLog::Log(LOGDEBUG,"%s, __cxa_demangle(%s) failed with status %d", __FUNCTION__, name.c_str(), status);
+
+  if (demangled)
+    free(demangled);
+#endif
+
+  return name;
 }
 
 bool CThread::WaitForThreadExit(DWORD dwMilliseconds)

--- a/xbmc/threads/Thread.cpp
+++ b/xbmc/threads/Thread.cpp
@@ -102,8 +102,9 @@ DWORD WINAPI CThread::staticThread(LPVOID* data)
   CUtil::InitRandomSeed();
 #endif
 
-  if (pThread->m_ThreadName.IsEmpty())
-    pThread->SetName(pThread->GetTypeName().c_str());
+  if (pThread->m_ThreadName.empty())
+    pThread->m_ThreadName = pThread->GetTypeName();
+  pThread->SetDebugCallStackName(pThread->m_ThreadName.c_str());
 
   CLog::Log(LOGDEBUG,"Thread %s start, auto delete: %d", pThread->m_ThreadName.c_str(), pThread->IsAutoDelete());
 
@@ -255,13 +256,11 @@ bool CThread::SetPriority(const int iPriority)
   }
 }
 
-void CThread::SetName( LPCTSTR szThreadName )
+void CThread::SetDebugCallStackName( const char *name )
 {
-  m_ThreadName = szThreadName;
-
   THREADNAME_INFO info;
   info.dwType = 0x1000;
-  info.szName = szThreadName;
+  info.szName = name;
   info.dwThreadID = m_ThreadId;
   info.dwFlags = 0;
 #ifndef _LINUX
@@ -277,14 +276,14 @@ void CThread::SetName( LPCTSTR szThreadName )
 
 // Get the thread name using the implementation dependant typeid() class
 // and attempt to clean it.
-CStdString CThread::GetTypeName(void)
+std::string CThread::GetTypeName(void)
 {
-  CStdString name = typeid(*this).name();
+  std::string name = typeid(*this).name();
 
 #if defined(_MSC_VER)
   // Visual Studio 2010 returns the name as "class CThread" etc
   if (name.substr(0, 6) == "class ")
-    name = name.Right(name.length() - 6);
+    name = name.substr(6, name.length() - 6);
 #elif defined(__GNUC__) && !defined(__clang__)
   // gcc provides __cxa_demangle to demangle the name
   char* demangled = NULL;

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -32,6 +32,7 @@
 
 #include "xbox/PlatformInclude.h"
 #include "Event.h"
+#include "utils/StdString.h"
 
 class IRunnable
 {
@@ -50,8 +51,8 @@ public:
 class CThread
 {
 public:
-  CThread(const char* ThreadName = "");
-  CThread(IRunnable* pRunnable, const char* ThreadName = "");
+  CThread(const char* ThreadName = NULL);
+  CThread(IRunnable* pRunnable, const char* ThreadName = NULL);
   virtual ~CThread();
   void Create(bool bAutoDelete = false, unsigned stacksize = 0);
   bool WaitForThreadExit(DWORD dwMilliseconds);
@@ -81,6 +82,9 @@ protected:
   HANDLE m_ThreadHandle;
 
 private:
+  CStdString GetTypeName(void);
+
+private:
   ThreadIdentifier ThreadId() const;
   bool m_bAutoDelete;
   HANDLE m_StopEvent;
@@ -92,7 +96,6 @@ private:
   unsigned __int64 m_iLastTime;
   float m_fLastUsage;
 
-protected:
   CStdString m_ThreadName;
 
 private:

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -64,6 +64,7 @@ public:
   operator HANDLE() const;
   bool IsAutoDelete() const;
   virtual void StopThread(bool bWait = true);
+  bool IsRunning() const { return m_ThreadHandle != NULL; };
   float GetRelativeUsage();  // returns the relative cpu usage of this thread since last call
   bool IsCurrentThread() const;
   int GetMinPriority(void);

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -29,10 +29,9 @@
 #pragma once
 #endif // _MSC_VER > 1000
 
-
+#include <string>
 #include "xbox/PlatformInclude.h"
 #include "Event.h"
-#include "utils/StdString.h"
 
 class IRunnable
 {
@@ -60,7 +59,6 @@ public:
   DWORD WaitForMultipleObjects(DWORD nCount, HANDLE *lpHandles, BOOL bWaitAll, DWORD dwMilliseconds);
   void Sleep(DWORD dwMilliseconds);
   bool SetPriority(const int iPriority);
-  void SetName( LPCTSTR szThreadName );
   HANDLE ThreadHandle();
   operator HANDLE();
   operator HANDLE() const;
@@ -82,7 +80,10 @@ protected:
   HANDLE m_ThreadHandle;
 
 private:
-  CStdString GetTypeName(void);
+  /*! \brief set the threadname for the debugger/callstack, implementation dependent.
+   */
+  void SetDebugCallStackName( const char *threadName );
+  std::string GetTypeName(void);
 
 private:
   ThreadIdentifier ThreadId() const;
@@ -96,7 +97,7 @@ private:
   unsigned __int64 m_iLastTime;
   float m_fLastUsage;
 
-  CStdString m_ThreadName;
+  std::string m_ThreadName;
 
 private:
   static DWORD WINAPI staticThread(LPVOID* data);

--- a/xbmc/threads/Thread.h
+++ b/xbmc/threads/Thread.h
@@ -50,8 +50,8 @@ public:
 class CThread
 {
 public:
-  CThread();
-  CThread(IRunnable* pRunnable);
+  CThread(const char* ThreadName = "");
+  CThread(IRunnable* pRunnable, const char* ThreadName = "");
   virtual ~CThread();
   void Create(bool bAutoDelete = false, unsigned stacksize = 0);
   bool WaitForThreadExit(DWORD dwMilliseconds);
@@ -91,6 +91,9 @@ private:
   unsigned __int64 m_iLastUsage;
   unsigned __int64 m_iLastTime;
   float m_fLastUsage;
+
+protected:
+  CStdString m_ThreadName;
 
 private:
   static DWORD WINAPI staticThread(LPVOID* data);

--- a/xbmc/threads/Timer.cpp
+++ b/xbmc/threads/Timer.cpp
@@ -1,0 +1,109 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+  *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include <algorithm>
+
+#include "Timer.h"
+#include "SystemClock.h"
+
+CTimer::CTimer(ITimerCallback *callback)
+  : CThread("Timer"),
+    m_callback(callback),
+    m_timeout(0),
+    m_interval(false),
+    m_endTime(0)
+{ }
+
+CTimer::~CTimer()
+{
+  Stop(true);
+}
+
+bool CTimer::Start(uint32_t timeout, bool interval /* = false */)
+{
+  if (m_callback == NULL || timeout == 0 || IsRunning())
+    return false;
+
+  m_timeout = timeout;
+  m_interval = interval;
+
+  Create();
+  return true;
+}
+
+bool CTimer::Stop(bool wait /* = false */)
+{
+  if (!IsRunning())
+    return false;
+
+  m_bStop = true;
+  m_eventTimeout.Set();
+  StopThread(wait);
+
+  return true;
+}
+
+bool CTimer::Restart()
+{
+  if (!IsRunning())
+    return false;
+
+  Stop(true);
+  return Start(m_timeout, m_interval);
+}
+
+float CTimer::GetElapsedSeconds() const
+{
+  return GetElapsedMilliseconds() / 1000.0f;
+}
+
+float CTimer::GetElapsedMilliseconds() const
+{
+  if (!IsRunning())
+    return 0.0f;
+
+  return (float)(XbmcThreads::SystemClockMillis() - (m_endTime - m_timeout));
+}
+
+void CTimer::Process()
+{
+  uint32_t currentTime = XbmcThreads::SystemClockMillis();
+  m_endTime = currentTime + m_timeout;
+
+  while (!m_bStop)
+  {
+    // wait the necessary time
+    if (!m_eventTimeout.WaitMSec(m_endTime - currentTime))
+    {
+      currentTime = XbmcThreads::SystemClockMillis();
+      if (m_endTime <= currentTime)
+      {
+        // execute OnTimeout() callback
+        m_callback->OnTimeout();
+
+        // stop if this is not an interval timer
+        if (!m_interval)
+          break;
+
+        m_endTime = currentTime + m_timeout;
+      }
+    }
+  }
+}

--- a/xbmc/threads/Timer.h
+++ b/xbmc/threads/Timer.h
@@ -1,0 +1,57 @@
+#pragma once
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://www.xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "Event.h"
+#include "Thread.h"
+
+class ITimerCallback
+{
+public:
+  virtual ~ITimerCallback() { }
+  
+  virtual void OnTimeout() = 0;
+};
+
+class CTimer : protected CThread
+{
+public:
+  CTimer(ITimerCallback *callback);
+  virtual ~CTimer();
+
+  bool Start(uint32_t timeout, bool interval = false);
+  bool Stop(bool wait = false);
+  bool Restart();
+
+  bool IsRunning() const { return CThread::IsRunning(); }
+
+  float GetElapsedSeconds() const;
+  float GetElapsedMilliseconds() const;
+  
+protected:
+  virtual void Process();
+  
+private:
+  ITimerCallback *m_callback;
+  uint32_t m_timeout;
+  bool m_interval;
+  uint32_t m_endTime;
+  CEvent m_eventTimeout;
+};

--- a/xbmc/utils/Idle.cpp
+++ b/xbmc/utils/Idle.cpp
@@ -22,7 +22,7 @@
 #include "Idle.h"
 
 
-CIdleThread::CIdleThread()
+CIdleThread::CIdleThread() : CThread("IdleThread")
 {}
 
 CIdleThread::~CIdleThread()
@@ -31,7 +31,6 @@ CIdleThread::~CIdleThread()
 void CIdleThread::OnStartup()
 {
   SetPriority(THREAD_PRIORITY_IDLE);
-  SetName("IdleThread");
 }
 
 void CIdleThread::OnExit()

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -53,7 +53,6 @@ CRssReader::CRssReader() : CThread()
   m_spacesBetweenFeeds = 0;
   m_bIsRunning = false;
   m_SavedScrollPos = 0;
-  m_ThreadName = "CRssReader";
   m_rtlText = false;
   m_requestRefresh = false;
 

--- a/xbmc/utils/RssReader.cpp
+++ b/xbmc/utils/RssReader.cpp
@@ -53,6 +53,7 @@ CRssReader::CRssReader() : CThread()
   m_spacesBetweenFeeds = 0;
   m_bIsRunning = false;
   m_SavedScrollPos = 0;
+  m_ThreadName = "CRssReader";
   m_rtlText = false;
   m_requestRefresh = false;
 

--- a/xbmc/utils/Stopwatch.cpp
+++ b/xbmc/utils/Stopwatch.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "threads/SystemClock.h"
 #include "Stopwatch.h"
 #if defined(_LINUX) && !defined(__APPLE__)
 #include <sys/sysinfo.h>
@@ -101,6 +102,6 @@ int64_t CStopWatch::GetTicks() const
 #ifndef _LINUX
   return CurrentHostCounter();
 #else
-  return CTimeUtils::GetTimeMS()
+  return XbmcThreads::SystemClockMillis()
 #endif
 }

--- a/xbmc/utils/SystemInfo.cpp
+++ b/xbmc/utils/SystemInfo.cpp
@@ -20,6 +20,7 @@
 
 #include <limits.h>
 
+#include "threads/SystemClock.h"
 #include "system.h"
 #include "SystemInfo.h"
 #include <conio.h>
@@ -220,12 +221,12 @@ CStdString CSysInfoJob::GetSystemUpTime(bool bTotalUptime)
   if(bTotalUptime)
   {
     //Total Uptime
-    iInputMinutes = g_sysinfo.GetTotalUptime() + ((int)(CTimeUtils::GetTimeMS() / 60000));
+    iInputMinutes = g_sysinfo.GetTotalUptime() + ((int)(XbmcThreads::SystemClockMillis() / 60000));
   }
   else
   {
     //Current UpTime
-    iInputMinutes = (int)(CTimeUtils::GetTimeMS() / 60000);
+    iInputMinutes = (int)(XbmcThreads::SystemClockMillis() / 60000);
   }
 
   SystemUpTime(iInputMinutes,iMinutes, iHours, iDays);

--- a/xbmc/utils/TimeUtils.cpp
+++ b/xbmc/utils/TimeUtils.cpp
@@ -18,9 +18,9 @@
  *
  */
 
-#include "system.h"
 #include "TimeUtils.h"
 #include "DateTime.h"
+#include "threads/SystemClock.h"
 
 int64_t CurrentHostCounter(void)
 {
@@ -40,7 +40,7 @@ unsigned int CTimeUtils::frameTime = 0;
 
 void CTimeUtils::UpdateFrameTime()
 {
-  frameTime = GetTimeMS();
+  frameTime = XbmcThreads::SystemClockMillis();
 }
 
 unsigned int CTimeUtils::GetFrameTime()
@@ -50,11 +50,6 @@ unsigned int CTimeUtils::GetFrameTime()
   UpdateFrameTime();
 #endif
   return frameTime;
-}
-
-unsigned int CTimeUtils::GetTimeMS()
-{
-  return timeGetTime();
 }
 
 CDateTime CTimeUtils::GetLocalTime(time_t time)

--- a/xbmc/utils/TimeUtils.h
+++ b/xbmc/utils/TimeUtils.h
@@ -33,7 +33,6 @@ class CTimeUtils
 public:
   static void UpdateFrameTime();      ///< update the frame time.  Not threadsafe
   static unsigned int GetFrameTime(); ///< returns the frame time in MS.  Not threadsafe
-  static unsigned int GetTimeMS();
   static CDateTime GetLocalTime(time_t time);
 private:
   static unsigned int frameTime;

--- a/xbmc/video/VideoDatabase.cpp
+++ b/xbmc/video/VideoDatabase.cpp
@@ -18,7 +18,7 @@
  *
  */
 
-#include "system.h"
+#include "threads/SystemClock.h"
 #include "video/VideoDatabase.h"
 #include "video/windows/GUIWindowVideoBase.h"
 #include "utils/RegExp.h"
@@ -592,7 +592,7 @@ bool CVideoDatabase::GetSubPaths(const CStdString &basepath, vector<int>& subpat
 
 int CVideoDatabase::RunQuery(const CStdString &sql)
 {
-  unsigned int time = CTimeUtils::GetTimeMS();
+  unsigned int time = XbmcThreads::SystemClockMillis();
   int rows = -1;
   if (m_pDS->query(sql.c_str()))
   {
@@ -600,7 +600,7 @@ int CVideoDatabase::RunQuery(const CStdString &sql)
     if (rows == 0)
       m_pDS->close();
   }
-  CLog::Log(LOGDEBUG, "%s took %d ms for %d items query: %s", __FUNCTION__, CTimeUtils::GetTimeMS() - time, rows, sql.c_str());
+  CLog::Log(LOGDEBUG, "%s took %d ms for %d items query: %s", __FUNCTION__, XbmcThreads::SystemClockMillis() - time, rows, sql.c_str());
   return rows;
 }
 
@@ -3057,7 +3057,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   if (record == NULL)
     return details;
 
-  DWORD time = CTimeUtils::GetTimeMS();
+  DWORD time = XbmcThreads::SystemClockMillis();
   int idMovie = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_MIN, VIDEODB_ID_MAX, DbMovieOffsets, details);
@@ -3078,13 +3078,13 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMovie(const dbiplus::sql_record* cons
   details.m_resumePoint.totalTimeInSeconds = record->at(VIDEODB_DETAILS_MOVIE_TOTAL_TIME).get_asInt();
   details.m_resumePoint.type = CBookmark::RESUME;
 
-  movieTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   if (needsCast)
   {
     GetCast("movie", "idMovie", details.m_iDbId, details.m_cast);
 
-    castTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+    castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
 
     // get tags
@@ -3124,7 +3124,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   if (record == NULL)
     return details;
 
-  DWORD time = CTimeUtils::GetTimeMS();
+  DWORD time = XbmcThreads::SystemClockMillis();
   int idTvShow = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_TV_MIN, VIDEODB_ID_TV_MAX, DbTvShowOffsets, details, 1);
@@ -3137,7 +3137,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
   details.m_playCount = record->at(VIDEODB_DETAILS_TVSHOW_NUM_WATCHED).get_asInt();
   details.m_strShowTitle = details.m_strTitle;
 
-  movieTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   if (needsCast)
   {
@@ -3152,7 +3152,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForTvShow(const dbiplus::sql_record* con
       m_pDS2->next();
     }
 
-    castTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+    castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
   }
   return details;
@@ -3170,7 +3170,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
   if (record == NULL)
     return details;
 
-  DWORD time = CTimeUtils::GetTimeMS();
+  DWORD time = XbmcThreads::SystemClockMillis();
   int idEpisode = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_EPISODE_MIN, VIDEODB_ID_EPISODE_MAX, DbEpisodeOffsets, details);
@@ -3195,14 +3195,14 @@ CVideoInfoTag CVideoDatabase::GetDetailsForEpisode(const dbiplus::sql_record* co
   details.m_resumePoint.totalTimeInSeconds = record->at(VIDEODB_DETAILS_EPISODE_TOTAL_TIME).get_asInt();
   details.m_resumePoint.type = CBookmark::RESUME;
 
-  movieTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   if (needsCast)
   {
     GetCast("episode", "idEpisode", details.m_iDbId, details.m_cast);
     GetCast("tvshow", "idShow", details.m_iIdShow, details.m_cast);
 
-    castTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+    castTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
     details.m_strPictureURL.Parse();
     CStdString strSQL = PrepareSQL("select * from bookmark join episode on episode.c%02d=bookmark.idBookmark where episode.idEpisode=%i and bookmark.type=%i", VIDEODB_ID_EPISODE_BOOKMARK,details.m_iDbId,CBookmark::EPISODE);
     m_pDS2->query(strSQL.c_str());
@@ -3222,7 +3222,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
 {
   CVideoInfoTag details;
 
-  DWORD time = CTimeUtils::GetTimeMS();
+  DWORD time = XbmcThreads::SystemClockMillis();
   int idMVideo = record->at(0).get_asInt();
 
   GetDetailsFromDB(record, VIDEODB_ID_MUSICVIDEO_MIN, VIDEODB_ID_MUSICVIDEO_MAX, DbMusicVideoOffsets, details);
@@ -3240,7 +3240,7 @@ CVideoInfoTag CVideoDatabase::GetDetailsForMusicVideo(const dbiplus::sql_record*
   details.m_resumePoint.totalTimeInSeconds = record->at(VIDEODB_DETAILS_MUSICVIDEO_TOTAL_TIME).get_asInt();
   details.m_resumePoint.type = CBookmark::RESUME;
 
-  movieTime += CTimeUtils::GetTimeMS() - time; time = CTimeUtils::GetTimeMS();
+  movieTime += XbmcThreads::SystemClockMillis() - time; time = XbmcThreads::SystemClockMillis();
 
   // get tags
   CStdString strSQL = PrepareSQL("SELECT tag.strTag FROM tag, taglinks WHERE taglinks.idMedia = %i AND taglinks.media_type = 'musicvideo' AND taglinks.idTag = tag.idTag ORDER BY tag.idTag", idMVideo);
@@ -4948,7 +4948,7 @@ bool CVideoDatabase::GetMusicVideoAlbumsNav(const CStdString& strBaseDir, CFileI
       m_pDS->close();
     }
 
-//    CLog::Log(LOGDEBUG, __FUNCTION__" Time: %d ms", CTimeUtils::GetTimeMS() - time);
+//    CLog::Log(LOGDEBUG, __FUNCTION__" Time: %d ms", XbmcThreads::SystemClockMillis() - time);
     return true;
   }
   catch (...)
@@ -5095,10 +5095,10 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
       return false;
 
     // run query
-    unsigned int time = CTimeUtils::GetTimeMS();
+    unsigned int time = XbmcThreads::SystemClockMillis();
     if (!m_pDS->query(strSQL.c_str())) return false;
     CLog::Log(LOGDEBUG, "%s -  query took %i ms",
-              __FUNCTION__, CTimeUtils::GetTimeMS() - time); time = CTimeUtils::GetTimeMS();
+              __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
     int iRowsFound = m_pDS->num_rows();
     if (iRowsFound == 0)
     {
@@ -5196,7 +5196,7 @@ bool CVideoDatabase::GetPeopleNav(const CStdString& strBaseDir, CFileItemList& i
       m_pDS->close();
     }
     CLog::Log(LOGDEBUG, "%s item retrieval took %i ms",
-              __FUNCTION__, CTimeUtils::GetTimeMS() - time); time = CTimeUtils::GetTimeMS();
+              __FUNCTION__, XbmcThreads::SystemClockMillis() - time); time = XbmcThreads::SystemClockMillis();
 
     return true;
   }

--- a/xbmc/video/VideoInfoScanner.cpp
+++ b/xbmc/video/VideoInfoScanner.cpp
@@ -18,6 +18,7 @@
  *
  */
 
+#include "threads/SystemClock.h"
 #include "FileItem.h"
 #include "VideoInfoScanner.h"
 #include "addons/AddonManager.h"
@@ -75,7 +76,7 @@ namespace VIDEO
   {
     try
     {
-      unsigned int tick = CTimeUtils::GetTimeMS();
+      unsigned int tick = XbmcThreads::SystemClockMillis();
 
       m_database.Open();
 
@@ -129,7 +130,7 @@ namespace VIDEO
 
       m_database.Close();
 
-      tick = CTimeUtils::GetTimeMS() - tick;
+      tick = XbmcThreads::SystemClockMillis() - tick;
       CLog::Log(LOGNOTICE, "VideoInfoScanner: Finished scan. Scanning for video info took %s", StringUtils::SecondsToTimeString(tick / 1000).c_str());
 
       m_bRunning = false;


### PR DESCRIPTION
This PR do follow things:
- Slightly refactored CThread - it now support defining thread names
- Added CThread::IsRunning() which is needed for CTimer class
- Replaced CTimeUtils::GetTimeMS() with XbmcThreads::SystemClockMillis()
- Added CTimer class from xbmc at revision 4a34ba24a179467947e400c3b0b47568967dd9cb

One thing which we should keep in mind is that I don't know if CThread::IsRunning() is correctly implemented. XBMC threading and our threading is pretty much different from Mid-2011. If we take a look on this [source code](https://github.com/xbmc/xbmc/commit/64427d44d61950244b376c8ae8b6dd62c460d7f6#diff-1581ce66fb2e353779d314517955ec4c7fc2a88402fb6dbba8e3a4025a8d8b89L142) from xbmc mainline we can see that **CThread::IsRunning()** replaced **m_ThreadHandle != NULL**. So that's my guess which can be wrong btw :) 