### PR TITLE
[GUILIB] changed: replace LPDIRECT3DTEXTURE8 with CBaseTexture in CTextureManager

### DIFF
--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -38,7 +38,14 @@ void CGUITextureD3D::Begin()
   // Set state to render the image
 #ifdef HAS_XBOX_D3D
   if (!m_texture.m_texCoordsArePixels)
-    p3DDevice->SetPalette( 0, texture->GetPaletteObject());
+  {
+    if (texture->GetPaletteObject())
+      p3DDevice->SetPalette( 0, texture->GetPaletteObject());
+    else
+    { // for image formats which are made of multiple textures (ex. GIFs), palette is stored in first texture
+      p3DDevice->SetPalette( 0, m_texture.m_textures[0]->GetPaletteObject());
+    }
+  }
   if (m_diffuse.size())
     p3DDevice->SetPalette( 1, m_diffuse.m_textures[0]->GetPaletteObject());
 #endif

--- a/xbmc/guilib/GUITextureD3D.cpp
+++ b/xbmc/guilib/GUITextureD3D.cpp
@@ -19,6 +19,7 @@
  */
 
 #include "include.h"
+#include "Texture.h"
 #include "GUITextureD3D.h"
 #include "GraphicContext.h"
 
@@ -31,15 +32,17 @@ CGUITextureD3D::CGUITextureD3D(float posX, float posY, float width, float height
 
 void CGUITextureD3D::Begin()
 {
+  CBaseTexture* texture = m_texture.m_textures[m_currentFrame];
   LPDIRECT3DDEVICE8 p3DDevice = g_graphicsContext.Get3DDevice();
+
   // Set state to render the image
 #ifdef HAS_XBOX_D3D
   if (!m_texture.m_texCoordsArePixels)
-    p3DDevice->SetPalette( 0, m_texture.m_palette);
-  if (m_diffuse.m_palette)
-    p3DDevice->SetPalette( 1, m_diffuse.m_palette);
+    p3DDevice->SetPalette( 0, texture->GetPaletteObject());
+  if (m_diffuse.size())
+    p3DDevice->SetPalette( 1, m_diffuse.m_textures[0]->GetPaletteObject());
 #endif
-  p3DDevice->SetTexture( 0, m_texture.m_textures[m_currentFrame] );
+  p3DDevice->SetTexture( 0, texture->GetTextureObject() );
   p3DDevice->SetTextureStageState( 0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR );
   p3DDevice->SetTextureStageState( 0, D3DTSS_MINFILTER, D3DTEXF_LINEAR );
   p3DDevice->SetTextureStageState( 0, D3DTSS_COLOROP, D3DTOP_MODULATE );
@@ -52,7 +55,7 @@ void CGUITextureD3D::Begin()
   p3DDevice->SetTextureStageState( 0, D3DTSS_ADDRESSV, D3DTADDRESS_CLAMP );
   if (m_diffuse.size())
   {
-    p3DDevice->SetTexture( 1, m_diffuse.m_textures[0] );
+    p3DDevice->SetTexture( 1, m_diffuse.m_textures[0]->GetTextureObject() );
     p3DDevice->SetTextureStageState( 1, D3DTSS_MAGFILTER, D3DTEXF_LINEAR );
     p3DDevice->SetTextureStageState( 1, D3DTSS_MINFILTER, D3DTEXF_LINEAR );
     p3DDevice->SetTextureStageState( 1, D3DTSS_COLORARG1, D3DTA_TEXTURE );
@@ -104,7 +107,7 @@ void CGUITextureD3D::End()
     p3DDevice->SetRenderState( D3DRS_FILLMODE, D3DFILL_SOLID );
   }
   p3DDevice->SetPalette( 0, NULL);
-  if (m_diffuse.m_palette)
+  if (m_diffuse.size())
     p3DDevice->SetPalette( 1, NULL);
 #endif
   // unset the texture and palette or the texture caching crashes because the runtime still has a reference

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -275,6 +275,43 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
   return GetTextureInfo();
 }
 
+bool CBaseTexture::LoadPaletted(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, IDirect3DPalette8 *palette)
+{
+  m_imageWidth = width;
+  m_imageHeight = height;
+  m_format = format;
+  m_palette = palette;
+
+  int w = PadPow2(width);
+  int h = PadPow2(height);
+
+  if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_P8, D3DPOOL_MANAGED, &m_texture) == D3D_OK)
+  {
+    D3DLOCKED_RECT lr;
+    RECT rc = { 0, 0, width, height };
+    if ( D3D_OK == m_texture->LockRect( 0, &lr, &rc, 0 ))
+    {
+      POINT pt = { 0, 0 };
+      XGSwizzleRect(pixels, pitch, &rc, lr.pBits, w, h, &pt, 1);
+
+      m_texture->UnlockRect( 0 );
+      return GetTextureInfo();
+    }
+  }
+  return false;
+}
+
+unsigned int CBaseTexture::PadPow2(unsigned int x)
+{
+  --x;
+  x |= x >> 1;
+  x |= x >> 2;
+  x |= x >> 4;
+  x |= x >> 8;
+  x |= x >> 16;
+  return ++x;
+}
+
 unsigned int CBaseTexture::GetRows(unsigned int height) const
 {
   switch (m_format)

--- a/xbmc/guilib/Texture.cpp
+++ b/xbmc/guilib/Texture.cpp
@@ -34,18 +34,85 @@
 /************************************************************************/
 /*                                                                      */
 /************************************************************************/
-CBaseTexture::CBaseTexture(unsigned int width, unsigned int height, unsigned int format)
+CBaseTexture::CBaseTexture(unsigned int width, unsigned int height, unsigned int format, IDirect3DTexture8* texture /* = NULL */, IDirect3DPalette8* palette /* = NULL */, bool packed /* = false */)
  : m_hasAlpha( true ),
-   m_imageWidth( width ),
-   m_imageHeight( height ),
-   m_orientation( 0 ),
-   m_texture( NULL )
+   m_packed( packed )
 {
+  m_pixels = NULL;
+  m_texture = texture;
+  m_palette = palette;
+  Allocate(width, height, format);
+  GetTextureInfo();
 }
 
 CBaseTexture::~CBaseTexture()
 {
-  SAFE_RELEASE(m_texture);
+  if (m_packed)
+  {
+    if (m_texture)
+    {
+      m_texture->BlockUntilNotBusy();
+      void* Data = (void*)(*(DWORD*)(((char*)m_texture) + sizeof(D3DTexture)));
+      if (Data)
+        XPhysicalFree(Data);
+      SAFE_DELETE_ARRAY(m_texture);
+    }
+    if (m_palette)
+    {
+      if ((m_palette->Common & D3DCOMMON_REFCOUNT_MASK) > 1)
+      {
+        SAFE_RELEASE(m_palette);
+      }
+      else
+      {
+        SAFE_DELETE(m_palette);
+      }
+    }
+  }
+  else
+  {
+    SAFE_RELEASE(m_texture);
+    SAFE_RELEASE(m_palette);
+  }
+}
+
+void CBaseTexture::Allocate(unsigned int width, unsigned int height, unsigned int format)
+{
+  m_imageWidth = width;
+  m_imageHeight = height;
+  m_format = format;
+  m_pitch = 0;
+  m_orientation = 0;
+
+  m_textureWidth = m_imageWidth;
+  m_textureHeight = m_imageHeight;
+  m_texCoordsArePixels = false;
+}
+
+bool CBaseTexture::GetTextureInfo()
+{
+  if (!m_texture)
+    return false;
+
+  D3DSURFACE_DESC desc;
+  if (!(D3D_OK == m_texture->GetLevelDesc(0, &desc)))
+    return false;
+
+  // GetLevelDesc(...) will automatically round texture to nearest power of 2, so no need to manually call PadPow2
+  m_textureWidth = (unsigned int)desc.Width;
+  m_textureHeight = (unsigned int)desc.Height;
+  m_texCoordsArePixels = (unsigned int)desc.Format == D3DFMT_LIN_A8R8G8B8;
+
+  D3DLOCKED_RECT lr;
+  if (!(D3D_OK == m_texture->LockRect(0, &lr, NULL, 0)))
+    return false;
+
+  m_pitch = (unsigned int)lr.Pitch;
+  m_pixels = (unsigned char *)lr.pBits;
+
+  m_texture->UnlockRect(0);
+
+  return true;
 }
 
 bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxWidth, unsigned int maxHeight,
@@ -78,9 +145,7 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
           *originalWidth = img.GetOrgWidth();
         if (originalHeight)
           *originalHeight = img.GetOrgHeight();
-        m_imageWidth = img.GetWidth();
-        m_imageHeight = img.GetHeight();
-        m_orientation = 0;
+        Allocate(img.GetWidth(), img.GetHeight(), XB_FMT_DXT1);
 
         //Texture is created using GetWidth and GetHeight, which return texture size (always POT)
         g_graphicsContext.Get3DDevice()->CreateTexture(img.GetWidth(), img.GetHeight(), 1, 0, D3DFMT_DXT1 , D3DPOOL_MANAGED, &m_texture);
@@ -89,12 +154,11 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
           D3DLOCKED_RECT lr;
           if ( D3D_OK == m_texture->LockRect( 0, &lr, NULL, 0 ))
           {
-            BYTE *pixels = (BYTE *)lr.pBits;
             //DDS Textures are always POT and don't need decoding, just memcpy into the texture.
-            memcpy(pixels, img.GetData(), img.GetSize());
+            memcpy(lr.pBits, img.GetData(), img.GetSize());
             m_texture->UnlockRect( 0 );
           }
-          return true;
+          return GetTextureInfo();
         }
         else
         {
@@ -121,12 +185,11 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
 
       if (jpegfile.Width() > 0 && jpegfile.Height() > 0)
       {
+        Allocate(jpegfile.Width(), jpegfile.Height(), XB_FMT_A8R8G8B8);
         if (originalWidth)
           *originalWidth = jpegfile.OrgWidth();
         if (originalHeight)
           *originalHeight = jpegfile.OrgHeight();
-        m_imageWidth = jpegfile.Width();
-        m_imageHeight = jpegfile.Height();
 
         g_graphicsContext.Get3DDevice()->CreateTexture(((jpegfile.Width() + 3) / 4) * 4, ((jpegfile.Height() + 3) / 4) * 4, 1, 0, D3DFMT_LIN_A8R8G8B8 , D3DPOOL_MANAGED, &m_texture);
         if (m_texture)
@@ -135,15 +198,14 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
           if ( D3D_OK == m_texture->LockRect( 0, &lr, NULL, 0 ))
           {
             DWORD destPitch = lr.Pitch;
-            BYTE *pixels = (BYTE *)lr.pBits;
-            bool ret = jpegfile.Decode(pixels, destPitch, XB_FMT_A8R8G8B8);
+            bool ret = jpegfile.Decode((BYTE *)lr.pBits, destPitch, XB_FMT_A8R8G8B8);
             m_texture->UnlockRect( 0 );
             if (ret)
             {
               if (autoRotate && jpegfile.Orientation())
                 m_orientation = jpegfile.Orientation() - 1;
               m_hasAlpha = false;
-              return true;
+              return GetTextureInfo();
             }
             else
               return false;
@@ -173,14 +235,13 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
 
   m_hasAlpha = NULL != image.alpha;
 
+  Allocate(image.width, image.height, XB_FMT_A8R8G8B8);
+  if (autoRotate && image.exifInfo.Orientation)
+    m_orientation = image.exifInfo.Orientation - 1;
   if (originalWidth)
     *originalWidth = image.originalwidth;
   if (originalHeight)
     *originalHeight = image.originalheight;
-  m_imageWidth = image.width;
-  m_imageHeight = image.height;
-  if (autoRotate && image.exifInfo.Orientation)
-    m_orientation = image.exifInfo.Orientation - 1;
 
   g_graphicsContext.Get3DDevice()->CreateTexture(image.width, image.height, 1, 0, D3DFMT_LIN_A8R8G8B8 , D3DPOOL_MANAGED, &m_texture);
   if (m_texture)
@@ -191,10 +252,9 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
       DWORD destPitch = lr.Pitch;
       // CxImage aligns rows to 4 byte boundaries
       DWORD srcPitch = ((image.width + 1)* 3 / 4) * 4;
-      BYTE *pixels = (BYTE *)lr.pBits;
       for (unsigned int y = 0; y < image.height; y++)
       {
-        BYTE *dst = pixels + y * destPitch;
+        BYTE *dst = (BYTE *)lr.pBits + y * destPitch;
         BYTE *src = image.texture + (image.height - 1 - y) * srcPitch;
         BYTE *alpha = image.alpha + (image.height - 1 - y) * image.width;
         for (unsigned int x = 0; x < image.width; x++)
@@ -212,7 +272,21 @@ bool CBaseTexture::LoadFromFile(const CStdString& texturePath, unsigned int maxW
     CLog::Log(LOGERROR, "%s - failed to create texture while loading image %s", __FUNCTION__, texturePath.c_str());
   dll.ReleaseImage(&image);
 
-  return m_texture != NULL;
+  return GetTextureInfo();
+}
+
+unsigned int CBaseTexture::GetRows(unsigned int height) const
+{
+  switch (m_format)
+  {
+  case XB_FMT_DXT1:
+  case XB_FMT_DXT3:
+  case XB_FMT_DXT5:
+  case XB_FMT_DXT5_YCoCg:
+    return (height + 3) / 4;
+  default:
+    return height;
+  }
 }
 
 bool CBaseTexture::HasAlpha() const

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -48,6 +48,7 @@ public:
 
   bool LoadFromFile(const CStdString& texturePath, unsigned int maxHeight = 0, unsigned int maxWidth = 0,
                     bool autoRotate = false, unsigned int *originalWidth = NULL, unsigned int *originalHeight = NULL);
+  bool LoadPaletted(unsigned int width, unsigned int height, unsigned int pitch, unsigned int format, const unsigned char *pixels, IDirect3DPalette8 *palette);
 
   bool HasAlpha() const;
 
@@ -68,6 +69,8 @@ public:
   void Allocate(unsigned int width, unsigned int height, unsigned int format);
   // populates some general info about loaded texture (width, height, pitch etc.)
   bool GetTextureInfo();
+
+  static unsigned int PadPow2(unsigned int x);
 
 protected:
   // helpers for computation of texture parameters for compressed textures

--- a/xbmc/guilib/Texture.h
+++ b/xbmc/guilib/Texture.h
@@ -42,7 +42,8 @@ class CBaseTexture
 {
 
 public:
-  CBaseTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8);
+  CBaseTexture(unsigned int width = 0, unsigned int height = 0, unsigned int format = XB_FMT_A8R8G8B8,
+               IDirect3DTexture8* texture = NULL, IDirect3DPalette8* palette = NULL, bool packed = false);
   virtual ~CBaseTexture();
 
   bool LoadFromFile(const CStdString& texturePath, unsigned int maxHeight = 0, unsigned int maxWidth = 0,
@@ -51,18 +52,46 @@ public:
   bool HasAlpha() const;
 
   IDirect3DTexture8* GetTextureObject() const { return m_texture; }
+  IDirect3DPalette8* GetPaletteObject() const { return m_palette; }
+  void SetPaletteObject(IDirect3DPalette8* palette) { m_palette = palette; }
+
+  unsigned char* GetPixels() const { return m_pixels; }
+  unsigned int GetPitch() const { return m_pitch; }
+  unsigned int GetRows() const { return GetRows(m_textureHeight); }
+  unsigned int GetTextureWidth() const { return m_textureWidth; }
+  unsigned int GetTextureHeight() const { return m_textureHeight; }
   unsigned int GetWidth() const { return m_imageWidth; }
   unsigned int GetHeight() const { return m_imageHeight; }
+  bool GetTexCoordsArePixels() const { return m_texCoordsArePixels; }
   int GetOrientation() const { return m_orientation; }
 
+  void Allocate(unsigned int width, unsigned int height, unsigned int format);
+  // populates some general info about loaded texture (width, height, pitch etc.)
+  bool GetTextureInfo();
+
 protected:
+  // helpers for computation of texture parameters for compressed textures
+  unsigned int GetRows(unsigned int height) const;
+
   unsigned int m_imageWidth;
   unsigned int m_imageHeight;
   unsigned int m_textureWidth;
   unsigned int m_textureHeight;
   IDirect3DTexture8* m_texture;
+  /* NOTICE for future:
+    Note that in SDL and Win32 we already convert the paletted textures into normal textures,
+    so there's no chance of having m_palette as a real palette */
+  IDirect3DPalette8* m_palette;
+  // this variable should hold Data which represents loaded Texture
+  unsigned char* m_pixels;
+  unsigned int m_format;
+  unsigned int m_pitch;
   int m_orientation;
   bool m_hasAlpha;
+  // What is this? On Kodi it's always false
+  bool m_texCoordsArePixels;
+  // true if texture is loaded from .XPR
+  bool m_packed;
 };
 
 #define CTexture CBaseTexture

--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -500,10 +500,13 @@ PackedLoadError:
   if (pPal) delete pPal;
   return false;
 }
-int CTextureBundle::LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filename, D3DXIMAGE_INFO* pInfo, LPDIRECT3DTEXTURE8** ppTextures,
-                             LPDIRECT3DPALETTE8* ppPalette, int& nLoops, int** ppDelays)
+int CTextureBundle::LoadAnim(const CStdString& Filename, CBaseTexture*** ppTextures,
+                              int &width, int &height, int& nLoops, int** ppDelays)
 {
-  *ppTextures = NULL; *ppPalette = NULL; *ppDelays = NULL;
+  DWORD ResDataOffset;
+  int nTextures = 0;
+
+  *ppTextures = NULL; *ppDelays = NULL;
 
   CAutoTexBuffer UnpackedBuf;
   if (!LoadFile(Filename, UnpackedBuf))
@@ -538,7 +541,7 @@ int CTextureBundle::LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filena
     Next += sizeof(D3DPalette);
   }
 
-  int nTextures = flags >> 16;
+  nTextures = flags >> 16;
   ppTex = new D3DTexture * [nTextures];
   *ppDelays = new int[nTextures];
   for (int i = 0; i < nTextures; ++i)
@@ -551,18 +554,18 @@ int CTextureBundle::LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filena
     Next += sizeof(int);
   }
 
-  DWORD ResDataOffset = ((DWORD)(Next - UnpackedBuf) + 127) & ~127;
+  ResDataOffset = ((DWORD)(Next - UnpackedBuf) + 127) & ~127;
   ResData = UnpackedBuf + ResDataOffset;
 
-  *ppTextures = new LPDIRECT3DTEXTURE8[nTextures];
+  *ppTextures = new CBaseTexture*[nTextures];
   for (int i = 0; i < nTextures; ++i)
   {
     if ((ppTex[i]->Common & D3DCOMMON_TYPE_MASK) != D3DCOMMON_TYPE_TEXTURE)
       goto PackedAnimError;
 
-    (*ppTextures)[i] = (LPDIRECT3DTEXTURE8)ppTex[i];
 #ifdef HAS_XBOX_D3D
-    (*ppTextures)[i]->Register(ResData);
+    (*ppTextures)[i] = new CTexture(pAnimInfo->RealSize[0], pAnimInfo->RealSize[1], XB_FMT_A8R8G8B8, (LPDIRECT3DTEXTURE8)ppTex[i], NULL, true);
+    (*ppTextures)[i]->GetTextureObject()->Register(ResData);
 #else
     GetTextureFromData(ppTex[i], ResData, &(*ppTextures)[i]);
 #endif
@@ -576,17 +579,14 @@ int CTextureBundle::LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filena
 #ifdef HAS_XBOX_D3D
   if (pPal)
   {
-    *ppPalette = (LPDIRECT3DPALETTE8)pPal;
-    (*ppPalette)->Register(ResData);
+    (*ppTextures)[0]->SetPaletteObject((LPDIRECT3DPALETTE8)pPal);
+    (*ppTextures)[0]->GetPaletteObject()->Register(ResData);
   }
   UnpackedBuf.Release();
 #endif
 
-  pInfo->Width = pAnimInfo->RealSize[0];
-  pInfo->Height = pAnimInfo->RealSize[1];
-  pInfo->Depth = 0;
-  pInfo->MipLevels = 1;
-  pInfo->Format = D3DFMT_UNKNOWN;
+  width = pAnimInfo->RealSize[0];
+  height = pAnimInfo->RealSize[1];
 
   return nTextures;
 

--- a/xbmc/guilib/TextureBundle.cpp
+++ b/xbmc/guilib/TextureBundle.cpp
@@ -419,16 +419,16 @@ bool CTextureBundle::LoadFile(const CStdString& Filename, CAutoTexBuffer& Unpack
   return success;
 }
 
-bool CTextureBundle::LoadTexture(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filename, D3DXIMAGE_INFO* pInfo, LPDIRECT3DTEXTURE8* ppTexture,
-                                    LPDIRECT3DPALETTE8* ppPalette)
+bool CTextureBundle::LoadTexture(const CStdString& Filename, CBaseTexture** ppTexture, int &width, int &height)
 {
-  *ppTexture = NULL; *ppPalette = NULL;
+  DWORD ResDataOffset;
+  *ppTexture = NULL;
 
   CAutoTexBuffer UnpackedBuf;
   if (!LoadFile(Filename, UnpackedBuf))
     return false;
 
-  D3DTexture* pTex = (D3DTexture*)(new char[sizeof(D3DTexture) + sizeof(DWORD)]);
+  D3DTexture* pTex = (D3DTexture*)(new char[sizeof(D3DTexture) + sizeof(DWORD)]); // Why we are appending sizeof(DWORD) here? It's not like that on Kodi
   D3DPalette* pPal = 0;
   void* ResData = 0;
 
@@ -460,36 +460,38 @@ bool CTextureBundle::LoadTexture(LPDIRECT3DDEVICE8 pDevice, const CStdString& Fi
   memcpy(RealSize, Next, 4);
   Next += 4;
 
-  DWORD ResDataOffset = ((Next - UnpackedBuf) + 127) & ~127;
+  ResDataOffset = ((Next - UnpackedBuf) + 127) & ~127;
   ResData = UnpackedBuf + ResDataOffset;
 
   if ((pTex->Common & D3DCOMMON_TYPE_MASK) != D3DCOMMON_TYPE_TEXTURE)
     goto PackedLoadError;
 
-  *ppTexture = (LPDIRECT3DTEXTURE8)pTex;
 #ifdef HAS_XBOX_D3D
-  (*ppTexture)->Register(ResData);
+  *ppTexture = new CTexture(RealSize[0], RealSize[1], XB_FMT_A8R8G8B8, (LPDIRECT3DTEXTURE8)pTex, NULL, true);
+  (*ppTexture)->GetTextureObject()->Register(ResData);
 #else
   GetTextureFromData(pTex, ResData, ppTexture);
+  delete[] pTex;
 #endif
-  *(DWORD*)(pTex + 1) = (DWORD)(BYTE*)UnpackedBuf;
 #ifdef HAS_XBOX_D3D
+  *(DWORD*)(pTex + 1) = (DWORD)(BYTE*)UnpackedBuf;
   if (pPal)
   {
-    *ppPalette = (LPDIRECT3DPALETTE8)pPal;
-    (*ppPalette)->Register(ResData);
+    (*ppTexture)->SetPaletteObject((LPDIRECT3DPALETTE8)pPal);
+    (*ppTexture)->GetPaletteObject()->Register(ResData);
   }
   UnpackedBuf.Release();
 #endif
 
-  pInfo->Width = RealSize[0];
-  pInfo->Height = RealSize[1];
-  pInfo->Depth = 0;
-  pInfo->MipLevels = 1;
+  width = RealSize[0];
+  height = RealSize[1];
+/* DXMERGE - this was previously used to specify the format of the image - probably only affects directx?
+#ifndef HAS_SDL
   D3DSURFACE_DESC desc;
   (*ppTexture)->GetLevelDesc(0, &desc);
   pInfo->Format = desc.Format;
-
+#endif
+*/
   return true;
 
 PackedLoadError:

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -63,8 +63,7 @@ public:
   bool PreloadFile(const CStdString& Filename);
   static CStdString Normalize(const CStdString &name);
 
-  bool LoadTexture(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filename, D3DXIMAGE_INFO* pInfo, LPDIRECT3DTEXTURE8* ppTexture,
-                      LPDIRECT3DPALETTE8* ppPalette);
+  bool LoadTexture(const CStdString& Filename, CBaseTexture** ppTexture, int &width, int &height);
 
   int LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filename, D3DXIMAGE_INFO* pInfo, LPDIRECT3DTEXTURE8** ppTextures,
                LPDIRECT3DPALETTE8* ppPalette, int& nLoops, int** ppDelays);

--- a/xbmc/guilib/TextureBundle.h
+++ b/xbmc/guilib/TextureBundle.h
@@ -65,7 +65,6 @@ public:
 
   bool LoadTexture(const CStdString& Filename, CBaseTexture** ppTexture, int &width, int &height);
 
-  int LoadAnim(LPDIRECT3DDEVICE8 pDevice, const CStdString& Filename, D3DXIMAGE_INFO* pInfo, LPDIRECT3DTEXTURE8** ppTextures,
-               LPDIRECT3DPALETTE8* ppPalette, int& nLoops, int** ppDelays);
+  int LoadAnim(const CStdString& Filename, CBaseTexture*** ppTextures, int &width, int &height, int& nLoops, int** ppDelays);
 };
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -46,23 +46,19 @@ extern "C" void dllprintf( const char *format, ... );
 
 CGUITextureManager g_TextureManager;
 
-CTextureArray::CTextureArray(int width, int height, int loops, LPDIRECT3DPALETTE8 palette, bool packed, bool texCoordsArePixels)
+CTextureArray::CTextureArray(int width, int height, int loops, bool texCoordsArePixels)
 {
   m_width = width;
   m_height = height;
   m_loops = loops;
   m_orientation = 0;
-  m_palette = palette;
   m_texWidth = 0;
   m_texHeight = 0;
 #ifdef HAS_XBOX_D3D
   m_texCoordsArePixels = texCoordsArePixels;
-  if (m_palette)
-    m_palette->AddRef();
 #else
   m_texCoordsArePixels = false;
 #endif
-  m_packed = packed;
 };
 
 CTextureArray::CTextureArray()
@@ -84,7 +80,6 @@ void CTextureArray::Reset()
 {
   m_textures.clear();
   m_delays.clear();
-  m_palette = NULL;
   m_width = 0;
   m_height = 0;
   m_loops = 0;
@@ -92,25 +87,23 @@ void CTextureArray::Reset()
   m_texWidth = 0;
   m_texHeight = 0;
   m_texCoordsArePixels = false;
-  m_packed = false;
 }
 
-void CTextureArray::Add(LPDIRECT3DTEXTURE8 texture, int delay)
+void CTextureArray::Add(CBaseTexture *texture, int delay)
 {
   if (!texture)
     return;
 
   m_textures.push_back(texture);
   m_delays.push_back(delay ? delay * 2 : 100);
-  D3DSURFACE_DESC desc;
-  if (D3D_OK == texture->GetLevelDesc(0, &desc))
-  {
-    m_texWidth = desc.Width;
-    m_texHeight = desc.Height;
+
+  m_texWidth = texture->GetTextureWidth();
+  m_texHeight = texture->GetTextureHeight();
 #ifdef HAS_XBOX_D3D
-    m_texCoordsArePixels = desc.Format == D3DFMT_LIN_A8R8G8B8;
+  m_texCoordsArePixels = texture->GetTexCoordsArePixels();
+#else
+  m_texCoordsArePixels = false;
 #endif
-  }
 }
 
 void CTextureArray::Set(CBaseTexture *texture, int width, int height)
@@ -119,11 +112,7 @@ void CTextureArray::Set(CBaseTexture *texture, int width, int height)
   m_width = width;
   m_height = height;
   m_orientation = texture ? texture->GetOrientation() : 0;
-#ifdef HAS_XBOX_D3D
-  Add(texture->GetTextureObject(), 100);
-#else
   Add(texture, 100);
-#endif
 }
 
 void CTextureArray::Free()
@@ -131,40 +120,11 @@ void CTextureArray::Free()
   CSingleLock lock(g_graphicsContext);
   for (unsigned int i = 0; i < m_textures.size(); i++)
   {
-    if (m_packed)
-    {
-#ifdef HAS_XBOX_D3D
-      m_textures[i]->BlockUntilNotBusy();
-      void* Data = (void*)(*(DWORD*)(((char*)m_textures[i]) + sizeof(D3DTexture)));
-      if (Data)
-        XPhysicalFree(Data);
-      delete [] m_textures[i];
-#else
-      m_textures[i]->Release();
-#endif
-    }
-    else
-      m_textures[i]->Release();
+    delete m_textures[i];
   }
+
   m_textures.clear();
   m_delays.clear();
-  // Note that in SDL and Win32 we already convert the paletted textures into normal textures,
-  // so there's no chance of having m_palette as a real palette
-#ifdef HAS_XBOX_D3D
-  if (m_palette)
-  {
-    if (m_packed)
-    {
-      if ((m_palette->Common & D3DCOMMON_REFCOUNT_MASK) > 1)
-        m_palette->Release();
-      else
-        delete m_palette;
-    }
-    else
-      m_palette->Release();
-  }
-#endif
-  m_palette = NULL;
 
   Reset();
 }
@@ -181,8 +141,8 @@ CTextureMap::CTextureMap()
   m_memUsage = 0;
 }
 
-CTextureMap::CTextureMap(const CStdString& textureName, int width, int height, int loops, LPDIRECT3DPALETTE8 palette, bool packed)
-: m_texture(width, height, loops, palette, packed)
+CTextureMap::CTextureMap(const CStdString& textureName, int width, int height, int loops)
+: m_texture(width, height, loops)
 {
   m_textureName = textureName;
   m_referenceCount = 0;
@@ -209,22 +169,16 @@ const CStdString& CTextureMap::GetName() const
   return m_textureName;
 }
 
-#ifndef HAS_SDL
-void CTextureMap::Add(LPDIRECT3DTEXTURE8 pTexture, int delay)
-#else
-void CTextureMap::Add(SDL_Surface* pTexture, int delay)
-#endif
+void CTextureMap::Add(CBaseTexture* texture, int delay)
 {
-#ifdef HAS_SDL_OPENGL
-  CGLTexture *glTexture = new CGLTexture(pTexture, false);
-  m_texture.Add(glTexture, delay);
-#else
-  m_texture.Add(pTexture, delay);
-#endif
+  m_texture.Add(texture, delay);
 
-  D3DSURFACE_DESC desc;
-  if (pTexture && D3D_OK == pTexture->GetLevelDesc(0, &desc))
-    m_memUsage += desc.Size;
+  if (texture)
+#ifdef HAS_XBOX_D3D
+    m_memUsage += sizeof(CTexture) + (texture->GetPitch() * texture->GetRows()); // This is equal to D3DSURFACE_DESC.Size
+#else
+    m_memUsage += sizeof(CTexture) + (texture->GetTextureWidth() * texture->GetTextureHeight() * 4); Kodi assumes format XB_FMT_A8R8G8B8 which is biggest
+#endif
 }
 
 bool CTextureMap::Release()
@@ -462,7 +416,6 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   //Lock here, we will do stuff that could break rendering
   CSingleLock lock(g_graphicsContext);
 
-  LPDIRECT3DTEXTURE8 pTexture = NULL;
   LPDIRECT3DPALETTE8 pPal = 0;
 
 #ifdef _DEBUG
@@ -470,136 +423,137 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   start = CurrentHostCounter();
 #endif
 
-  D3DXIMAGE_INFO info;
-
   if (strPath.Right(4).ToLower() == ".gif")
   {
-    CTextureMap* pMap;
+    return 0;
+//     CTextureMap* pMap;
 
-    if (bundle >= 0)
-    {
-      LPDIRECT3DTEXTURE8* pTextures;
-      int nLoops = 0;
-      int* Delay;
-      int nImages = m_TexBundle[bundle].LoadAnim(g_graphicsContext.Get3DDevice(), strTextureName, &info, &pTextures, &pPal, nLoops, &Delay);
-      if (!nImages)
-      {
-        CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
-        delete [] pTextures;
-        delete [] Delay;
-        return 0;
-      }
+//     if (bundle >= 0)
+//     {
+//       LPDIRECT3DTEXTURE8* pTextures;
+//       int nLoops = 0;
+//       int* Delay;
+//       int nImages = m_TexBundle[bundle].LoadAnim(g_graphicsContext.Get3DDevice(), strTextureName, &info, &pTextures, &pPal, nLoops, &Delay);
+//       if (!nImages)
+//       {
+//         CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
+//         delete [] pTextures;
+//         delete [] Delay;
+//         return 0;
+//       }
 
-      pMap = new CTextureMap(strTextureName, info.Width, info.Height, nLoops, pPal, true);
-      for (int iImage = 0; iImage < nImages; ++iImage)
-      {
-        pMap->Add(pTextures[iImage], Delay[iImage]);
-      }
+//       pMap = new CTextureMap(strTextureName, info.Width, info.Height, nLoops, pPal, true);
+//       for (int iImage = 0; iImage < nImages; ++iImage)
+//       {
+//         pMap->Add(pTextures[iImage], Delay[iImage]);
+//       }
 
-      delete [] pTextures;
-      delete [] Delay;
-#ifdef HAS_XBOX_D3D
-      pPal->Release();
-#endif
-    }
-    else
-    {
-      CAnimatedGifSet AnimatedGifSet;
-      int iImages = AnimatedGifSet.LoadGIF(strPath.c_str());
-      if (iImages == 0)
-      {
-        CStdString rootPath = strPath.Left(g_SkinInfo->Path().GetLength());
-        if (0 == rootPath.CompareNoCase(g_SkinInfo->Path()))
-          CLog::Log(LOGERROR, "Texture manager unable to load file: %s", strPath.c_str());
-        return 0;
-      }
-      int iWidth = AnimatedGifSet.FrameWidth;
-      int iHeight = AnimatedGifSet.FrameHeight;
+//       delete [] pTextures;
+//       delete [] Delay;
+// #ifdef HAS_XBOX_D3D
+//       pPal->Release();
+// #endif
+//     }
+//     else
+//     {
+//       CAnimatedGifSet AnimatedGifSet;
+//       int iImages = AnimatedGifSet.LoadGIF(strPath.c_str());
+//       if (iImages == 0)
+//       {
+//         CStdString rootPath = strPath.Left(g_SkinInfo->Path().GetLength());
+//         if (0 == rootPath.CompareNoCase(g_SkinInfo->Path()))
+//           CLog::Log(LOGERROR, "Texture manager unable to load file: %s", strPath.c_str());
+//         return 0;
+//       }
+//       int iWidth = AnimatedGifSet.FrameWidth;
+//       int iHeight = AnimatedGifSet.FrameHeight;
 
-      int iPaletteSize = (1 << AnimatedGifSet.m_vecimg[0]->BPP);
-#ifdef HAS_XBOX_D3D
-      g_graphicsContext.Get3DDevice()->CreatePalette(D3DPALETTE_256, &pPal);
-      PALETTEENTRY* pal;
-      pPal->Lock((D3DCOLOR**)&pal, 0);
+//       int iPaletteSize = (1 << AnimatedGifSet.m_vecimg[0]->BPP);
+// #ifdef HAS_XBOX_D3D
+//       g_graphicsContext.Get3DDevice()->CreatePalette(D3DPALETTE_256, &pPal);
+//       PALETTEENTRY* pal;
+//       pPal->Lock((D3DCOLOR**)&pal, 0);
 
-      memcpy(pal, AnimatedGifSet.m_vecimg[0]->Palette, sizeof(PALETTEENTRY)*iPaletteSize);
-      for (int i = 0; i < iPaletteSize; i++)
-        pal[i].peFlags = 0xff; // alpha
-      if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
-        pal[AnimatedGifSet.m_vecimg[0]->Transparent].peFlags = 0;
+//       memcpy(pal, AnimatedGifSet.m_vecimg[0]->Palette, sizeof(PALETTEENTRY)*iPaletteSize);
+//       for (int i = 0; i < iPaletteSize; i++)
+//         pal[i].peFlags = 0xff; // alpha
+//       if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
+//         pal[AnimatedGifSet.m_vecimg[0]->Transparent].peFlags = 0;
 
-      pPal->Unlock();
-#endif
-      pMap = new CTextureMap(strTextureName, iWidth, iHeight, AnimatedGifSet.nLoops, pPal, false);
-      for (int iImage = 0; iImage < iImages; iImage++)
-      {
-        int w = PadPow2(iWidth);
-        int h = PadPow2(iHeight);
-#ifdef HAS_XBOX_D3D
-        if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_P8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
-#else
-        if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
-#endif
-        {
-          CAnimatedGif* pImage = AnimatedGifSet.m_vecimg[iImage];
-          D3DLOCKED_RECT lr;
-          RECT rc = { 0, 0, pImage->Width, pImage->Height };
-          if ( D3D_OK == pTexture->LockRect( 0, &lr, &rc, 0 ))
-          {
-#ifdef HAS_XBOX_D3D
-            POINT pt = { 0, 0 };
-            XGSwizzleRect(pImage->Raster, pImage->BytesPerRow, &rc, lr.pBits, w, h, &pt, 1);
-#else
-            COLOR *palette = AnimatedGifSet.m_vecimg[0]->Palette;
-            // set the alpha values to fully opaque
-            for (int i = 0; i < iPaletteSize; i++)
-              palette[i].x = 0xff;
-            // and set the transparent colour
-            if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
-              palette[AnimatedGifSet.m_vecimg[0]->Transparent].x = 0;
+//       pPal->Unlock();
+// #endif
+//       pMap = new CTextureMap(strTextureName, iWidth, iHeight, AnimatedGifSet.nLoops, pPal, false);
+//       for (int iImage = 0; iImage < iImages; iImage++)
+//       {
+//         int w = PadPow2(iWidth);
+//         int h = PadPow2(iHeight);
+// #ifdef HAS_XBOX_D3D
+//         if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_P8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
+// #else
+//         if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
+// #endif
+//         {
+//           CAnimatedGif* pImage = AnimatedGifSet.m_vecimg[iImage];
+//           D3DLOCKED_RECT lr;
+//           RECT rc = { 0, 0, pImage->Width, pImage->Height };
+//           if ( D3D_OK == pTexture->LockRect( 0, &lr, &rc, 0 ))
+//           {
+// #ifdef HAS_XBOX_D3D
+//             POINT pt = { 0, 0 };
+//             XGSwizzleRect(pImage->Raster, pImage->BytesPerRow, &rc, lr.pBits, w, h, &pt, 1);
+// #else
+//             COLOR *palette = AnimatedGifSet.m_vecimg[0]->Palette;
+//             // set the alpha values to fully opaque
+//             for (int i = 0; i < iPaletteSize; i++)
+//               palette[i].x = 0xff;
+//             // and set the transparent colour
+//             if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
+//               palette[AnimatedGifSet.m_vecimg[0]->Transparent].x = 0;
 
-            for (int y = 0; y < pImage->Height; y++)
-            {
-              BYTE *dest = (BYTE *)lr.pBits + y * lr.Pitch;
-              BYTE *source = (BYTE *)pImage->Raster + y * pImage->BytesPerRow;
-              for (int x = 0; x < pImage->Width; x++)
-              {
-                COLOR col = palette[*source++];
-                *dest++ = col.b;
-                *dest++ = col.g;
-                *dest++ = col.r;
-                *dest++ = col.x;
-              }
-            }
-#endif
-            pTexture->UnlockRect( 0 );
+//             for (int y = 0; y < pImage->Height; y++)
+//             {
+//               BYTE *dest = (BYTE *)lr.pBits + y * lr.Pitch;
+//               BYTE *source = (BYTE *)pImage->Raster + y * pImage->BytesPerRow;
+//               for (int x = 0; x < pImage->Width; x++)
+//               {
+//                 COLOR col = palette[*source++];
+//                 *dest++ = col.b;
+//                 *dest++ = col.g;
+//                 *dest++ = col.r;
+//                 *dest++ = col.x;
+//               }
+//             }
+// #endif
+//             pTexture->UnlockRect( 0 );
 
-            pMap->Add(pTexture, pImage->Delay);
-          }
-        }
-      } // of for (int iImage=0; iImage < iImages; iImage++)
+//             pMap->Add(pTexture, pImage->Delay);
+//           }
+//         }
+//       } // of for (int iImage=0; iImage < iImages; iImage++)
 
-#ifdef HAS_XBOX_D3D
-      pPal->Release();
-#endif
-    }
+// #ifdef HAS_XBOX_D3D
+//       pPal->Release();
+// #endif
+//     }
 
-#ifdef _DEBUG
-    int64_t end, freq;
-    end = CurrentHostCounter();
-    freq = CurrentHostFrequency();
-    char temp[200];
-    sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
-    OutputDebugString(temp);
-#endif
+// #ifdef _DEBUG
+//     int64_t end, freq;
+//     end = CurrentHostCounter();
+//     freq = CurrentHostFrequency();
+//     char temp[200];
+//     sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
+//     OutputDebugString(temp);
+// #endif
 
-    m_vecTextures.push_back(pMap);
-    return 1;
+//     m_vecTextures.push_back(pMap);
+//     return 1;
   } // of if (strPath.Right(4).ToLower()==".gif")
 
+  CBaseTexture *pTexture = NULL;
+  int width = 0, height = 0;
   if (bundle >= 0)
   {
-    if (FAILED(m_TexBundle[bundle].LoadTexture(g_graphicsContext.Get3DDevice(), strTextureName, &info, &pTexture, &pPal)))
+    if (FAILED(m_TexBundle[bundle].LoadTexture(strTextureName, &pTexture, width, height)))
     {
       CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
       return 0;
@@ -607,63 +561,74 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   }
   else
   {
-    // normal picture
-    // convert from utf8
-    CStdString texturePath;
-    g_charsetConverter.utf8ToStringCharset(strPath, texturePath);
+    bool isThumbnail = URIUtils::GetExtension(strPath).Equals(".tbn");
 
-    // if the file is a thumbnail, load with picture loader (fast jpeg decoder), and limit to our chosen thumbsize
-    // as thumbnails could be slightly bigger on disk due to libjpeg scaling
-    if (URIUtils::GetExtension(strPath).Equals(".tbn"))
-    {
-      CTexture texture;
-      if (!texture.LoadFromFile(strPath, g_advancedSettings.m_thumbSize, g_advancedSettings.m_thumbSize))
-        return 0;
-      info.Width = texture.GetWidth();
-      info.Height = texture.GetHeight();
-    }
-    else
-    {
+    pTexture = new CTexture();
+    if (!pTexture->LoadFromFile(strPath, isThumbnail ? g_advancedSettings.m_thumbSize : 0, isThumbnail ? g_advancedSettings.m_thumbSize : 0))
+      return 0;
+    width = pTexture->GetWidth();
+    height = pTexture->GetHeight();
 
-      HRESULT result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
-                                       D3DX_DEFAULT, D3DX_DEFAULT, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
-                                       D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
+//     // normal picture
+//     // convert from utf8
+//     CStdString texturePath;
+//     g_charsetConverter.utf8ToStringCharset(strPath, texturePath);
 
-      int checkWidth  = D3DX_DEFAULT;
-      int checkHeight = D3DX_DEFAULT;
+//     // if the file is a thumbnail, load with picture loader (fast jpeg decoder), and limit to our chosen thumbsize
+//     // as thumbnails could be slightly bigger on disk due to libjpeg scaling
+//     if (URIUtils::GetExtension(strPath).Equals(".tbn"))
+//     {
+//       CBaseTexture* texture = new CTexture();
+//       if (!texture->LoadFromFile(strPath, g_advancedSettings.m_thumbSize, g_advancedSettings.m_thumbSize))
+//         return 0;
+//       info.Width = texture->GetWidth();
+//       info.Height = texture->GetHeight();
+//     }
+//     else
+//     {
 
-      // Don't allow anything bigger than 720p on Xbox because of the limited amount of memory
-      if ( info.Width > 1280 )
-        checkWidth = 1280;
+//       HRESULT result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
+//                                        D3DX_DEFAULT, D3DX_DEFAULT, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
+//                                        D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
 
-      if ( info.Height > 720 )
-        checkHeight = 720;
+//       int checkWidth  = D3DX_DEFAULT;
+//       int checkHeight = D3DX_DEFAULT;
 
-      if (checkWidth != D3DX_DEFAULT || checkHeight != D3DX_DEFAULT )
-      {
-        // HACK!: If the picture/texture turns out to be too large try to load with a resolution equal to our screen
-        CLog::Log(LOGWARNING, "%s - Texture file %s (%i x %i) is too big! Reloading resized", __FUNCTION__, strPath.c_str(), info.Width, info.Height );
+//       // Don't allow anything bigger than 720p on Xbox because of the limited amount of memory
+//       if ( info.Width > 1280 )
+//         checkWidth = 1280;
 
-        if (pTexture)
-        {
-          pTexture->Release();
-          pTexture = NULL;
-        }
+//       if ( info.Height > 720 )
+//         checkHeight = 720;
 
-        result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
-                                         checkWidth, checkHeight, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
-                                         D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
-      }
+//       if (checkWidth != D3DX_DEFAULT || checkHeight != D3DX_DEFAULT )
+//       {
+//         // HACK!: If the picture/texture turns out to be too large try to load with a resolution equal to our screen
+//         CLog::Log(LOGWARNING, "%s - Texture file %s (%i x %i) is too big! Reloading resized", __FUNCTION__, strPath.c_str(), info.Width, info.Height );
 
-      if (result != D3D_OK)
-      {
-//       if (!strnicmp(strPath.c_str(), "special://home/skin/", 20) && !strnicmp(strPath.c_str(), "special://xbmc/skin/", 20))
-          CLog::Log(LOGERROR, "%s - Texture manager unable to load file: %s", __FUNCTION__, strPath.c_str());
-        return 0;
-      }
-    }
+//         if (pTexture)
+//         {
+//           pTexture->Release();
+//           pTexture = NULL;
+//         }
+
+//         result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
+//                                          checkWidth, checkHeight, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
+//                                          D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
+//       }
+
+//       if (result != D3D_OK)
+//       {
+// //       if (!strnicmp(strPath.c_str(), "special://home/skin/", 20) && !strnicmp(strPath.c_str(), "special://xbmc/skin/", 20))
+//           CLog::Log(LOGERROR, "%s - Texture manager unable to load file: %s", __FUNCTION__, strPath.c_str());
+//         return 0;
+//       }
+//     }
   }
-  CTextureMap* pMap = new CTextureMap(strTextureName, info.Width, info.Height, 0, pPal, bundle >= 0);
+
+  if (!pTexture) return 0;
+
+  CTextureMap* pMap = new CTextureMap(strTextureName, width, height, 0);
 
   pMap->Add(pTexture, 100);
   m_vecTextures.push_back(pMap);
@@ -677,10 +642,6 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   OutputDebugString(temp);
 #endif
 
-#ifdef HAS_XBOX_D3D
-  if (pPal)
-    pPal->Release();
-#endif
   return 1;
 }
 

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -592,6 +592,7 @@ void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName)
   CLog::Log(LOGWARNING, "%s: Unable to release texture %s", __FUNCTION__, strTextureName.c_str());
 }
 
+#ifndef HAS_XBOX_D3D
 void CGUITextureManager::FreeUnusedTextures()
 {
   CSingleLock lock(g_graphicsContext);
@@ -599,6 +600,7 @@ void CGUITextureManager::FreeUnusedTextures()
     delete *i;
   m_unusedTextures.clear();
 }
+#endif
 
 void CGUITextureManager::Cleanup()
 {

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -19,34 +19,36 @@
 */
 
 
-#include "include.h"
 #include "TextureManager.h"
 #include "Texture.h"
 #include "AnimatedGif.h"
 #include "GraphicContext.h"
 #include "threads/SingleLock.h"
-#include "utils/StringUtils.h"
-#include "pictures/Picture.h"
 #include "utils/CharsetConverter.h"
-#include "filesystem/File.h"
-#include "filesystem/Directory.h"
-#include "filesystem/SpecialProtocol.h"
-#include "settings/AdvancedSettings.h"
-#include "utils/TimeUtils.h"
+#include "utils/log.h"
 #include "utils/URIUtils.h"
 #include "addons/Skin.h"
+#ifdef _DEBUG
+#include "utils/TimeUtils.h"
+#endif
+#include "filesystem/File.h"
+#include "filesystem/Directory.h"
+#include <assert.h>
 
 #ifdef HAS_XBOX_D3D
 #include <XGraphics.h>
+#include "settings/AdvancedSettings.h"
 #endif
 
 using namespace std;
 
-extern "C" void dllprintf( const char *format, ... );
-
 CGUITextureManager g_TextureManager;
 
-CTextureArray::CTextureArray(int width, int height, int loops, bool texCoordsArePixels)
+
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
+CTextureArray::CTextureArray(int width, int height, int loops,  bool texCoordsArePixels)
 {
   m_width = width;
   m_height = height;
@@ -59,7 +61,7 @@ CTextureArray::CTextureArray(int width, int height, int loops, bool texCoordsAre
 #else
   m_texCoordsArePixels = false;
 #endif
-};
+}
 
 CTextureArray::CTextureArray()
 {
@@ -75,6 +77,7 @@ unsigned int CTextureArray::size() const
 {
   return m_textures.size();
 }
+
 
 void CTextureArray::Reset()
 {
@@ -154,6 +157,35 @@ CTextureMap::~CTextureMap()
   FreeTexture();
 }
 
+bool CTextureMap::Release()
+{
+  if (!m_texture.m_textures.size())
+    return true;
+  if (!m_referenceCount)
+    return true;
+
+  m_referenceCount--;
+  if (!m_referenceCount)
+  {
+#ifdef HAS_XBOX_D3D
+    FreeTexture();
+#endif
+    return true;
+  }
+  return false;
+}
+
+const CStdString& CTextureMap::GetName() const
+{
+  return m_textureName;
+}
+
+const CTextureArray& CTextureMap::GetTexture()
+{
+  m_referenceCount++;
+  return m_texture;
+}
+
 void CTextureMap::Dump() const
 {
   if (!m_referenceCount)
@@ -164,9 +196,26 @@ void CTextureMap::Dump() const
   OutputDebugString(strLog.c_str());
 }
 
-const CStdString& CTextureMap::GetName() const
+unsigned int CTextureMap::GetMemoryUsage() const
 {
-  return m_textureName;
+  return m_memUsage;
+}
+
+void CTextureMap::Flush()
+{
+  if (!m_referenceCount)
+    FreeTexture();
+}
+
+
+void CTextureMap::FreeTexture()
+{
+  m_texture.Free();
+}
+
+bool CTextureMap::IsEmpty() const
+{
+  return m_texture.m_textures.size() == 0;
 }
 
 void CTextureMap::Add(CBaseTexture* texture, int delay)
@@ -177,60 +226,21 @@ void CTextureMap::Add(CBaseTexture* texture, int delay)
 #ifdef HAS_XBOX_D3D
     m_memUsage += sizeof(CTexture) + (texture->GetPitch() * texture->GetRows()); // This is equal to D3DSURFACE_DESC.Size
 #else
-    m_memUsage += sizeof(CTexture) + (texture->GetTextureWidth() * texture->GetTextureHeight() * 4); Kodi assumes format XB_FMT_A8R8G8B8 which is biggest
+    m_memUsage += sizeof(CTexture) + (texture->GetTextureWidth() * texture->GetTextureHeight() * 4);
 #endif
 }
 
-bool CTextureMap::Release()
-{
-  if (!m_texture.m_textures.size()) return true;
-  if (!m_referenceCount) return true;
-
-  m_referenceCount--;
-  if (!m_referenceCount)
-  {
-    FreeTexture();
-    return true;
-  }
-  return false;
-}
-
-const CTextureArray &CTextureMap::GetTexture()
-{
-  m_referenceCount++;
-  return m_texture;
-}
-
-void CTextureMap::Flush()
-{
-  if (!m_referenceCount)
-    FreeTexture();
-}
-
-void CTextureMap::FreeTexture()
-{
-  m_texture.Free();
-}
-
-unsigned int CTextureMap::GetMemoryUsage() const
-{
-  return m_memUsage;
-}
-
-bool CTextureMap::IsEmpty() const
-{
-  return m_texture.m_textures.size() == 0;
-}
-
-//------------------------------------------------------------------------------
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
 CGUITextureManager::CGUITextureManager(void)
 {
 #ifdef HAS_XBOX_D3D
   D3DXSetDXT3DXT5(TRUE);
-#endif
   for (int bundle = 0; bundle < 2; bundle++)
     m_iNextPreload[bundle] = m_PreLoadNames[bundle].end();
-  // we set the theme bundle to be the first bundle (thus prioritising it
+#endif
+  // we set the theme bundle to be the first bundle (thus prioritizing it)
   m_TexBundle[0].SetThemeBundle(true);
 }
 
@@ -239,10 +249,9 @@ CGUITextureManager::~CGUITextureManager(void)
   Cleanup();
 }
 
-static const CTextureArray emptyTexture;
-
-const CTextureArray &CGUITextureManager::GetTexture(const CStdString& strTextureName)
+const CTextureArray& CGUITextureManager::GetTexture(const CStdString& strTextureName)
 {
+  static CTextureArray emptyTexture;
   //  CLog::Log(LOGINFO, " refcount++ for  GetTexture(%s)\n", strTextureName.c_str());
   for (int i = 0; i < (int)m_vecTextures.size(); ++i)
   {
@@ -256,26 +265,7 @@ const CTextureArray &CGUITextureManager::GetTexture(const CStdString& strTexture
   return emptyTexture;
 }
 
-// Round a number to the nearest power of 2 rounding up
-// runs pretty quickly - the only expensive op is the bsr
-// alternive would be to dec the source, round down and double the result
-// which is slightly faster but rounds 1 to 2
-DWORD __forceinline __stdcall PadPow2(DWORD x)
-{
-  __asm {
-    mov edx, x    // put the value in edx
-    xor ecx, ecx  // clear ecx - if x is 0 bsr doesn't alter it
-    bsr ecx, edx  // find MSB position
-    mov eax, 1    // shift 1 by result effectively
-    shl eax, cl   // doing a round down to power of 2
-    cmp eax, edx  // check if x was already a power of two
-    adc ecx, 0    // if it wasn't then CF is set so add to ecx
-    mov eax, 1    // shift 1 by result again, this does a round
-    shl eax, cl   // up as a result of adding CF to ecx
-  }
-  // return result in eax
-}
-
+#ifdef HAS_XBOX_D3D
 void CGUITextureManager::StartPreLoad()
 {
   for (int bundle = 0; bundle < 2; bundle++)
@@ -329,7 +319,11 @@ void CGUITextureManager::FlushPreLoad()
     m_iNextPreload[i] = m_PreLoadNames[i].end();
   }
 }
+#endif
 
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
 bool CGUITextureManager::CanLoad(const CStdString &texturePath) const
 {
   if (texturePath == "-")
@@ -361,6 +355,7 @@ bool CGUITextureManager::HasTexture(const CStdString &textureName, CStdString *p
     {
       for (int i = 0; i < 2; i++)
       {
+#ifdef HAS_XBOX_D3D
         if (m_iNextPreload[i] != m_PreLoadNames[i].end() && (*m_iNextPreload[i] == bundledName))
         {
           ++m_iNextPreload[i];
@@ -369,6 +364,7 @@ bool CGUITextureManager::HasTexture(const CStdString &textureName, CStdString *p
             m_TexBundle[i].PreloadFile(*m_iNextPreload[i]);
         }
       }
+#endif
       if (size) *size = 1;
       return true;
     }
@@ -376,6 +372,7 @@ bool CGUITextureManager::HasTexture(const CStdString &textureName, CStdString *p
 
   for (int i = 0; i < 2; i++)
   {
+#ifdef HAS_XBOX_D3D
     if (m_iNextPreload[i] != m_PreLoadNames[i].end() && (*m_iNextPreload[i] == bundledName))
     {
       if (bundle) *bundle = i;
@@ -385,7 +382,9 @@ bool CGUITextureManager::HasTexture(const CStdString &textureName, CStdString *p
         m_TexBundle[i].PreloadFile(*m_iNextPreload[i]);
       return true;
     }
-    else if (m_TexBundle[i].HasFile(bundledName))
+    else
+#endif
+    if (m_TexBundle[i].HasFile(bundledName))
     {
       if (bundle) *bundle = i;
       return true;
@@ -434,8 +433,10 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
       if (!nImages)
       {
         CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
+#ifdef HAS_XBOX_D3D
         delete [] pTextures;
         delete [] Delay;
+#endif
         return 0;
       }
 
@@ -477,6 +478,15 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
         pal[AnimatedGifSet.m_vecimg[0]->Transparent].peFlags = 0;
 
       palette->Unlock();
+#else
+      // fixup our palette
+      COLOR *palette = AnimatedGifSet.m_vecimg[0]->Palette;
+      // set the alpha values to fully opaque
+      for (int i = 0; i < 256; i++)
+        palette[i].x = 0xff;
+      // and set the transparent colour
+      if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
+        palette[AnimatedGifSet.m_vecimg[0]->Transparent].x = 0;
 #endif
 
       pMap = new CTextureMap(strTextureName, iWidth, iHeight, AnimatedGifSet.nLoops);
@@ -487,7 +497,11 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
         if (glTexture)
         {
           CAnimatedGif* pImage = AnimatedGifSet.m_vecimg[iImage];
+#ifdef HAS_XBOX_D3D
           glTexture->LoadPaletted(pImage->Width, pImage->Height, pImage->BytesPerRow, XB_FMT_A8, (unsigned char *)pImage->Raster, iImage == 0 ? palette : NULL);
+#else
+          glTexture->LoadPaletted(pImage->Width, pImage->Height, pImage->BytesPerRow, XB_FMT_A8R8G8B8, (unsigned char *)pImage->Raster, palette);
+#endif
           pMap->Add(glTexture, pImage->Delay);
         }
       } // of for (int iImage=0; iImage < iImages; iImage++)
@@ -518,10 +532,13 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   }
   else
   {
-    bool isThumbnail = URIUtils::GetExtension(strPath).Equals(".tbn");
-
     pTexture = new CTexture();
+#ifdef HAS_XBOX_D3D
+    bool isThumbnail = URIUtils::GetExtension(strPath).Equals(".tbn");
     if (!pTexture->LoadFromFile(strPath, isThumbnail ? g_advancedSettings.m_thumbSize : 0, isThumbnail ? g_advancedSettings.m_thumbSize : 0))
+#else
+    if(!pTexture->LoadFromFile(strPath))
+#endif
       return 0;
     width = pTexture->GetWidth();
     height = pTexture->GetHeight();
@@ -560,7 +577,12 @@ void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName)
       if (pMap->Release())
       {
         //CLog::Log(LOGINFO, "  cleanup:%s", strTextureName.c_str());
+#ifdef HAS_XBOX_D3D
         delete pMap;
+#else
+        // add to our textures to free
+        m_unusedTextures.push_back(pMap);
+#endif
         i = m_vecTextures.erase(i);
       }
       return;
@@ -568,6 +590,14 @@ void CGUITextureManager::ReleaseTexture(const CStdString& strTextureName)
     ++i;
   }
   CLog::Log(LOGWARNING, "%s: Unable to release texture %s", __FUNCTION__, strTextureName.c_str());
+}
+
+void CGUITextureManager::FreeUnusedTextures()
+{
+  CSingleLock lock(g_graphicsContext);
+  for (ivecTextures i = m_unusedTextures.begin(); i != m_unusedTextures.end(); ++i)
+    delete *i;
+  m_unusedTextures.clear();
 }
 
 void CGUITextureManager::Cleanup()
@@ -585,6 +615,9 @@ void CGUITextureManager::Cleanup()
   }
   for (int i = 0; i < 2; i++)
     m_TexBundle[i].Cleanup();
+#ifndef HAS_XBOX_D3D
+  FreeUnusedTextures();
+#endif
 }
 
 void CGUITextureManager::Dump() const
@@ -635,18 +668,21 @@ unsigned int CGUITextureManager::GetMemoryUsage() const
 
 void CGUITextureManager::SetTexturePath(const CStdString &texturePath)
 {
+  CSingleLock lock(m_section);
   m_texturePaths.clear();
   AddTexturePath(texturePath);
 }
 
 void CGUITextureManager::AddTexturePath(const CStdString &texturePath)
 {
+  CSingleLock lock(m_section);
   if (!texturePath.IsEmpty())
     m_texturePaths.push_back(texturePath);
 }
 
 void CGUITextureManager::RemoveTexturePath(const CStdString &texturePath)
 {
+  CSingleLock lock(m_section);
   for (vector<CStdString>::iterator it = m_texturePaths.begin(); it != m_texturePaths.end(); ++it)
   {
     if (*it == texturePath)
@@ -663,6 +699,7 @@ CStdString CGUITextureManager::GetTexturePath(const CStdString &textureName, boo
     return textureName;
   else
   { // texture doesn't include the full path, so check all fallbacks
+    CSingleLock lock(m_section);
     for (vector<CStdString>::iterator it = m_texturePaths.begin(); it != m_texturePaths.end(); ++it)
     {
       CStdString path = URIUtils::AddFileToFolder(it->c_str(), "media");

--- a/xbmc/guilib/TextureManager.cpp
+++ b/xbmc/guilib/TextureManager.cpp
@@ -416,8 +416,6 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
   //Lock here, we will do stuff that could break rendering
   CSingleLock lock(g_graphicsContext);
 
-  LPDIRECT3DPALETTE8 pPal = 0;
-
 #ifdef _DEBUG
   int64_t start;
   start = CurrentHostCounter();
@@ -425,128 +423,87 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
 
   if (strPath.Right(4).ToLower() == ".gif")
   {
-    return 0;
-//     CTextureMap* pMap;
+    CTextureMap* pMap;
 
-//     if (bundle >= 0)
-//     {
-//       LPDIRECT3DTEXTURE8* pTextures;
-//       int nLoops = 0;
-//       int* Delay;
-//       int nImages = m_TexBundle[bundle].LoadAnim(g_graphicsContext.Get3DDevice(), strTextureName, &info, &pTextures, &pPal, nLoops, &Delay);
-//       if (!nImages)
-//       {
-//         CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
-//         delete [] pTextures;
-//         delete [] Delay;
-//         return 0;
-//       }
+    if (bundle >= 0)
+    {
+      CBaseTexture **pTextures;
+      int nLoops = 0, width = 0, height = 0;
+      int* Delay;
+      int nImages = m_TexBundle[bundle].LoadAnim(strTextureName, &pTextures, width, height, nLoops, &Delay);
+      if (!nImages)
+      {
+        CLog::Log(LOGERROR, "Texture manager unable to load bundled file: %s", strTextureName.c_str());
+        delete [] pTextures;
+        delete [] Delay;
+        return 0;
+      }
 
-//       pMap = new CTextureMap(strTextureName, info.Width, info.Height, nLoops, pPal, true);
-//       for (int iImage = 0; iImage < nImages; ++iImage)
-//       {
-//         pMap->Add(pTextures[iImage], Delay[iImage]);
-//       }
+      pMap = new CTextureMap(strTextureName, width, height, nLoops);
+      for (int iImage = 0; iImage < nImages; ++iImage)
+      {
+        pMap->Add(pTextures[iImage], Delay[iImage]);
+      }
 
-//       delete [] pTextures;
-//       delete [] Delay;
-// #ifdef HAS_XBOX_D3D
-//       pPal->Release();
-// #endif
-//     }
-//     else
-//     {
-//       CAnimatedGifSet AnimatedGifSet;
-//       int iImages = AnimatedGifSet.LoadGIF(strPath.c_str());
-//       if (iImages == 0)
-//       {
-//         CStdString rootPath = strPath.Left(g_SkinInfo->Path().GetLength());
-//         if (0 == rootPath.CompareNoCase(g_SkinInfo->Path()))
-//           CLog::Log(LOGERROR, "Texture manager unable to load file: %s", strPath.c_str());
-//         return 0;
-//       }
-//       int iWidth = AnimatedGifSet.FrameWidth;
-//       int iHeight = AnimatedGifSet.FrameHeight;
+      delete [] pTextures;
+      delete [] Delay;
+    }
+    else
+    {
+      CAnimatedGifSet AnimatedGifSet;
+      int iImages = AnimatedGifSet.LoadGIF(strPath.c_str());
+      if (iImages == 0)
+      {
+        CStdString rootPath = strPath.Left(g_SkinInfo->Path().GetLength());
+        if (0 == rootPath.CompareNoCase(g_SkinInfo->Path()))
+          CLog::Log(LOGERROR, "Texture manager unable to load file: %s", strPath.c_str());
+        return 0;
+      }
+      int iWidth = AnimatedGifSet.FrameWidth;
+      int iHeight = AnimatedGifSet.FrameHeight;
 
-//       int iPaletteSize = (1 << AnimatedGifSet.m_vecimg[0]->BPP);
-// #ifdef HAS_XBOX_D3D
-//       g_graphicsContext.Get3DDevice()->CreatePalette(D3DPALETTE_256, &pPal);
-//       PALETTEENTRY* pal;
-//       pPal->Lock((D3DCOLOR**)&pal, 0);
+#ifdef HAS_XBOX_D3D
+      LPDIRECT3DPALETTE8 palette = 0;
 
-//       memcpy(pal, AnimatedGifSet.m_vecimg[0]->Palette, sizeof(PALETTEENTRY)*iPaletteSize);
-//       for (int i = 0; i < iPaletteSize; i++)
-//         pal[i].peFlags = 0xff; // alpha
-//       if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
-//         pal[AnimatedGifSet.m_vecimg[0]->Transparent].peFlags = 0;
+      int iPaletteSize = (1 << AnimatedGifSet.m_vecimg[0]->BPP);
+      g_graphicsContext.Get3DDevice()->CreatePalette(D3DPALETTE_256, &palette);
+      PALETTEENTRY* pal;
+      palette->Lock((D3DCOLOR**)&pal, 0);
 
-//       pPal->Unlock();
-// #endif
-//       pMap = new CTextureMap(strTextureName, iWidth, iHeight, AnimatedGifSet.nLoops, pPal, false);
-//       for (int iImage = 0; iImage < iImages; iImage++)
-//       {
-//         int w = PadPow2(iWidth);
-//         int h = PadPow2(iHeight);
-// #ifdef HAS_XBOX_D3D
-//         if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_P8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
-// #else
-//         if (D3DXCreateTexture(g_graphicsContext.Get3DDevice(), w, h, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED, &pTexture) == D3D_OK)
-// #endif
-//         {
-//           CAnimatedGif* pImage = AnimatedGifSet.m_vecimg[iImage];
-//           D3DLOCKED_RECT lr;
-//           RECT rc = { 0, 0, pImage->Width, pImage->Height };
-//           if ( D3D_OK == pTexture->LockRect( 0, &lr, &rc, 0 ))
-//           {
-// #ifdef HAS_XBOX_D3D
-//             POINT pt = { 0, 0 };
-//             XGSwizzleRect(pImage->Raster, pImage->BytesPerRow, &rc, lr.pBits, w, h, &pt, 1);
-// #else
-//             COLOR *palette = AnimatedGifSet.m_vecimg[0]->Palette;
-//             // set the alpha values to fully opaque
-//             for (int i = 0; i < iPaletteSize; i++)
-//               palette[i].x = 0xff;
-//             // and set the transparent colour
-//             if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
-//               palette[AnimatedGifSet.m_vecimg[0]->Transparent].x = 0;
+      memcpy(pal, AnimatedGifSet.m_vecimg[0]->Palette, sizeof(PALETTEENTRY)*iPaletteSize);
+      for (int i = 0; i < iPaletteSize; i++)
+        pal[i].peFlags = 0xff; // alpha
+      if (AnimatedGifSet.m_vecimg[0]->Transparency && AnimatedGifSet.m_vecimg[0]->Transparent >= 0)
+        pal[AnimatedGifSet.m_vecimg[0]->Transparent].peFlags = 0;
 
-//             for (int y = 0; y < pImage->Height; y++)
-//             {
-//               BYTE *dest = (BYTE *)lr.pBits + y * lr.Pitch;
-//               BYTE *source = (BYTE *)pImage->Raster + y * pImage->BytesPerRow;
-//               for (int x = 0; x < pImage->Width; x++)
-//               {
-//                 COLOR col = palette[*source++];
-//                 *dest++ = col.b;
-//                 *dest++ = col.g;
-//                 *dest++ = col.r;
-//                 *dest++ = col.x;
-//               }
-//             }
-// #endif
-//             pTexture->UnlockRect( 0 );
+      palette->Unlock();
+#endif
 
-//             pMap->Add(pTexture, pImage->Delay);
-//           }
-//         }
-//       } // of for (int iImage=0; iImage < iImages; iImage++)
+      pMap = new CTextureMap(strTextureName, iWidth, iHeight, AnimatedGifSet.nLoops);
 
-// #ifdef HAS_XBOX_D3D
-//       pPal->Release();
-// #endif
-//     }
+      for (int iImage = 0; iImage < iImages; iImage++)
+      {
+        CTexture *glTexture = new CTexture();
+        if (glTexture)
+        {
+          CAnimatedGif* pImage = AnimatedGifSet.m_vecimg[iImage];
+          glTexture->LoadPaletted(pImage->Width, pImage->Height, pImage->BytesPerRow, XB_FMT_A8, (unsigned char *)pImage->Raster, iImage == 0 ? palette : NULL);
+          pMap->Add(glTexture, pImage->Delay);
+        }
+      } // of for (int iImage=0; iImage < iImages; iImage++)
+    }
 
-// #ifdef _DEBUG
-//     int64_t end, freq;
-//     end = CurrentHostCounter();
-//     freq = CurrentHostFrequency();
-//     char temp[200];
-//     sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
-//     OutputDebugString(temp);
-// #endif
+#ifdef _DEBUG
+    int64_t end, freq;
+    end = CurrentHostCounter();
+    freq = CurrentHostFrequency();
+    char temp[200];
+    sprintf(temp, "Load %s: %.1fms%s\n", strPath.c_str(), 1000.f * (end - start) / freq, (bundle >= 0) ? " (bundled)" : "");
+    OutputDebugString(temp);
+#endif
 
-//     m_vecTextures.push_back(pMap);
-//     return 1;
+    m_vecTextures.push_back(pMap);
+    return 1;
   } // of if (strPath.Right(4).ToLower()==".gif")
 
   CBaseTexture *pTexture = NULL;
@@ -568,68 +525,11 @@ int CGUITextureManager::Load(const CStdString& strTextureName, bool checkBundleO
       return 0;
     width = pTexture->GetWidth();
     height = pTexture->GetHeight();
-
-//     // normal picture
-//     // convert from utf8
-//     CStdString texturePath;
-//     g_charsetConverter.utf8ToStringCharset(strPath, texturePath);
-
-//     // if the file is a thumbnail, load with picture loader (fast jpeg decoder), and limit to our chosen thumbsize
-//     // as thumbnails could be slightly bigger on disk due to libjpeg scaling
-//     if (URIUtils::GetExtension(strPath).Equals(".tbn"))
-//     {
-//       CBaseTexture* texture = new CTexture();
-//       if (!texture->LoadFromFile(strPath, g_advancedSettings.m_thumbSize, g_advancedSettings.m_thumbSize))
-//         return 0;
-//       info.Width = texture->GetWidth();
-//       info.Height = texture->GetHeight();
-//     }
-//     else
-//     {
-
-//       HRESULT result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
-//                                        D3DX_DEFAULT, D3DX_DEFAULT, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
-//                                        D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
-
-//       int checkWidth  = D3DX_DEFAULT;
-//       int checkHeight = D3DX_DEFAULT;
-
-//       // Don't allow anything bigger than 720p on Xbox because of the limited amount of memory
-//       if ( info.Width > 1280 )
-//         checkWidth = 1280;
-
-//       if ( info.Height > 720 )
-//         checkHeight = 720;
-
-//       if (checkWidth != D3DX_DEFAULT || checkHeight != D3DX_DEFAULT )
-//       {
-//         // HACK!: If the picture/texture turns out to be too large try to load with a resolution equal to our screen
-//         CLog::Log(LOGWARNING, "%s - Texture file %s (%i x %i) is too big! Reloading resized", __FUNCTION__, strPath.c_str(), info.Width, info.Height );
-
-//         if (pTexture)
-//         {
-//           pTexture->Release();
-//           pTexture = NULL;
-//         }
-
-//         result = D3DXCreateTextureFromFileEx(g_graphicsContext.Get3DDevice(), CSpecialProtocol::TranslatePath(texturePath).c_str(),
-//                                          checkWidth, checkHeight, 1, 0, D3DFMT_LIN_A8R8G8B8, D3DPOOL_MANAGED,
-//                                          D3DX_FILTER_NONE , D3DX_FILTER_NONE, 0, &info, NULL, &pTexture);
-//       }
-
-//       if (result != D3D_OK)
-//       {
-// //       if (!strnicmp(strPath.c_str(), "special://home/skin/", 20) && !strnicmp(strPath.c_str(), "special://xbmc/skin/", 20))
-//           CLog::Log(LOGERROR, "%s - Texture manager unable to load file: %s", __FUNCTION__, strPath.c_str());
-//         return 0;
-//       }
-//     }
   }
 
   if (!pTexture) return 0;
 
   CTextureMap* pMap = new CTextureMap(strTextureName, width, height, 0);
-
   pMap->Add(pTexture, 100);
   m_vecTextures.push_back(pMap);
 

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -38,17 +38,16 @@ class CTextureArray
 {
 public:
   CTextureArray();
-  CTextureArray(int width, int height, int loops, LPDIRECT3DPALETTE8 palette = NULL, bool packed = false, bool texCoordsArePixels = false);
+  CTextureArray(int width, int height, int loops, bool texCoordsArePixels = false);
 
   void Reset();
 
-  void Add(LPDIRECT3DTEXTURE8 texture, int delay);
+  void Add(CBaseTexture *texture, int delay);
   void Set(CBaseTexture *texture, int width, int height);
   void Free();
   unsigned int size() const;
 
-  std::vector<LPDIRECT3DTEXTURE8> m_textures;
-  LPDIRECT3DPALETTE8 m_palette;
+  std::vector<CBaseTexture *> m_textures;
   std::vector<int> m_delays;
   int m_width;
   int m_height;
@@ -57,7 +56,6 @@ public:
   int m_texWidth;
   int m_texHeight;
   bool m_texCoordsArePixels;
-  bool m_packed;
 };
 
 /*!
@@ -70,8 +68,8 @@ public:
   CTextureMap();
   virtual ~CTextureMap();
 
-  CTextureMap(const CStdString& textureName, int width, int height, int loops, LPDIRECT3DPALETTE8 palette, bool packed);
-  void Add(LPDIRECT3DTEXTURE8 pTexture, int delay);
+  CTextureMap(const CStdString& textureName, int width, int height, int loops);
+  void Add(CBaseTexture *texture, int delay);
   bool Release();
 
   const CStdString& GetName() const;

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -129,10 +129,14 @@ public:
   void SetTexturePath(const CStdString &texturePath);    ///< Set a single path as the path to check when loading media (clear then add)
   void RemoveTexturePath(const CStdString &texturePath); ///< Remove a path from the paths to check when loading media
 
+#ifndef HAS_XBOX_D3D
   void FreeUnusedTextures(); ///< Free textures (called from app thread only)
+#endif
 protected:
   std::vector<CTextureMap*> m_vecTextures;
+#ifndef HAS_XBOX_D3D // We could probably switch to XBMC way of cleaning unused textures
   std::vector<CTextureMap*> m_unusedTextures;
+#endif
   typedef std::vector<CTextureMap*>::iterator ivecTextures;
   // we have 2 texture bundles (one for the base textures, one for the theme)
   CTextureBundle m_TexBundle[2];

--- a/xbmc/guilib/TextureManager.h
+++ b/xbmc/guilib/TextureManager.h
@@ -29,16 +29,20 @@
 #include <vector>
 #include <list>
 #include "TextureBundle.h"
+#include "threads/CriticalSection.h"
 
 #pragma once
 
-
-// currently just used as a transport from texture manager to rest of app
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
 class CTextureArray
 {
 public:
-  CTextureArray();
   CTextureArray(int width, int height, int loops, bool texCoordsArePixels = false);
+  CTextureArray();
+
+  virtual ~CTextureArray();
 
   void Reset();
 
@@ -47,7 +51,7 @@ public:
   void Free();
   unsigned int size() const;
 
-  std::vector<CBaseTexture *> m_textures;
+  std::vector<CBaseTexture* > m_textures;
   std::vector<int> m_delays;
   int m_width;
   int m_height;
@@ -62,20 +66,23 @@ public:
  \ingroup textures
  \brief
  */
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
 class CTextureMap
 {
 public:
   CTextureMap();
+  CTextureMap(const CStdString& textureName, int width, int height, int loops);
   virtual ~CTextureMap();
 
-  CTextureMap(const CStdString& textureName, int width, int height, int loops);
-  void Add(CBaseTexture *texture, int delay);
+  void Add(CBaseTexture* texture, int delay);
   bool Release();
 
   const CStdString& GetName() const;
-  const CTextureArray &GetTexture();
+  const CTextureArray& GetTexture();
   void Dump() const;
-  unsigned int GetMemoryUsage() const;
+  uint32_t GetMemoryUsage() const;
   void Flush();
   bool IsEmpty() const;
 protected:
@@ -84,31 +91,36 @@ protected:
   CStdString m_textureName;
   CTextureArray m_texture;
   unsigned int m_referenceCount;
-  unsigned int m_memUsage;
+  uint32_t m_memUsage;
 };
 
 /*!
  \ingroup textures
  \brief
  */
+/************************************************************************/
+/*                                                                      */
+/************************************************************************/
 class CGUITextureManager
 {
 public:
   CGUITextureManager(void);
   virtual ~CGUITextureManager(void);
 
+#ifdef HAS_XBOX_D3D
   void StartPreLoad();
   void PreLoad(const CStdString& strTextureName);
   void EndPreLoad();
   void FlushPreLoad();
+#endif
   bool HasTexture(const CStdString &textureName, CStdString *path = NULL, int *bundle = NULL, int *size = NULL);
   bool CanLoad(const CStdString &texturePath) const; ///< Returns true if the texture manager can load this texture
   int Load(const CStdString& strTextureName, bool checkBundleOnly = false);
-  const CTextureArray &GetTexture(const CStdString& strTextureName);
+  const CTextureArray& GetTexture(const CStdString& strTextureName);
   void ReleaseTexture(const CStdString& strTextureName);
   void Cleanup();
   void Dump() const;
-  unsigned int GetMemoryUsage() const;
+  uint32_t GetMemoryUsage() const;
   void Flush();
   CStdString GetTexturePath(const CStdString& textureName, bool directory = false);
   void GetBundledTexturesFromPath(const CStdString& texturePath, std::vector<CStdString> &items);
@@ -117,15 +129,20 @@ public:
   void SetTexturePath(const CStdString &texturePath);    ///< Set a single path as the path to check when loading media (clear then add)
   void RemoveTexturePath(const CStdString &texturePath); ///< Remove a path from the paths to check when loading media
 
+  void FreeUnusedTextures(); ///< Free textures (called from app thread only)
 protected:
   std::vector<CTextureMap*> m_vecTextures;
+  std::vector<CTextureMap*> m_unusedTextures;
   typedef std::vector<CTextureMap*>::iterator ivecTextures;
   // we have 2 texture bundles (one for the base textures, one for the theme)
   CTextureBundle m_TexBundle[2];
+#ifdef HAS_XBOX_D3D
   std::list<CStdString> m_PreLoadNames[2];
   std::list<CStdString>::iterator m_iNextPreload[2];
+#endif
 
   std::vector<CStdString> m_texturePaths;
+  CCriticalSection m_section;
 };
 
 /*!


### PR DESCRIPTION
This PR moves more even more logic regarding textures to our own implementation of CBaseTexture. This should make some GUILIB code even more inline with XBMC mainline