### PR TITLE
[Confluence] adjustments needed by PR4613 #4772 

### DIFF
--- a/addons/skin.confluence.lite/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogAlbumInfo.xml
@@ -117,9 +117,9 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>140</left>
+								<left>0</left>
 								<top>0</top>
-								<width>160</width>
+								<width>140</width>
 								<height>30</height>
 								<font>font13</font>
 								<align>right</align>
@@ -152,9 +152,9 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>140</left>
+								<left>0</left>
 								<top>0</top>
-								<width>160</width>
+								<width>140</width>
 								<height>30</height>
 								<font>font13</font>
 								<align>right</align>
@@ -270,7 +270,7 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -305,7 +305,7 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -506,7 +506,7 @@
 							<label>([COLOR=selected][B]$INFO[ListItem.TrackNumber][/B][/COLOR]) - $INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>420</left>
+							<left>220</left>
 							<top>0</top>
 							<width>200</width>
 							<height>40</height>
@@ -546,7 +546,7 @@
 							<label>([COLOR=selected][B]$INFO[ListItem.TrackNumber][/B][/COLOR]) - $INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>420</left>
+							<left>220</left>
 							<top>0</top>
 							<width>200</width>
 							<height>40</height>

--- a/addons/skin.confluence.lite/720p/DialogAlbumInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogAlbumInfo.xml
@@ -7,8 +7,8 @@
 			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>1100</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
@@ -18,8 +18,8 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label">
 					<description>Album header label</description>
-					<posx>210</posx>
-					<posy>50</posy>
+					<left>210</left>
+					<top>50</top>
 					<width>1030</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -32,8 +32,8 @@
 				</control>
 				<control type="label">
 					<description>Artist header label</description>
-					<posx>210</posx>
-					<posy>50</posy>
+					<left>210</left>
+					<top>50</top>
 					<width>1030</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -46,13 +46,13 @@
 				</control>
 				<control type="group">
 					<visible>Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>387</posx>
+					<top>90</top>
+					<left>387</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
 						<description>Current Fanart image</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>675</width>
 						<height>380</height>
 						<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
@@ -65,8 +65,8 @@
 						<visible>IsEmpty(Listitem.Property(Fanart_Image))</visible>
 						<control type="image">
 							<description>No Fanart Back</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>675</width>
 							<height>380</height>
 							<texture background="true">special://skin/backgrounds/Fanart_Fallback_Music_Small.jpg</texture>
@@ -76,8 +76,8 @@
 							<colordiffuse>88FFFFFF</colordiffuse>
 						</control>
 						<control type="label">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>675</width>
 							<height>380</height>
 							<font>font30_title</font>
@@ -91,12 +91,12 @@
 				</control>
 				<control type="group">
 					<visible>container.content(Albums) + !Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>380</width>
 						<height>360</height>
 						<aspectratio>keep</aspectratio>
@@ -105,8 +105,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="list" id="49">
-						<posx>390</posx>
-						<posy>20</posy>
+						<left>390</left>
+						<top>20</top>
 						<width>640</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -117,8 +117,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>140</posx>
-								<posy>0</posy>
+								<left>140</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -129,8 +129,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>150</posx>
-								<posy>0</posy>
+								<left>150</left>
+								<top>0</top>
 								<width>500</width>
 								<height>30</height>
 								<font>font13</font>
@@ -143,8 +143,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>640</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -152,8 +152,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>140</posx>
-								<posy>0</posy>
+								<left>140</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -164,8 +164,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>150</posx>
-								<posy>0</posy>
+								<left>150</left>
+								<top>0</top>
 								<width>500</width>
 								<height>30</height>
 								<font>font13</font>
@@ -234,8 +234,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>390</posx>
-						<posy>370</posy>
+						<left>390</left>
+						<top>370</top>
 						<width>640</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -244,12 +244,12 @@
 				</control>
 				<control type="group">
 					<visible>container.content(Artists) + !Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>380</width>
 						<height>360</height>
 						<aspectratio>keep</aspectratio>
@@ -258,8 +258,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="list" id="49">
-						<posx>390</posx>
-						<posy>20</posy>
+						<left>390</left>
+						<top>20</top>
 						<width>640</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -270,8 +270,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -282,8 +282,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -296,8 +296,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>640</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -305,8 +305,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -317,8 +317,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -387,8 +387,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>390</posx>
-						<posy>370</posy>
+						<left>390</left>
+						<top>370</top>
 						<width>640</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -396,8 +396,8 @@
 					</control>
 				</control>
 				<control type="label">
-					<posx>130r</posx>
-					<posy>480</posy>
+					<left>130r</left>
+					<top>480</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -410,8 +410,8 @@
 					<visible>Control.IsVisible(4)</visible>
 				</control>
 				<control type="label">
-					<posx>130r</posx>
-					<posy>480</posy>
+					<left>130r</left>
+					<top>480</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -424,8 +424,8 @@
 					<visible>Control.IsVisible(50) + Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<posx>130r</posx>
-					<posy>480</posy>
+					<left>130r</left>
+					<top>480</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -439,8 +439,8 @@
 				</control>
 				<control type="spincontrol" id="61">
 					<description>Next page button</description>
-					<posx>120r</posx>
-					<posy>485</posy>
+					<left>120r</left>
+					<top>485</top>
 					<subtype>page</subtype>
 					<font>-</font>
 					<onleft>61</onleft>
@@ -452,8 +452,8 @@
 				</control>
 				<control type="textbox" id="4">
 					<description>Description</description>
-					<posx>210</posx>
-					<posy>515</posy>
+					<left>210</left>
+					<top>515</top>
 					<width>1030</width>
 					<height>120</height>
 					<font>font12</font>
@@ -465,8 +465,8 @@
 				</control>
 				<control type="image">
 					<description>Actor image</description>
-					<posx>210</posx>
-					<posy>480</posy>
+					<left>210</left>
+					<top>480</top>
 					<width>160</width>
 					<height>160</height>
 					<texture fallback="DefaultAlbumCover.png">$INFO[Container(50).Listitem.Icon]</texture>
@@ -474,8 +474,8 @@
 					<visible>Control.IsVisible(50)</visible>
 				</control>
 				<control type="panel" id="50">
-					<posx>380</posx>
-					<posy>520</posy>
+					<left>380</left>
+					<top>520</top>
 					<width>860</width>
 					<height>120</height>
 					<onleft>9000</onleft>
@@ -488,15 +488,15 @@
 					<orientation>vertical</orientation>
 					<itemlayout condition="Container.Content(Albums)" height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -506,8 +506,8 @@
 							<label>([COLOR=selected][B]$INFO[ListItem.TrackNumber][/B][/COLOR]) - $INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>420</posx>
-							<posy>0</posy>
+							<left>420</left>
+							<top>0</top>
 							<width>200</width>
 							<height>40</height>
 							<font>font12</font>
@@ -519,24 +519,24 @@
 					</itemlayout>
 					<focusedlayout condition="Container.Content(Albums)" height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>!Control.HasFocus(50)</visible>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>Control.HasFocus(50)</visible>
 							<texture border="5">button-focus2.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -546,8 +546,8 @@
 							<label>([COLOR=selected][B]$INFO[ListItem.TrackNumber][/B][/COLOR]) - $INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>420</posx>
-							<posy>0</posy>
+							<left>420</left>
+							<top>0</top>
 							<width>200</width>
 							<height>40</height>
 							<font>font12</font>
@@ -559,15 +559,15 @@
 					</focusedlayout>
 					<itemlayout condition="Container.Content(Artists)" height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -579,24 +579,24 @@
 					</itemlayout>
 					<focusedlayout condition="Container.Content(Artists)" height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>!Control.HasFocus(50)</visible>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>Control.HasFocus(50)</visible>
 							<texture border="5">button-focus2.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -608,8 +608,8 @@
 					</focusedlayout>
 				</control>
 				<control type="grouplist" id="9000">
-					<posx>210</posx>
-					<posy>660</posy>
+					<left>210</left>
+					<top>660</top>
 					<width>1030</width>
 					<height>40</height>
 					<itemgap>2</itemgap>

--- a/addons/skin.confluence.lite/720p/DialogBusy.xml
+++ b/addons/skin.confluence.lite/720p/DialogBusy.xml
@@ -3,25 +3,25 @@
 	<animation effect="fade" time="200">WindowClose</animation>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="group">
-			<posx>1070</posx>
-			<posy>640</posy>
+			<left>1070</left>
+			<top>640</top>
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>200</width>
 				<height>70</height>
 				<texture border="20">OverlayDialogBackground.png</texture>
 			</control>
 			<control type="image">
 				<description>Busy animation</description>
-				<posx>20</posx>
-				<posy>20</posy>
+				<left>20</left>
+				<top>20</top>
 				<width>32</width>
 				<height>32</height>
 				<texture>busy.png</texture>
@@ -30,8 +30,8 @@
 			</control>
 			<control type="label">
 				<description>Busy label</description>
-				<posx>60</posx>
-				<posy>20</posy>
+				<left>60</left>
+				<top>20</top>
 				<width>120</width>
 				<height>32</height>
 				<align>left</align>
@@ -41,8 +41,8 @@
 			</control>
       <control type="progress" id="10">
 				<description>Progressbar</description>
-				<posx>20</posx>
-				<posy>65</posy>
+				<left>20</left>
+				<top>65</top>
 				<width>160</width>
 				<height>10</height>
 				<!-- <info>System.Progressbar</info> -->

--- a/addons/skin.confluence.lite/720p/DialogButtonMenu.xml
+++ b/addons/skin.confluence.lite/720p/DialogButtonMenu.xml
@@ -3,20 +3,20 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
 		</control>
 		<control type="grouplist" id="9000">
-			<posx>470</posx>
-			<posy>0</posy>
+			<left>470</left>
+			<top>0</top>
 			<width>340</width>
 			<height>720</height>
 			<onleft>9000</onleft>
@@ -27,8 +27,8 @@
 			<align>center</align>
 			<control type="image" id="1">
 				<description>background top image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>340</width>
 				<height>30</height>
 				<texture border="20,19,20,0">DialogContextTop.png</texture>
@@ -164,15 +164,15 @@
 				<visible>System.HasAlarm(shutdowntimer)</visible>
 				<control type="image">
 					<description>background middle image</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>340</width>
 					<height>70</height>
 					<texture border="25,5,25,5">DialogContextMiddle.png</texture>
 				</control>
 				<control type="textbox">
-					<posx>25</posx>
-					<posy>20</posy>
+					<left>25</left>
+					<top>20</top>
 					<width>290</width>
 					<height>50</height>
 					<font>font12</font>
@@ -184,7 +184,7 @@
 			</control>
 			<control type="image" id="12">
 				<description>background bottom image</description>
-				<posx>0</posx>
+				<left>0</left>
 				<width>340</width>
 				<height>25</height>
 				<texture border="20,0,19,20">DialogContextBottom.png</texture>

--- a/addons/skin.confluence.lite/720p/DialogContextMenu.xml
+++ b/addons/skin.confluence.lite/720p/DialogContextMenu.xml
@@ -3,30 +3,30 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="image" id="999">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>340</width>
 			<height>720</height>
 			<texture border="20">DialogBack.png</texture>
 		</control>
     <control type="grouplist" id="996">
 			<description>grouplist for context buttons</description>
-			<posx>20</posx>
-			<posy>30</posy>
+			<left>20</left>
+			<top>30</top>
 			<width>300</width>
 			<height max="670">auto</height>
 			<itemgap>2</itemgap>
     </control>
 		<control type="button" id="1000">
 			<description>context button template</description>
-			<posx>-</posx>
-			<posy>20</posy>
+			<left>-</left>
+			<top>20</top>
 			<width>300</width>
 			<height>40</height>
 			<font>fontContextMenu</font>

--- a/addons/skin.confluence.lite/720p/DialogExtendedProgressBar.xml
+++ b/addons/skin.confluence.lite/720p/DialogExtendedProgressBar.xml
@@ -4,21 +4,21 @@
 	<animation effect="slide" start="0,0" end="0,-70" delay="400" time="100">WindowClose</animation>
 	<controls>
 		<control type="group">
-			<posx>720</posx>
-			<posy>0</posy>
+			<left>720</left>
+			<top>0</top>
 			<animation effect="slide" end="-400,0" time="200" condition="Window.IsVisible(133)">conditional</animation>
 			<animation effect="slide" end="0,-80" time="200" condition="Window.IsVisible(FullscreenVideo) | Window.IsVisible(Visualisation)">conditional</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>-10</posy>
+				<left>0</left>
+				<top>-10</top>
 				<width>400</width>
 				<height>70</height>
 				<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
 			</control>
 			<control type="label" id="30">
 				<description>Header Label</description>
-				<posx>15</posx>
-				<posy>4</posy>
+				<left>15</left>
+				<top>4</top>
 				<width>370</width>
 				<height>18</height>
 				<font>font10_title</font>
@@ -28,8 +28,8 @@
 			</control>
 			<control type="label" id="31">
 				<description>Title Label</description>
-				<posx>15</posx>
-				<posy>20</posy>
+				<left>15</left>
+				<top>20</top>
 				<width>370</width>
 				<height>20</height>
 				<font>font10</font>
@@ -38,8 +38,8 @@
 			</control>
 			<control type="progress" id="32">
 				<description>progress control</description>
-				<posx>15</posx>
-				<posy>42</posy>
+				<left>15</left>
+				<top>42</top>
 				<width>370</width>
 				<height>8</height>
 			</control>

--- a/addons/skin.confluence.lite/720p/DialogFavourites.xml
+++ b/addons/skin.confluence.lite/720p/DialogFavourites.xml
@@ -2,23 +2,23 @@
 	<defaultcontrol always="true">450</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="group">
 			<animation effect="slide" start="400,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="400,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<posx>400r</posx>
-				<posy>0</posy>
+				<left>400r</left>
+				<top>0</top>
 				<width>400</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">HomeBladeSub.png</texture>
 			</control>
 			<control type="image">
-				<posx>370r</posx>
-				<posy>30</posy>
+				<left>370r</left>
+				<top>30</top>
 				<width>200</width>
 				<height>200</height>
 				<aspectratio align="center">keep</aspectratio>
@@ -28,8 +28,8 @@
 				<bordersize>8</bordersize>
 			</control>
 			<control type="list" id="450">
-				<posx>390r</posx>
-				<posy>250</posy>
+				<left>390r</left>
+				<top>250</top>
 				<width>450</width>
 				<height>380</height>
 				<onup>450</onup>
@@ -40,15 +40,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="40">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>370</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>350</width>
 						<height>40</height>
 						<font>font12_title</font>
@@ -60,24 +60,24 @@
 				</itemlayout>
 				<focusedlayout height="40">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>370</width>
 						<height>40</height>
 						<visible>!Control.HasFocus(450)</visible>
 						<texture border="3">button-nofocus.png</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>370</width>
 						<height>40</height>
 						<visible>Control.HasFocus(450)</visible>
 						<texture border="3">button-focus.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>350</width>
 						<height>40</height>
 						<font>font12_title</font>
@@ -90,8 +90,8 @@
 			</control>
 			<control type="label">
 				<description>Page label</description>
-				<posx>30r</posx>
-				<posy>670</posy>
+				<left>30r</left>
+				<top>670</top>
 				<width>350</width>
 				<height>30</height>
 				<align>right</align>

--- a/addons/skin.confluence.lite/720p/DialogFileStacking.xml
+++ b/addons/skin.confluence.lite/720p/DialogFileStacking.xml
@@ -3,21 +3,21 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>315</posx>
-		<posy>260</posy>
+		<left>315</left>
+		<top>260</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>650</width>
 			<height>200</height>
 			<texture border="20">OverlayDialogBackground.png</texture>
 		</control>
 		<control type="label">
 			<description>heading label</description>
-			<posx>40</posx>
-			<posy>18</posy>
+			<left>40</left>
+			<top>18</top>
 			<width>570</width>
 			<height>30</height>
 			<align>center</align>
@@ -27,8 +27,8 @@
 			<textcolor>white</textcolor>
 		</control>
 		<control type="label">
-			<posx>40</posx>
-			<posy>60</posy>
+			<left>40</left>
+			<top>60</top>
 			<width>570</width>
 			<height>30</height>
 			<align>center</align>
@@ -38,24 +38,24 @@
 			<textcolor>grey2</textcolor>
 		</control>
 		<control type="image">
-			<posx>50</posx>
-			<posy>110</posy>
+			<left>50</left>
+			<top>110</top>
 			<width>20</width>
 			<height>25</height>
 			<texture>scroll-left-focus.png</texture>
 			<visible>Container(450).HasPrevious</visible>
 		</control>
 		<control type="image">
-			<posx>575</posx>
-			<posy>110</posy>
+			<left>575</left>
+			<top>110</top>
 			<width>20</width>
 			<height>25</height>
 			<texture>scroll-right-focus.png</texture>
 			<visible>Container(450).HasNext</visible>
 		</control>
 		<control type="list" id="450">
-			<posx>85</posx>
-			<posy>105</posy>
+			<left>85</left>
+			<top>105</top>
 			<width>480</width>
 			<height>100</height>
 			<onleft>450</onleft>
@@ -68,8 +68,8 @@
 			<scrolltime>200</scrolltime>
 			<itemlayout width="40">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>38</width>
 					<height>32</height>
 					<aspectratio>stretch</aspectratio>
@@ -78,8 +78,8 @@
 			</itemlayout>
 			<focusedlayout width="40">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>38</width>
 					<height>32</height>
 					<aspectratio>stretch</aspectratio>
@@ -88,8 +88,8 @@
 			</focusedlayout>
 		</control>
 		<control type="label">
-			<posx>40</posx>
-			<posy>155</posy>
+			<left>40</left>
+			<top>155</top>
 			<width>570</width>
 			<height>22</height>
 			<font>font13_title</font>

--- a/addons/skin.confluence.lite/720p/DialogKaraokeSongSelector.xml
+++ b/addons/skin.confluence.lite/720p/DialogKaraokeSongSelector.xml
@@ -3,19 +3,19 @@
 	<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100">WindowClose</animation>
 	<controls>
 		<control type="group">
-			<posx>100</posx>
-			<posy>0</posy>
+			<left>100</left>
+			<top>0</top>
 			<control type="image">
-				<posx>0</posx>
-				<posy>-10</posy>
+				<left>0</left>
+				<top>-10</top>
 				<width>370</width>
 				<height>70</height>
 				<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
 			</control>
 			<control type="label" id="401">
 				<description>Song Number Label</description>
-				<posx>15</posx>
-				<posy>2</posy>
+				<left>15</left>
+				<top>2</top>
 				<width>340</width>
 				<height>25</height>
 				<font>font13_title</font>
@@ -25,8 +25,8 @@
 			</control>
 			<control type="label" id="402">
 				<description>Song Name Label</description>
-				<posx>15</posx>
-				<posy>27</posy>
+				<left>15</left>
+				<top>27</top>
 				<width>340</width>
 				<height>20</height>
 				<font>font13</font>

--- a/addons/skin.confluence.lite/720p/DialogKaraokeSongSelectorLarge.xml
+++ b/addons/skin.confluence.lite/720p/DialogKaraokeSongSelectorLarge.xml
@@ -2,30 +2,30 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>415</posx>
-		<posy>275</posy>
+		<left>415</left>
+		<top>275</top>
 	</coordinates>
 	<controls>
 		<control type="group">
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>450</width>
 				<height>170</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>370</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label" id="1">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>370</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -37,8 +37,8 @@
 			</control>
 			<control type="label" id="401">
 				<description>Song Number Label</description>
-				<posx>30</posx>
-				<posy>70</posy>
+				<left>30</left>
+				<top>70</top>
 				<width>390</width>
 				<height>30</height>
 				<font>font28_title</font>
@@ -48,8 +48,8 @@
 			</control>
 			<control type="label" id="402">
 				<description>Song Name Label</description>
-				<posx>30</posx>
-				<posy>120</posy>
+				<left>30</left>
+				<top>120</top>
 				<width>390</width>
 				<height>20</height>
 				<font>font24</font>

--- a/addons/skin.confluence.lite/720p/DialogKeyboard.xml
+++ b/addons/skin.confluence.lite/720p/DialogKeyboard.xml
@@ -3,32 +3,32 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>2</system>
-		<posx>255</posx>
-		<posy>145</posy>
+		<left>255</left>
+		<top>145</top>
 	</coordinates>
 	<controls>
 		<control type="group">
 			<include>VisibleFadeEffect</include>
 			<visible>!Window.IsVisible(numericinput)</visible>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>760</width>
 				<height>430</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>680</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label" id="311">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -38,8 +38,8 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="image">
-				<posx>50</posx>
-				<posy>60</posy>
+				<left>50</left>
+				<top>60</top>
 				<width>660</width>
 				<height>50</height>
 				<aspectratio>stretch</aspectratio>
@@ -47,8 +47,8 @@
 			</control>
 			<control type="label" id="310">
 				<description>Edit Text</description>
-				<posx>55</posx>
-				<posy>60</posy>
+				<left>55</left>
+				<top>60</top>
 				<width>650</width>
 				<height>50</height>
 				<font>font13</font>
@@ -56,8 +56,8 @@
 				<aligny>center</aligny>
 			</control>
 			<control type="image">
-				<posx>130</posx>
-				<posy>110</posy>
+				<left>130</left>
+				<top>110</top>
 				<width>500</width>
 				<height>30</height>
 				<aspectratio>stretch</aspectratio>
@@ -65,12 +65,12 @@
 			</control>
 			<control type="group">
 				<visible>!Skin.HasSetting(QWERTYKeys)</visible>
-				<posx>30</posx>
-				<posy>140</posy>
+				<left>30</left>
+				<top>140</top>
 				<control type="button" id="300">
 					<description>DONE button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20177</label>
@@ -87,8 +87,8 @@
 				</control>
 				<control type="button" id="48">
 					<description>'0' button</description>
-					<posx>200</posx>
-					<posy>0</posy>
+					<left>200</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>300</onleft>
@@ -104,8 +104,8 @@
 				</control>
 				<control type="button" id="49">
 					<description>'1' button</description>
-					<posx>250</posx>
-					<posy>0</posy>
+					<left>250</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>48</onleft>
@@ -121,8 +121,8 @@
 				</control>
 				<control type="button" id="50">
 					<description>'2' button</description>
-					<posx>300</posx>
-					<posy>0</posy>
+					<left>300</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>49</onleft>
@@ -138,8 +138,8 @@
 				</control>
 				<control type="button" id="51">
 					<description>'3' button</description>
-					<posx>350</posx>
-					<posy>0</posy>
+					<left>350</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>50</onleft>
@@ -155,8 +155,8 @@
 				</control>
 				<control type="button" id="52">
 					<description>'4' button</description>
-					<posx>400</posx>
-					<posy>0</posy>
+					<left>400</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>51</onleft>
@@ -172,8 +172,8 @@
 				</control>
 				<control type="button" id="53">
 					<description>'5' button</description>
-					<posx>450</posx>
-					<posy>0</posy>
+					<left>450</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>52</onleft>
@@ -189,8 +189,8 @@
 				</control>
 				<control type="button" id="54">
 					<description>'6' button</description>
-					<posx>500</posx>
-					<posy>0</posy>
+					<left>500</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>53</onleft>
@@ -206,8 +206,8 @@
 				</control>
 				<control type="button" id="55">
 					<description>'7' button</description>
-					<posx>550</posx>
-					<posy>0</posy>
+					<left>550</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>54</onleft>
@@ -223,8 +223,8 @@
 				</control>
 				<control type="button" id="56">
 					<description>'8' button</description>
-					<posx>600</posx>
-					<posy>0</posy>
+					<left>600</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>55</onleft>
@@ -240,8 +240,8 @@
 				</control>
 				<control type="button" id="57">
 					<description>'9' button</description>
-					<posx>650</posx>
-					<posy>0</posy>
+					<left>650</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>56</onleft>
@@ -257,8 +257,8 @@
 				</control>
 				<control type="radiobutton" id="302">
 					<description>SHIFT button</description>
-					<posx>0</posx>
-					<posy>50</posy>
+					<left>0</left>
+					<top>50</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20178</label>
@@ -278,8 +278,8 @@
 				</control>
 				<control type="button" id="65">
 					<description>'A' button</description>
-					<posx>200</posx>
-					<posy>50</posy>
+					<left>200</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>302</onleft>
@@ -295,8 +295,8 @@
 				</control>
 				<control type="button" id="66">
 					<description>'B' button</description>
-					<posx>250</posx>
-					<posy>50</posy>
+					<left>250</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>65</onleft>
@@ -312,8 +312,8 @@
 				</control>
 				<control type="button" id="67">
 					<description>'C' button</description>
-					<posx>300</posx>
-					<posy>50</posy>
+					<left>300</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>66</onleft>
@@ -329,8 +329,8 @@
 				</control>
 				<control type="button" id="68">
 					<description>'D' button</description>
-					<posx>350</posx>
-					<posy>50</posy>
+					<left>350</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>67</onleft>
@@ -346,8 +346,8 @@
 				</control>
 				<control type="button" id="69">
 					<description>'E' button</description>
-					<posx>400</posx>
-					<posy>50</posy>
+					<left>400</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>68</onleft>
@@ -363,8 +363,8 @@
 				</control>
 				<control type="button" id="70">
 					<description>'F' button</description>
-					<posx>450</posx>
-					<posy>50</posy>
+					<left>450</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>69</onleft>
@@ -380,8 +380,8 @@
 				</control>
 				<control type="button" id="71">
 					<description>'G' button</description>
-					<posx>500</posx>
-					<posy>50</posy>
+					<left>500</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>70</onleft>
@@ -397,8 +397,8 @@
 				</control>
 				<control type="button" id="72">
 					<description>'H' button</description>
-					<posx>550</posx>
-					<posy>50</posy>
+					<left>550</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>71</onleft>
@@ -414,8 +414,8 @@
 				</control>
 				<control type="button" id="73">
 					<description>'I' button</description>
-					<posx>600</posx>
-					<posy>50</posy>
+					<left>600</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>72</onleft>
@@ -431,8 +431,8 @@
 				</control>
 				<control type="button" id="74">
 					<description>'J' button</description>
-					<posx>650</posx>
-					<posy>50</posy>
+					<left>650</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>73</onleft>
@@ -448,8 +448,8 @@
 				</control>
 				<control type="radiobutton" id="303">
 					<description>CAPS LOCK button</description>
-					<posx>0</posx>
-					<posy>100</posy>
+					<left>0</left>
+					<top>100</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20179</label>
@@ -469,8 +469,8 @@
 				</control>
 				<control type="button" id="75">
 					<description>'K' button</description>
-					<posx>200</posx>
-					<posy>100</posy>
+					<left>200</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>303</onleft>
@@ -486,8 +486,8 @@
 				</control>
 				<control type="button" id="76">
 					<description>'L' button</description>
-					<posx>250</posx>
-					<posy>100</posy>
+					<left>250</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>75</onleft>
@@ -503,8 +503,8 @@
 				</control>
 				<control type="button" id="77">
 					<description>'M' button</description>
-					<posx>300</posx>
-					<posy>100</posy>
+					<left>300</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>76</onleft>
@@ -520,8 +520,8 @@
 				</control>
 				<control type="button" id="78">
 					<description>'N' button</description>
-					<posx>350</posx>
-					<posy>100</posy>
+					<left>350</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>77</onleft>
@@ -537,8 +537,8 @@
 				</control>
 				<control type="button" id="79">
 					<description>'O' button</description>
-					<posx>400</posx>
-					<posy>100</posy>
+					<left>400</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>78</onleft>
@@ -554,8 +554,8 @@
 				</control>
 				<control type="button" id="80">
 					<description>'P' button</description>
-					<posx>450</posx>
-					<posy>100</posy>
+					<left>450</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>79</onleft>
@@ -571,8 +571,8 @@
 				</control>
 				<control type="button" id="81">
 					<description>'Q' button</description>
-					<posx>500</posx>
-					<posy>100</posy>
+					<left>500</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>80</onleft>
@@ -588,8 +588,8 @@
 				</control>
 				<control type="button" id="82">
 					<description>'R' button</description>
-					<posx>550</posx>
-					<posy>100</posy>
+					<left>550</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>81</onleft>
@@ -605,8 +605,8 @@
 				</control>
 				<control type="button" id="83">
 					<description>'S' button</description>
-					<posx>600</posx>
-					<posy>100</posy>
+					<left>600</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>82</onleft>
@@ -622,8 +622,8 @@
 				</control>
 				<control type="button" id="84">
 					<description>'T' button</description>
-					<posx>650</posx>
-					<posy>100</posy>
+					<left>650</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>83</onleft>
@@ -639,8 +639,8 @@
 				</control>
 				<control type="radiobutton" id="304">
 					<description>Symbols button</description>
-					<posx>0</posx>
-					<posy>150</posy>
+					<left>0</left>
+					<top>150</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20180</label>
@@ -660,8 +660,8 @@
 				</control>
 				<control type="button" id="85">
 					<description>'U' button</description>
-					<posx>200</posx>
-					<posy>150</posy>
+					<left>200</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>304</onleft>
@@ -677,8 +677,8 @@
 				</control>
 				<control type="button" id="86">
 					<description>'V' button</description>
-					<posx>250</posx>
-					<posy>150</posy>
+					<left>250</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>85</onleft>
@@ -694,8 +694,8 @@
 				</control>
 				<control type="button" id="87">
 					<description>'W' button</description>
-					<posx>300</posx>
-					<posy>150</posy>
+					<left>300</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>86</onleft>
@@ -711,8 +711,8 @@
 				</control>
 				<control type="button" id="88">
 					<description>'X' button</description>
-					<posx>350</posx>
-					<posy>150</posy>
+					<left>350</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>87</onleft>
@@ -728,8 +728,8 @@
 				</control>
 				<control type="button" id="89">
 					<description>'Y' button</description>
-					<posx>400</posx>
-					<posy>150</posy>
+					<left>400</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>88</onleft>
@@ -745,8 +745,8 @@
 				</control>
 				<control type="button" id="90">
 					<description>'Z' button</description>
-					<posx>450</posx>
-					<posy>150</posy>
+					<left>450</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>89</onleft>
@@ -762,8 +762,8 @@
 				</control>
 				<control type="button" id="8">
 					<description>BACKSPACE button</description>
-					<posx>500</posx>
-					<posy>150</posy>
+					<left>500</left>
+					<top>150</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20181</label>
@@ -780,8 +780,8 @@
 				</control>
 				<control type="button" id="307">
 					<description>IP Input button</description>
-					<posx>0</posx>
-					<posy>200</posy>
+					<left>0</left>
+					<top>200</top>
 					<width>200</width>
 					<height>50</height>
 					<texturenofocus border="25,5,25,5">KeyboardCornerBottomNF.png</texturenofocus>
@@ -798,8 +798,8 @@
 				</control>
 				<control type="button" id="32">
 					<description>SPACE button</description>
-					<posx>200</posx>
-					<posy>200</posy>
+					<left>200</left>
+					<top>200</top>
 					<width>300</width>
 					<height>50</height>
 					<label>20182</label>
@@ -816,8 +816,8 @@
 				</control>
 				<control type="button" id="305">
 					<description>previous button</description>
-					<posx>500</posx>
-					<posy>200</posy>
+					<left>500</left>
+					<top>200</top>
 					<width>100</width>
 					<height>50</height>
 					<label>&lt;</label>
@@ -834,8 +834,8 @@
 				</control>
 				<control type="button" id="306">
 					<description>next button</description>
-					<posx>600</posx>
-					<posy>200</posy>
+					<left>600</left>
+					<top>200</top>
 					<width>100</width>
 					<height>50</height>
 					<label>&gt;</label>
@@ -853,12 +853,12 @@
 			</control>
 			<control type="group">
 				<visible>Skin.HasSetting(QWERTYKeys)</visible>
-				<posx>30</posx>
-				<posy>135</posy>
+				<left>30</left>
+				<top>135</top>
 				<control type="button" id="300">
 					<description>DONE button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20177</label>
@@ -875,8 +875,8 @@
 				</control>
 				<control type="button" id="49">
 					<description>'1' button</description>
-					<posx>200</posx>
-					<posy>0</posy>
+					<left>200</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>300</onleft>
@@ -892,8 +892,8 @@
 					</control>
 				<control type="button" id="50">
 					<description>'2' button</description>
-					<posx>250</posx>
-					<posy>0</posy>
+					<left>250</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>49</onleft>
@@ -909,8 +909,8 @@
 				</control>
 				<control type="button" id="51">
 					<description>'3' button</description>
-					<posx>300</posx>
-					<posy>0</posy>
+					<left>300</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>50</onleft>
@@ -926,8 +926,8 @@
 				</control>
 				<control type="button" id="52">
 					<description>'4' button</description>
-					<posx>350</posx>
-					<posy>0</posy>
+					<left>350</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>51</onleft>
@@ -943,8 +943,8 @@
 				</control>
 				<control type="button" id="53">
 					<description>'5' button</description>
-					<posx>400</posx>
-					<posy>0</posy>
+					<left>400</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>52</onleft>
@@ -960,8 +960,8 @@
 				</control>
 				<control type="button" id="54">
 					<description>'6' button</description>
-					<posx>450</posx>
-					<posy>0</posy>
+					<left>450</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>53</onleft>
@@ -977,8 +977,8 @@
 				</control>
 				<control type="button" id="55">
 					<description>'7' button</description>
-					<posx>500</posx>
-					<posy>0</posy>
+					<left>500</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>54</onleft>
@@ -994,8 +994,8 @@
 				</control>
 				<control type="button" id="56">
 					<description>'8' button</description>
-					<posx>550</posx>
-					<posy>0</posy>
+					<left>550</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>55</onleft>
@@ -1011,8 +1011,8 @@
 				</control>
 				<control type="button" id="57">
 					<description>'9' button</description>
-					<posx>600</posx>
-					<posy>0</posy>
+					<left>600</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>56</onleft>
@@ -1028,8 +1028,8 @@
 				</control>
 				<control type="button" id="48">
 					<description>'0' button</description>
-					<posx>650</posx>
-					<posy>0</posy>
+					<left>650</left>
+					<top>0</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>57</onleft>
@@ -1045,8 +1045,8 @@
 				</control>
 				<control type="radiobutton" id="302">
 					<description>SHIFT button</description>
-					<posx>0</posx>
-					<posy>50</posy>
+					<left>0</left>
+					<top>50</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20178</label>
@@ -1066,8 +1066,8 @@
 				</control>
 				<control type="button" id="65">
 					<description>'A' button</description>
-					<posx>200</posx>
-					<posy>100</posy>
+					<left>200</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>303</onleft>
@@ -1083,8 +1083,8 @@
 				</control>
 				<control type="button" id="66">
 					<description>'B' button</description>
-					<posx>400</posx>
-					<posy>150</posy>
+					<left>400</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>86</onleft>
@@ -1100,8 +1100,8 @@
 				</control>
 				<control type="button" id="67">
 					<description>'C' button</description>
-					<posx>300</posx>
-					<posy>150</posy>
+					<left>300</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>88</onleft>
@@ -1117,8 +1117,8 @@
 				</control>
 				<control type="button" id="68">
 					<description>'D' button</description>
-					<posx>300</posx>
-					<posy>100</posy>
+					<left>300</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>83</onleft>
@@ -1134,8 +1134,8 @@
 				</control>
 				<control type="button" id="69">
 					<description>'E' button</description>
-					<posx>300</posx>
-					<posy>50</posy>
+					<left>300</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>87</onleft>
@@ -1151,8 +1151,8 @@
 				</control>
 				<control type="button" id="70">
 					<description>'F' button</description>
-					<posx>350</posx>
-					<posy>100</posy>
+					<left>350</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>68</onleft>
@@ -1168,8 +1168,8 @@
 				</control>
 				<control type="button" id="71">
 					<description>'G' button</description>
-					<posx>400</posx>
-					<posy>100</posy>
+					<left>400</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>70</onleft>
@@ -1185,8 +1185,8 @@
 				</control>
 				<control type="button" id="72">
 					<description>'H' button</description>
-					<posx>450</posx>
-					<posy>100</posy>
+					<left>450</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>71</onleft>
@@ -1202,8 +1202,8 @@
 				</control>
 				<control type="button" id="73">
 					<description>'I' button</description>
-					<posx>550</posx>
-					<posy>50</posy>
+					<left>550</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>85</onleft>
@@ -1219,8 +1219,8 @@
 				</control>
 				<control type="button" id="74">
 					<description>'J' button</description>
-					<posx>500</posx>
-					<posy>100</posy>
+					<left>500</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>72</onleft>
@@ -1236,8 +1236,8 @@
 				</control>
 				<control type="radiobutton" id="303">
 					<description>CAPS LOCK button</description>
-					<posx>0</posx>
-					<posy>100</posy>
+					<left>0</left>
+					<top>100</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20179</label>
@@ -1257,8 +1257,8 @@
 				</control>
 				<control type="button" id="75">
 					<description>'K' button</description>
-					<posx>550</posx>
-					<posy>100</posy>
+					<left>550</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>74</onleft>
@@ -1274,8 +1274,8 @@
 				</control>
 				<control type="button" id="76">
 					<description>'L' button</description>
-					<posx>600</posx>
-					<posy>100</posy>
+					<left>600</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>75</onleft>
@@ -1291,8 +1291,8 @@
 				</control>
 				<control type="button" id="77">
 					<description>'M' button</description>
-					<posx>500</posx>
-					<posy>150</posy>
+					<left>500</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>78</onleft>
@@ -1308,8 +1308,8 @@
 				</control>
 				<control type="button" id="78">
 					<description>'N' button</description>
-					<posx>450</posx>
-					<posy>150</posy>
+					<left>450</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>66</onleft>
@@ -1325,8 +1325,8 @@
 				</control>
 				<control type="button" id="79">
 					<description>'O' button</description>
-					<posx>600</posx>
-					<posy>50</posy>
+					<left>600</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>73</onleft>
@@ -1342,8 +1342,8 @@
 				</control>
 				<control type="button" id="80">
 					<description>'P' button</description>
-					<posx>650</posx>
-					<posy>50</posy>
+					<left>650</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>79</onleft>
@@ -1359,8 +1359,8 @@
 				</control>
 				<control type="button" id="81">
 					<description>'Q' button</description>
-					<posx>200</posx>
-					<posy>50</posy>
+					<left>200</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>302</onleft>
@@ -1376,8 +1376,8 @@
 				</control>
 				<control type="button" id="82">
 					<description>'R' button</description>
-					<posx>350</posx>
-					<posy>50</posy>
+					<left>350</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>69</onleft>
@@ -1393,8 +1393,8 @@
 				</control>
 				<control type="button" id="83">
 					<description>'S' button</description>
-					<posx>250</posx>
-					<posy>100</posy>
+					<left>250</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>65</onleft>
@@ -1410,8 +1410,8 @@
 				</control>
 				<control type="button" id="84">
 					<description>'T' button</description>
-					<posx>400</posx>
-					<posy>50</posy>
+					<left>400</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>82</onleft>
@@ -1427,8 +1427,8 @@
 				</control>
 				<control type="radiobutton" id="304">
 					<description>Symbols button</description>
-					<posx>0</posx>
-					<posy>150</posy>
+					<left>0</left>
+					<top>150</top>
 					<width>200</width>
 					<height>50</height>
 					<label>20180</label>
@@ -1448,8 +1448,8 @@
 				</control>
 				<control type="button" id="85">
 					<description>'U' button</description>
-					<posx>500</posx>
-					<posy>50</posy>
+					<left>500</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>89</onleft>
@@ -1465,8 +1465,8 @@
 				</control>
 				<control type="button" id="86">
 					<description>'V' button</description>
-					<posx>350</posx>
-					<posy>150</posy>
+					<left>350</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>67</onleft>
@@ -1482,8 +1482,8 @@
 				</control>
 				<control type="button" id="87">
 					<description>'W' button</description>
-					<posx>250</posx>
-					<posy>50</posy>
+					<left>250</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>81</onleft>
@@ -1499,8 +1499,8 @@
 				</control>
 				<control type="button" id="88">
 					<description>'X' button</description>
-					<posx>250</posx>
-					<posy>150</posy>
+					<left>250</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>90</onleft>
@@ -1516,8 +1516,8 @@
 				</control>
 				<control type="button" id="89">
 					<description>'Y' button</description>
-					<posx>450</posx>
-					<posy>50</posy>
+					<left>450</left>
+					<top>50</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>84</onleft>
@@ -1533,8 +1533,8 @@
 				</control>
 				<control type="button" id="90">
 					<description>'Z' button</description>
-					<posx>200</posx>
-					<posy>150</posy>
+					<left>200</left>
+					<top>150</top>
 					<width>50</width>
 					<height>50</height>
 					<onleft>304</onleft>
@@ -1550,8 +1550,8 @@
 				</control>
 				<control type="button" id="8">
 					<description>BACKSPACE button</description>
-					<posx>550</posx>
-					<posy>150</posy>
+					<left>550</left>
+					<top>150</top>
 					<width>150</width>
 					<height>50</height>
 					<label>20181</label>
@@ -1568,8 +1568,8 @@
 				</control>
 				<control type="button" id="307">
 					<description>IP Input button</description>
-					<posx>0</posx>
-					<posy>200</posy>
+					<left>0</left>
+					<top>200</top>
 					<width>200</width>
 					<height>50</height>
 					<texturenofocus border="25,25,5,5">KeyboardCornerBottomNF.png</texturenofocus>
@@ -1586,8 +1586,8 @@
 				</control>
 				<control type="button" id="32">
 					<description>SPACE button</description>
-					<posx>200</posx>
-					<posy>200</posy>
+					<left>200</left>
+					<top>200</top>
 					<width>300</width>
 					<height>50</height>
 					<label>20182</label>
@@ -1604,8 +1604,8 @@
 				</control>
 				<control type="button" id="305">
 					<description>previous button</description>
-					<posx>500</posx>
-					<posy>200</posy>
+					<left>500</left>
+					<top>200</top>
 					<width>100</width>
 					<height>50</height>
 					<label>&lt;</label>
@@ -1622,8 +1622,8 @@
 				</control>
 				<control type="button" id="306">
 					<description>next button</description>
-					<posx>600</posx>
-					<posy>200</posy>
+					<left>600</left>
+					<top>200</top>
 					<width>100</width>
 					<height>50</height>
 					<label>&gt;</label>
@@ -1639,8 +1639,8 @@
 				</control>
 				<control type="image">
 					<description>blank button</description>
-					<posx>650</posx>
-					<posy>100</posy>
+					<left>650</left>
+					<top>100</top>
 					<width>50</width>
 					<height>50</height>
 					<texture border="3">KeyboardKeyNF.png</texture>

--- a/addons/skin.confluence.lite/720p/DialogMediaSource.xml
+++ b/addons/skin.confluence.lite/720p/DialogMediaSource.xml
@@ -2,31 +2,31 @@
 	<defaultcontrol>10</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>100</posy>
+		<left>240</left>
+		<top>100</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>500</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label" id="2">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -38,8 +38,8 @@
 		</control>
 		<control type="label">
 			<description>path label</description>
-			<posx>20</posx>
-			<posy>65</posy>
+			<left>20</left>
+			<top>65</top>
 			<width>760</width>
 			<height>30</height>
 			<align>center</align>
@@ -50,8 +50,8 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="list" id="10">
-			<posx>30</posx>
-			<posy>105</posy>
+			<left>30</left>
+			<top>105</top>
 			<width>525</width>
 			<height>225</height>
 			<onup>9001</onup>
@@ -62,15 +62,15 @@
 			<scrolltime>200</scrolltime>
 			<itemlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>525</width>
 					<height>40</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>490</width>
 					<height>40</height>
 					<font>font13</font>
@@ -83,24 +83,24 @@
 			</itemlayout>
 			<focusedlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>525</width>
 					<height>40</height>
 					<visible>!Control.HasFocus(10)</visible>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>525</width>
 					<height>41</height>
 					<visible>Control.HasFocus(10)</visible>
 					<texture border="5">button-focus2.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>490</width>
 					<height>40</height>
 					<font>font13</font>
@@ -112,8 +112,8 @@
 			</focusedlayout>
 		</control>
 		<control type="scrollbar" id="60">
-			<posx>555</posx>
-			<posy>105</posy>
+			<left>555</left>
+			<top>105</top>
 			<width>25</width>
 			<height>225</height>
 			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -127,12 +127,12 @@
 			<orientation>vertical</orientation>
 		</control>
 		<control type="group" id="9000">
-			<posx>580</posx>
-			<posy>105</posy>
+			<left>580</left>
+			<top>105</top>
 			<control type="button" id="11">
 				<description>Browse Button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>190</width>
 				<height>40</height>
 				<label>1024</label>
@@ -148,8 +148,8 @@
 			</control>
 			<control type="button" id="13">
 				<description>Add Path Button</description>
-				<posx>0</posx>
-				<posy>45</posy>
+				<left>0</left>
+				<top>45</top>
 				<width>190</width>
 				<height>40</height>
 				<label>15019</label>
@@ -165,8 +165,8 @@
 			</control>
 			<control type="button" id="14">
 				<description>Remove Path Button</description>
-				<posx>0</posx>
-				<posy>90</posy>
+				<left>0</left>
+				<top>90</top>
 				<width>190</width>
 				<height>40</height>
 				<label>1210</label>
@@ -183,8 +183,8 @@
 		</control>
 		<control type="label">
 			<description>Name label</description>
-			<posx>30</posx>
-			<posy>335</posy>
+			<left>30</left>
+			<top>335</top>
 			<width>740</width>
 			<height>30</height>
 			<align>center</align>
@@ -196,8 +196,8 @@
 		</control>
 		<control type="button" id="12">
 			<description>Name Button</description>
-			<posx>30</posx>
-			<posy>370</posy>
+			<left>30</left>
+			<top>370</top>
 			<width>740</width>
 			<height>40</height>
 			<align>center</align>
@@ -212,12 +212,12 @@
 			<ondown>9001</ondown>
 		</control>
 		<control type="group" id="9001">
-			<posx>190</posx>
-			<posy>435</posy>
+			<left>190</left>
+			<top>435</top>
 			<control type="button" id="18">
 				<description>Ok Button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -233,8 +233,8 @@
 			</control>
 			<control type="button" id="19">
 				<description>Cancel Button</description>
-				<posx>210</posx>
-				<posy>0</posy>
+				<left>210</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/DialogNotification.xml
+++ b/addons/skin.confluence.lite/720p/DialogNotification.xml
@@ -2,15 +2,15 @@
 	<animation effect="fade" start="0" end="100" time="200">WindowOpen</animation>
 	<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 	<coordinates>
-		<posx>860</posx>
-		<posy>640</posy>
+		<left>860</left>
+		<top>640</top>
 	</coordinates>
 	<controls>
 		<control type="group">
 			<animation effect="slide" start="0,0" end="-190,0" time="200" condition="Window.IsVisible(BusyDialog)">conditional</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>400</width>
 				<height>70</height>
 				<colordiffuse>EEFFFFFF</colordiffuse>
@@ -18,8 +18,8 @@
 			</control>
 			<control type="image" id="400">
 				<description>avatar</description>
-				<posx>20</posx>
-				<posy>10</posy>
+				<left>20</left>
+				<top>10</top>
 				<width>50</width>
 				<height>50</height>
 				<aspectratio>keep</aspectratio>
@@ -27,8 +27,8 @@
 			</control>
 			<control type="fadelabel" id="401">
 				<description>Line 1 Label</description>
-				<posx>75</posx>
-				<posy>15</posy>
+				<left>75</left>
+				<top>15</top>
 				<width>310</width>
 				<height>18</height>
 				<font>font12_title</font>
@@ -40,8 +40,8 @@
 			</control>
 			<control type="fadelabel" id="402">
 				<description>Line 2 Label</description>
-				<posx>75</posx>
-				<posy>35</posy>
+				<left>75</left>
+				<top>35</top>
 				<width>310</width>
 				<height>20</height>
 				<font>font12_title</font>
@@ -53,8 +53,8 @@
 			</control>
 			<control type="image" id="403">
 				<description>avatar</description>
-				<posx>20</posx>
-				<posy>10</posy>
+				<left>20</left>
+				<top>10</top>
 				<width>50</width>
 				<height>50</height>
 				<aspectratio>keep</aspectratio>
@@ -63,8 +63,8 @@
 			</control>
 			<control type="image" id="404">
 				<description>avatar</description>
-				<posx>20</posx>
-				<posy>10</posy>
+				<left>20</left>
+				<top>10</top>
 				<width>50</width>
 				<height>50</height>
 				<aspectratio>keep</aspectratio>
@@ -73,8 +73,8 @@
 			</control>
 			<control type="image" id="405">
 				<description>avatar</description>
-				<posx>20</posx>
-				<posy>10</posy>
+				<left>20</left>
+				<top>10</top>
 				<width>50</width>
 				<height>50</height>
 				<aspectratio>keep</aspectratio>

--- a/addons/skin.confluence.lite/720p/DialogNumeric.xml
+++ b/addons/skin.confluence.lite/720p/DialogNumeric.xml
@@ -3,28 +3,28 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>2</system>
-		<posx>480</posx>
-		<posy>145</posy>
+		<left>480</left>
+		<top>145</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>320</width>
 			<height>430</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>240</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="image">
-			<posx>30</posx>
-			<posy>70</posy>
+			<left>30</left>
+			<top>70</top>
 			<width>260</width>
 			<height>50</height>
 			<aspectratio>stretch</aspectratio>
@@ -32,8 +32,8 @@
 		</control>
 		<control type="label" id="4">
 			<description>Edit Text</description>
-			<posx>35</posx>
-			<posy>70</posy>
+			<left>35</left>
+			<top>70</top>
 			<width>250</width>
 			<height>50</height>
 			<font>font13</font>
@@ -43,8 +43,8 @@
 			<aligny>center</aligny>
 		</control>
 		<control type="image">
-			<posx>40</posx>
-			<posy>120</posy>
+			<left>40</left>
+			<top>120</top>
 			<width>240</width>
 			<height>30</height>
 			<aspectratio>stretch</aspectratio>
@@ -52,8 +52,8 @@
 		</control>
 		<control type="label" id="1">
 			<description>dialog Heading</description>
-			<posx>20</posx>
-			<posy>20</posy>
+			<left>20</left>
+			<top>20</top>
 			<width>280</width>
 			<height>35</height>
 			<font>font12_title</font>
@@ -64,12 +64,12 @@
 			<wrapmultiline>true</wrapmultiline>
 		</control>
 		<control type="group">
-			<posx>40</posx>
-			<posy>155</posy>
+			<left>40</left>
+			<top>155</top>
 			<control type="button" id="11">
 				<description>1 button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -86,8 +86,8 @@
 			</control>
 			<control type="button" id="12">
 				<description>2 button</description>
-				<posx>60</posx>
-				<posy>0</posy>
+				<left>60</left>
+				<top>0</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -104,8 +104,8 @@
 			</control>
 			<control type="button" id="13">
 				<description>3 button</description>
-				<posx>120</posx>
-				<posy>0</posy>
+				<left>120</left>
+				<top>0</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -122,8 +122,8 @@
 			</control>
 			<control type="button" id="23">
 				<description>Backspace button</description>
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>60</width>
 				<height>120</height>
 				<font>font12</font>
@@ -142,8 +142,8 @@
 			</control>
 			<control type="button" id="14">
 				<description>4 button</description>
-				<posx>0</posx>
-				<posy>60</posy>
+				<left>0</left>
+				<top>60</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -160,8 +160,8 @@
 			</control>
 			<control type="button" id="15">
 				<description>5 button</description>
-				<posx>60</posx>
-				<posy>60</posy>
+				<left>60</left>
+				<top>60</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -178,8 +178,8 @@
 			</control>
 			<control type="button" id="16">
 				<description>6 button</description>
-				<posx>120</posx>
-				<posy>60</posy>
+				<left>120</left>
+				<top>60</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -196,8 +196,8 @@
 			</control>
 			<control type="button" id="17">
 				<description>7 button</description>
-				<posx>0</posx>
-				<posy>120</posy>
+				<left>0</left>
+				<top>120</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -214,8 +214,8 @@
 			</control>
 			<control type="button" id="18">
 				<description>8 button</description>
-				<posx>60</posx>
-				<posy>120</posy>
+				<left>60</left>
+				<top>120</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -232,8 +232,8 @@
 			</control>
 			<control type="button" id="19">
 				<description>9 button</description>
-				<posx>120</posx>
-				<posy>120</posy>
+				<left>120</left>
+				<top>120</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -250,8 +250,8 @@
 			</control>
 			<control type="button" id="21">
 				<description>Done button</description>
-				<posx>180</posx>
-				<posy>120</posy>
+				<left>180</left>
+				<top>120</top>
 				<width>60</width>
 				<height>120</height>
 				<font>font12</font>
@@ -270,8 +270,8 @@
 			</control>
 			<control type="button" id="20">
 				<description>prev button</description>
-				<posx>0</posx>
-				<posy>180</posy>
+				<left>0</left>
+				<top>180</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font30</font>
@@ -288,8 +288,8 @@
 			</control>
 			<control type="button" id="10">
 				<description>0 button</description>
-				<posx>60</posx>
-				<posy>180</posy>
+				<left>60</left>
+				<top>180</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font13</font>
@@ -306,8 +306,8 @@
 			</control>
 			<control type="button" id="22">
 				<description>next button</description>
-				<posx>120</posx>
-				<posy>180</posy>
+				<left>120</left>
+				<top>180</top>
 				<width>60</width>
 				<height>60</height>
 				<font>font30</font>

--- a/addons/skin.confluence.lite/720p/DialogPictureInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogPictureInfo.xml
@@ -2,16 +2,16 @@
 	<defaultcontrol always="true">5</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>45</posy>
+		<left>240</left>
+		<top>45</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="group">
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>800</width>
 				<height>630</height>
 				<texture border="40">DialogBack.png</texture>
@@ -19,8 +19,8 @@
 			</control>
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>800</width>
 				<height>630</height>
 				<texture border="40">DialogBack.png</texture>
@@ -28,16 +28,16 @@
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>720</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -48,8 +48,8 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>755</posx>
-				<posy>70</posy>
+				<left>755</left>
+				<top>70</top>
 				<width>25</width>
 				<height>495</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -64,8 +64,8 @@
 			</control>
 			<control type="list" id="5">
 				<animation effect="slide" start="0,0" end="10,0" time="0" condition="!Control.IsVisible(60)">Conditional</animation>
-				<posx>30</posx>
-				<posy>70</posy>
+				<left>30</left>
+				<top>70</top>
 				<width>720</width>
 				<height>495</height>
 				<onleft>60</onleft>
@@ -76,15 +76,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="45">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font13</font>
@@ -96,8 +96,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>710</posx>
-						<posy>0</posy>
+						<left>710</left>
+						<top>0</top>
 						<width>650</width>
 						<height>40</height>
 						<font>font13</font>
@@ -111,24 +111,24 @@
 				</itemlayout>
 				<focusedlayout height="45">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<visible>!Control.HasFocus(5)</visible>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<texture border="5">button-focus2.png</texture>
 						<visible>Control.HasFocus(5)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font13</font>
@@ -140,8 +140,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>710</posx>
-						<posy>0</posy>
+						<left>710</left>
+						<top>0</top>
 						<width>650</width>
 						<height>40</height>
 						<font>font13</font>
@@ -156,8 +156,8 @@
 			</control>
 			<control type="label">
 				<description>number of files/pages in list text label</description>
-				<posx>760</posx>
-				<posy>570</posy>
+				<left>760</left>
+				<top>570</top>
 				<width>300</width>
 				<height>35</height>
 				<font>font12</font>

--- a/addons/skin.confluence.lite/720p/DialogPictureInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogPictureInfo.xml
@@ -96,7 +96,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>710</left>
+						<left>60</left>
 						<top>0</top>
 						<width>650</width>
 						<height>40</height>
@@ -140,7 +140,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>710</left>
+						<left>60</left>
 						<top>0</top>
 						<width>650</width>
 						<height>40</height>

--- a/addons/skin.confluence.lite/720p/DialogPluginSettings.xml
+++ b/addons/skin.confluence.lite/720p/DialogPluginSettings.xml
@@ -2,31 +2,31 @@
 	<defaultcontrol always="true">9</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>60</posy>
+		<left>240</left>
+		<top>60</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>600</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label" id="20">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -38,8 +38,8 @@
 		</control>
 		<control type="grouplist" id="9">
 			<description>button area</description>
-			<posx>45</posx>
-			<posy>70</posy>
+			<left>45</left>
+			<top>70</top>
 			<width>710</width>
 			<height>40</height>
 			<itemgap>5</itemgap>
@@ -52,8 +52,8 @@
 		</control>
 		<control type="image">
 			<description>Has Previous</description>
-			<posx>25</posx>
-			<posy>80</posy>
+			<left>25</left>
+			<top>80</top>
 			<width>20</width>
 			<height>20</height>
 			<texture>scroll-left-focus.png</texture>
@@ -61,8 +61,8 @@
 		</control>
 		<control type="image">
 			<description>Has Next</description>
-			<posx>755</posx>
-			<posy>80</posy>
+			<left>755</left>
+			<top>80</top>
 			<width>20</width>
 			<height>20</height>
 			<texture>scroll-right-focus.png</texture>
@@ -70,8 +70,8 @@
 		</control>
 		<control type="grouplist" id="2">
 			<description>control area</description>
-			<posx>40</posx>
-			<posy>120</posy>
+			<left>40</left>
+			<top>120</top>
 			<width>720</width>
 			<height>380</height>
 			<itemgap>5</itemgap>
@@ -82,8 +82,8 @@
 			<onright>30</onright>
 		</control>
 		<control type="scrollbar" id="30">
-			<posx>765</posx>
-			<posy>120</posy>
+			<left>765</left>
+			<top>120</top>
 			<width>25</width>
 			<height>380</height>
 			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -97,12 +97,12 @@
 			<orientation>vertical</orientation>
 		</control>
 		<control type="group" id="9001">
-			<posy>535</posy>
-			<posx>90</posx>
+			<top>535</top>
+			<left>90</left>
 			<control type="button" id="10">
 				<description>OK Button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -116,8 +116,8 @@
 			</control>
 			<control type="button" id="11">
 				<description>Cancel Button</description>
-				<posx>210</posx>
-				<posy>0</posy>
+				<left>210</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -131,8 +131,8 @@
 			</control>
 			<control type="button" id="12">
 				<description>Defaults Button</description>
-				<posx>420</posx>
-				<posy>0</posy>
+				<left>420</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/DialogSeekBar.xml
+++ b/addons/skin.confluence.lite/720p/DialogSeekBar.xml
@@ -6,12 +6,12 @@
 	<controls>
 		<control type="group">
 			<visible>player.chaptercount + Window.IsVisible(FullScreenVideo)</visible>
-			<posx>665r</posx>
-			<posy>-6</posy>
+			<left>665r</left>
+			<top>-6</top>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>150</width>
 				<height>70</height>
 				<colordiffuse>EEFFFFFF</colordiffuse>
@@ -19,8 +19,8 @@
 			</control>
 			<control type="label" id="1">
 				<description>Chapter Pos No</description>
-				<posx>20</posx>
-				<posy>10</posy>
+				<left>20</left>
+				<top>10</top>
 				<width>110</width>
 				<height>20</height>
 				<align>center</align>
@@ -32,8 +32,8 @@
 			</control>
 			<control type="label" id="1">
 				<description>Chapter Pos No</description>
-				<posx>20</posx>
-				<posy>30</posy>
+				<left>20</left>
+				<top>30</top>
 				<width>110</width>
 				<height>20</height>
 				<align>center</align>
@@ -45,53 +45,53 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>520r</posx>
-			<posy>-6</posy>
+			<left>520r</left>
+			<top>-6</top>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>370</width>
 				<height>70</height>
 				<colordiffuse>EEFFFFFF</colordiffuse>
 				<texture border="12">OverlayDialogBackground.png</texture>
 			</control>
 			<control type="group">
-				<posx>260</posx>
-				<posy>10</posy>
+				<left>260</left>
+				<top>10</top>
 				<control type="image">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>80</width>
 					<height>50</height>
 					<texture>OSDSeekFrame.png</texture>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>3</posy>
+					<left>0</left>
+					<top>3</top>
 					<width>20</width>
 					<height>44</height>
 					<texture>OSDSeekRewind.png</texture>
 					<visible>Player.Rewinding</visible>
 				</control>
 				<control type="image">
-					<posx>80</posx>
-					<posy>3</posy>
+					<left>80</left>
+					<top>3</top>
 					<width>20</width>
 					<height>44</height>
 					<texture>OSDSeekForward.png</texture>
 					<visible>Player.Forwarding</visible>
 				</control>
 				<control type="image">
-					<posx>31</posx>
-					<posy>4</posy>
+					<left>31</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDPause.png</texture>
 					<visible>Player.Paused</visible>
 				</control>
 				<control type="image">
-					<posx>31</posx>
-					<posy>4</posy>
+					<left>31</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDPlay.png</texture>
@@ -99,40 +99,40 @@
 				</control>
 
 				<control type="image">
-					<posx>28</posx>
-					<posy>4</posy>
+					<left>28</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD2x.png</texture>
 					<visible>Player.Rewinding2x</visible>
 				</control>
 				<control type="image">
-					<posx>25</posx>
-					<posy>4</posy>
+					<left>25</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD4x.png</texture>
 					<visible>Player.Rewinding4x</visible>
 				</control>
 				<control type="image">
-					<posx>22</posx>
-					<posy>4</posy>
+					<left>22</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD8x.png</texture>
 					<visible>Player.Rewinding8x</visible>
 				</control>
 				<control type="image">
-					<posx>19</posx>
-					<posy>4</posy>
+					<left>19</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD16x.png</texture>
 					<visible>Player.Rewinding16x</visible>
 				</control>
 				<control type="image">
-					<posx>17</posx>
-					<posy>4</posy>
+					<left>17</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD32x.png</texture>
@@ -140,40 +140,40 @@
 				</control>
 
 				<control type="image">
-					<posx>34</posx>
-					<posy>4</posy>
+					<left>34</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD2x.png</texture>
 					<visible>Player.Forwarding2x</visible>
 				</control>
 				<control type="image">
-					<posx>37</posx>
-					<posy>4</posy>
+					<left>37</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD4x.png</texture>
 					<visible>Player.Forwarding4x</visible>
 				</control>
 				<control type="image">
-					<posx>40</posx>
-					<posy>4</posy>
+					<left>40</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD8x.png</texture>
 					<visible>Player.Forwarding8x</visible>
 				</control>
 				<control type="image">
-					<posx>43</posx>
-					<posy>4</posy>
+					<left>43</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD16x.png</texture>
 					<visible>Player.Forwarding16x</visible>
 				</control>
 				<control type="image">
-					<posx>45</posx>
-					<posy>4</posy>
+					<left>45</left>
+					<top>4</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSD32x.png</texture>
@@ -183,8 +183,8 @@
 
 			<control type="label">
 				<description>Playing Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -196,8 +196,8 @@
 			</control>
 			<control type="label">
 				<description>Paused Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -209,8 +209,8 @@
 			</control>
 			<control type="label">
 				<description>Cache Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -222,8 +222,8 @@
 			</control>
 			<control type="label">
 				<description>Seeking Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -234,8 +234,8 @@
 			</control>
 			<control type="label">
 				<description>FF Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -247,8 +247,8 @@
 			</control>
 			<control type="label">
 				<description>RW Label</description>
-				<posx>20</posx>
-				<posy>7</posy>
+				<left>20</left>
+				<top>7</top>
 				<width>240</width>
 				<height>20</height>
 				<align>left</align>
@@ -260,8 +260,8 @@
 			</control>
 			<control type="label">
 				<description>Elapsed Time Label</description>
-				<posx>20</posx>
-				<posy>23</posy>
+				<left>20</left>
+				<top>23</top>
 				<width>240</width>
 				<height>20</height>
 				<font>font13_title</font>
@@ -273,8 +273,8 @@
 			</control>
 			<control type="label">
 				<description>Seek Time Label</description>
-				<posx>20</posx>
-				<posy>23</posy>
+				<left>20</left>
+				<top>23</top>
 				<width>240</width>
 				<height>20</height>
 				<font>font13_title</font>
@@ -286,8 +286,8 @@
 			</control>
 			<control type="progress">
 				<description>ProgressbarCache</description>
-				<posx>20</posx>
-				<posy>45</posy>
+				<left>20</left>
+				<top>45</top>
 				<width>240</width>
 				<height>15</height>
 				<info>Player.ProgressCache</info>
@@ -296,8 +296,8 @@
 			</control>
 			<control type="progress" id="23">
 				<description>Progressbar</description>
-				<posx>20</posx>
-				<posy>45</posy>
+				<left>20</left>
+				<top>45</top>
 				<width>240</width>
 				<height>15</height>
 				<info>Player.Progress</info>
@@ -305,8 +305,8 @@
 			</control>
 			<control type="slider" id="401">
 				<description>Seek Slider</description>
-				<posx>20</posx>
-				<posy>42</posy>
+				<left>20</left>
+				<top>42</top>
 				<width>240</width>
 				<height>12</height>
 				<texturesliderbar>seekslider.png</texturesliderbar>

--- a/addons/skin.confluence.lite/720p/DialogSelect.xml
+++ b/addons/skin.confluence.lite/720p/DialogSelect.xml
@@ -138,6 +138,7 @@
 					<width>80</width>
 					<height>76</height>
 					<texture>$INFO[Listitem.Icon]</texture>
+					<aspectratio>keep</aspectratio>
 					<bordertexture border="3">black-back2.png</bordertexture>
 					<bordersize>2</bordersize>
 				</control>
@@ -190,6 +191,7 @@
 					<width>80</width>
 					<height>76</height>
 					<texture>$INFO[Listitem.Icon]</texture>
+					<aspectratio>keep</aspectratio>
 					<bordertexture border="3">black-back2.png</bordertexture>
 					<bordersize>2</bordersize>
 				</control>

--- a/addons/skin.confluence.lite/720p/DialogSelect.xml
+++ b/addons/skin.confluence.lite/720p/DialogSelect.xml
@@ -2,15 +2,15 @@
 	<defaultcontrol always="true">3</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>335</posx>
-		<posy>35</posy>
+		<left>335</left>
+		<top>35</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>610</width>
 			<height>650</height>
 			<texture border="40">DialogBack.png</texture>
@@ -18,8 +18,8 @@
 		</control>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>610</width>
 			<height>650</height>
 			<texture border="40">DialogBack.png</texture>
@@ -27,16 +27,16 @@
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>530</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label" id="1">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>530</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -47,8 +47,8 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="list" id="3">
-			<posx>20</posx>
-			<posy>67</posy>
+			<left>20</left>
+			<top>67</top>
 			<width>550</width>
 			<height>506</height>
 			<onup>3</onup>
@@ -60,15 +60,15 @@
 			<animation effect="slide" start="0,0" end="10,0" time="0" condition="!Control.IsVisible(61)">Conditional</animation>
 			<itemlayout height="46" width="550">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>40</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="label">
-					<posx>20</posx>
-					<posy>0</posy>
+					<left>20</left>
+					<top>0</top>
 					<width>510</width>
 					<height>40</height>
 					<font>font13</font>
@@ -81,8 +81,8 @@
 			</itemlayout>
 			<focusedlayout height="46" width="550">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>40</height>
 					<texture border="5">button-nofocus.png</texture>
@@ -90,8 +90,8 @@
 					<include>VisibleFadeEffect</include>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>40</height>
 					<texture border="5">button-focus2.png</texture>
@@ -99,8 +99,8 @@
 					<include>VisibleFadeEffect</include>
 				</control>
 				<control type="label">
-					<posx>20</posx>
-					<posy>0</posy>
+					<left>20</left>
+					<top>0</top>
 					<width>510</width>
 					<height>40</height>
 					<font>font13</font>
@@ -113,8 +113,8 @@
 			</focusedlayout>
 		</control>
 		<control type="list" id="6">
-			<posx>20</posx>
-			<posy>65</posy>
+			<left>20</left>
+			<top>65</top>
 			<width>550</width>
 			<height>510</height>
 			<onup>6</onup>
@@ -126,15 +126,15 @@
 			<animation effect="slide" start="0,0" end="10,0" time="0" condition="!Control.IsVisible(61)">Conditional</animation>
 			<itemlayout height="85" width="550">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>80</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image">
-					<posx>2</posx>
-					<posy>2</posy>
+					<left>2</left>
+					<top>2</top>
 					<width>80</width>
 					<height>76</height>
 					<texture>$INFO[Listitem.Icon]</texture>
@@ -142,8 +142,8 @@
 					<bordersize>2</bordersize>
 				</control>
 				<control type="label">
-					<posx>90</posx>
-					<posy>0</posy>
+					<left>90</left>
+					<top>0</top>
 					<width>450</width>
 					<height>30</height>
 					<font>font13</font>
@@ -154,8 +154,8 @@
 					<label>[B]$INFO[ListItem.Label][/B]</label>
 				</control>
 				<control type="textbox">
-					<posx>90</posx>
-					<posy>30</posy>
+					<left>90</left>
+					<top>30</top>
 					<width>450</width>
 					<height>50</height>
 					<font>font12</font>
@@ -167,8 +167,8 @@
 			</itemlayout>
 			<focusedlayout height="85" width="550">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>80</height>
 					<texture border="5">button-nofocus.png</texture>
@@ -176,8 +176,8 @@
 					<include>VisibleFadeEffect</include>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>550</width>
 					<height>80</height>
 					<texture border="5">button-focus2.png</texture>
@@ -185,8 +185,8 @@
 					<include>VisibleFadeEffect</include>
 				</control>
 				<control type="image">
-					<posx>2</posx>
-					<posy>2</posy>
+					<left>2</left>
+					<top>2</top>
 					<width>80</width>
 					<height>76</height>
 					<texture>$INFO[Listitem.Icon]</texture>
@@ -194,8 +194,8 @@
 					<bordersize>2</bordersize>
 				</control>
 				<control type="label">
-					<posx>90</posx>
-					<posy>0</posy>
+					<left>90</left>
+					<top>0</top>
 					<width>450</width>
 					<height>30</height>
 					<font>font13</font>
@@ -206,8 +206,8 @@
 					<label>[B]$INFO[ListItem.Label][/B]</label>
 				</control>
 				<control type="textbox">
-					<posx>90</posx>
-					<posy>30</posy>
+					<left>90</left>
+					<top>30</top>
 					<width>450</width>
 					<height>50</height>
 					<font>font12</font>
@@ -219,8 +219,8 @@
 			</focusedlayout>
 		</control>
 		<control type="scrollbar" id="61">
-			<posx>570</posx>
-			<posy>65</posy>
+			<left>570</left>
+			<top>65</top>
 			<width>25</width>
 			<height>510</height>
 			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -237,8 +237,8 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<posx>580</posx>
-			<posy>585</posy>
+			<left>580</left>
+			<top>585</top>
 			<width>300</width>
 			<height>35</height>
 			<font>font12</font>
@@ -251,8 +251,8 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<posx>580</posx>
-			<posy>587</posy>
+			<left>580</left>
+			<top>587</top>
 			<width>300</width>
 			<height>35</height>
 			<font>font12</font>
@@ -265,8 +265,8 @@
 		</control>
 		<control type="button" id="5">
 			<description>Manual button</description>
-			<posx>20</posx>
-			<posy>585</posy>
+			<left>20</left>
+			<top>585</top>
 			<width>200</width>
 			<height>40</height>
 			<label>186</label>

--- a/addons/skin.confluence.lite/720p/DialogSlider.xml
+++ b/addons/skin.confluence.lite/720p/DialogSlider.xml
@@ -4,21 +4,21 @@
 	<animation effect="slide" start="0,0" end="0,-80" time="100">WindowClose</animation>
 	<coordinates>
 		<system>1</system>
-		<posx>405</posx>
-		<posy>0</posy>
+		<left>405</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>0</posx>
-			<posy>-10</posy>
+			<left>0</left>
+			<top>-10</top>
 			<width>460</width>
 			<height>80</height>
 			<texture flipy="true" border="20,2,20,20">InfoMessagePanel.png</texture>
 		</control>
 		<control type="label" id="10">
 			<description>Dialog header</description>
-			<posx>20</posx>
-			<posy>10</posy>
+			<left>20</left>
+			<top>10</top>
 			<width>230</width>
 			<height>20</height>
 			<align>left</align>
@@ -28,8 +28,8 @@
 		</control>
 		<control type="label" id="12">
 			<description>Slider Value</description>
-			<posx>440</posx>
-			<posy>10</posy>
+			<left>440</left>
+			<top>10</top>
 			<width>220</width>
 			<height>20</height>
 			<align>right</align>
@@ -39,8 +39,8 @@
 		</control>
 		<control type="slider" id="11">
 			<description>Slider</description>
-			<posx>20</posx>
-			<posy>35</posy>
+			<left>20</left>
+			<top>35</top>
 			<width>420</width>
 			<height>20</height>
 			<aligny>center</aligny>

--- a/addons/skin.confluence.lite/720p/DialogSongInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogSongInfo.xml
@@ -2,8 +2,8 @@
 	<defaultcontrol always="true">10</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>185</posx>
-		<posy>105</posy>
+		<left>185</left>
+		<top>105</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
@@ -12,24 +12,24 @@
 			<visible>!Window.IsVisible(MusicInformation)</visible>
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>910</width>
 				<height>510</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>830</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>830</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -41,8 +41,8 @@
 			</control>
 			<control type="label">
 				<description>Song Title value</description>
-				<posx>40</posx>
-				<posy>60</posy>
+				<left>40</left>
+				<top>60</top>
 				<width>830</width>
 				<height>30</height>
 				<align>center</align>
@@ -53,28 +53,28 @@
 				<scroll>true</scroll>
 			</control>
 			<control type="image">
-				<posx>40</posx>
-				<posy>120</posy>
+				<left>40</left>
+				<top>120</top>
 				<width>200</width>
 				<height>200</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
 				<texture>$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="image">
-				<posx>40</posx>
-				<posy>320</posy>
+				<left>40</left>
+				<top>320</top>
 				<width>200</width>
 				<height>200</height>
 				<aspectratio aligny="top">keep</aspectratio>
 				<texture flipy="true" diffuse="diffuse_mirror2.png">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="group">
-				<posx>250</posx>
-				<posy>120</posy>
+				<left>250</left>
+				<top>120</top>
 				<control type="label">
 					<description>Artist Title</description>
-					<posx>150</posx>
-					<posy>0</posy>
+					<left>150</left>
+					<top>0</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -85,8 +85,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Artist Value</description>
-					<posx>160</posx>
-					<posy>0</posy>
+					<left>160</left>
+					<top>0</top>
 					<width>460</width>
 					<height>25</height>
 					<align>left</align>
@@ -99,8 +99,8 @@
 				</control>
 				<control type="label">
 					<description>Album Title</description>
-					<posx>150</posx>
-					<posy>30</posy>
+					<left>150</left>
+					<top>30</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -111,8 +111,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Album Value</description>
-					<posx>160</posx>
-					<posy>30</posy>
+					<left>160</left>
+					<top>30</top>
 					<width>460</width>
 					<height>25</height>
 					<align>left</align>
@@ -125,8 +125,8 @@
 				</control>
 				<control type="label">
 					<description>Genre Title</description>
-					<posx>150</posx>
-					<posy>60</posy>
+					<left>150</left>
+					<top>60</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -139,8 +139,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Genre Value</description>
-					<posx>160</posx>
-					<posy>60</posy>
+					<left>160</left>
+					<top>60</top>
 					<width>460</width>
 					<height>25</height>
 					<align>left</align>
@@ -151,8 +151,8 @@
 				</control>
 				<control type="label">
 					<description>Year Title</description>
-					<posx>150</posx>
-					<posy>90</posy>
+					<left>150</left>
+					<top>90</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -163,8 +163,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Year Value</description>
-					<posx>160</posx>
-					<posy>90</posy>
+					<left>160</left>
+					<top>90</top>
 					<width>460</width>
 					<height>25</height>
 					<align>left</align>
@@ -175,8 +175,8 @@
 				</control>
 				<control type="label">
 					<description>Track Number Title</description>
-					<posx>150</posx>
-					<posy>120</posy>
+					<left>150</left>
+					<top>120</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -187,8 +187,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Track Number Value</description>
-					<posx>160</posx>
-					<posy>120</posy>
+					<left>160</left>
+					<top>120</top>
 					<width>460</width>
 					<height>25</height>
 					<align>left</align>
@@ -199,8 +199,8 @@
 				</control>
 				<control type="label">
 					<description>Rating Title</description>
-					<posx>150</posx>
-					<posy>150</posy>
+					<left>150</left>
+					<top>150</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -210,12 +210,12 @@
 					<label>$LOCALIZE[563]:</label>
 				</control>
 				<control type="group">
-					<posx>160</posx>
-					<posy>148</posy>
+					<left>160</left>
+					<top>148</top>
 					<control type="image">
 						<description>Rating value</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>150</width>
 						<height>32</height>
 						<aspectratio align="left">keep</aspectratio>
@@ -223,8 +223,8 @@
 					</control>
 					<control type="button" id="14">
 						<description>Decrease Rating</description>
-						<posx>160</posx>
-						<posy>5</posy>
+						<left>160</left>
+						<top>5</top>
 						<width>33</width>
 						<height>22</height>
 						<onclick>DecreaseRating</onclick>
@@ -237,8 +237,8 @@
 					</control>
 					<control type="button" id="15">
 						<description>Increase Rating</description>
-						<posx>193</posx>
-						<posy>5</posy>
+						<left>193</left>
+						<top>5</top>
 						<width>33</width>
 						<height>22</height>
 						<onclick>IncreaseRating</onclick>
@@ -252,8 +252,8 @@
 				</control>
 				<control type="label">
 					<description>Comment Title</description>
-					<posx>150</posx>
-					<posy>180</posy>
+					<left>150</left>
+					<top>180</top>
 					<width>150</width>
 					<height>25</height>
 					<align>right</align>
@@ -264,8 +264,8 @@
 				</control>
 				<control type="textbox">
 					<description>Comment value</description>
-					<posx>160</posx>
-					<posy>177</posy>
+					<left>160</left>
+					<top>177</top>
 					<width>460</width>
 					<height>140</height>
 					<font>font13</font>
@@ -274,12 +274,12 @@
 				</control>
 			</control>
 			<control type="group" id="9000">
-				<posx>40</posx>
-				<posy>445</posy>
+				<left>40</left>
+				<top>445</top>
 				<control type="button" id ="10">
 					<description>Ok button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>200</width>
 					<height>40</height>
 					<label>186</label>
@@ -292,8 +292,8 @@
 				</control>
 				<control type="button" id="11">
 					<description>Cancel button</description>
-					<posx>210</posx>
-					<posy>0</posy>
+					<left>210</left>
+					<top>0</top>
 					<width>200</width>
 					<height>40</height>
 					<label>222</label>
@@ -306,8 +306,8 @@
 				</control>
 				<control type="button" id="12">
 					<description>Album Info button</description>
-					<posx>420</posx>
-					<posy>0</posy>
+					<left>420</left>
+					<top>0</top>
 					<width>200</width>
 					<height>40</height>
 					<label>10523</label>
@@ -320,8 +320,8 @@
 				</control>
 				<control type="button" id ="13">
 					<description>Get Thumb button</description>
-					<posx>630</posx>
-					<posy>0</posy>
+					<left>630</left>
+					<top>0</top>
 					<width>200</width>
 					<height>40</height>
 					<label>13405</label>

--- a/addons/skin.confluence.lite/720p/DialogTextViewer.xml
+++ b/addons/skin.confluence.lite/720p/DialogTextViewer.xml
@@ -5,8 +5,8 @@
 			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>1100</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
@@ -16,8 +16,8 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label" id="1">
 					<description>header label</description>
-					<posx>210</posx>
-					<posy>40</posy>
+					<left>210</left>
+					<top>40</top>
 					<width>1030</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -28,8 +28,8 @@
 				</control>
 				<control type="textbox" id="5">
 					<description>textarea</description>
-					<posx>210</posx>
-					<posy>90</posy>
+					<left>210</left>
+					<top>90</top>
 					<width>1000</width>
 					<height>600</height>
 					<label>-</label>
@@ -40,8 +40,8 @@
 					<pagecontrol>61</pagecontrol>
 				</control>
 				<control type="scrollbar" id="61">
-					<posx>1220</posx>
-					<posy>90</posy>
+					<left>1220</left>
+					<top>90</top>
 					<width>25</width>
 					<height>600</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>

--- a/addons/skin.confluence.lite/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogVideoInfo.xml
@@ -7,8 +7,8 @@
 			<animation effect="slide" start="1100,0" end="0,0" time="400" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="1100,0" time="400" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>1100</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
@@ -18,8 +18,8 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label">
 					<description>header label</description>
-					<posx>210</posx>
-					<posy>40</posy>
+					<left>210</left>
+					<top>40</top>
 					<width>1030</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -31,8 +31,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>200</posx>
-					<posy>480</posy>
+					<left>200</left>
+					<top>480</top>
 					<width>600</width>
 					<align>left</align>
 					<itemgap>2</itemgap>
@@ -47,13 +47,13 @@
 				</control>
 				<control type="group">
 					<visible>Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>387</posx>
+					<top>90</top>
+					<left>387</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
 						<description>Current Fanart image</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>675</width>
 						<height>380</height>
 						<texture background="true">$INFO[ListItem.Art(fanart)]</texture>
@@ -66,8 +66,8 @@
 						<visible>IsEmpty(Listitem.Property(Fanart_Image))</visible>
 						<control type="image">
 							<description>No Fanart Back</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>675</width>
 							<height>380</height>
 							<texture>Fanart_Fallback_Small.jpg</texture>
@@ -77,8 +77,8 @@
 							<colordiffuse>99FFFFFF</colordiffuse>
 						</control>
 						<control type="label">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>675</width>
 							<height>380</height>
 							<font>font30_title</font>
@@ -91,29 +91,29 @@
 					</control>
 				</control>
 				<control type="group">
-					<posy>90</posy>
-					<posx>387</posx>
+					<top>90</top>
+					<left>387</left>
 					<visible>Control.HasFocus(15)</visible>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
 						<description>Border</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>675</width>
 						<height>380</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="image">
 						<description>background</description>
-						<posx>5</posx>
-						<posy>5</posy>
+						<left>5</left>
+						<top>5</top>
 						<width>665</width>
 						<height>370</height>
 						<texture>black-back.png</texture>
 					</control>
 					<control type="label">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>675</width>
 						<height>380</height>
 						<font>font30_title</font>
@@ -126,8 +126,8 @@
 					</control>
 					<control type="videowindow">
 						<description>No Fanart Back</description>
-						<posx>5</posx>
-						<posy>5</posy>
+						<left>5</left>
+						<top>5</top>
 						<width>665</width>
 						<height>370</height>
 						<visible>Player.HasVideo</visible>
@@ -135,12 +135,12 @@
 				</control>
 				<control type="group">
 					<visible>[!container.content(tvshows) + !container.content(episodes) + !container.content(musicvideos)] + ![Control.HasFocus(12) | Control.HasFocus(15)]</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>270</width>
 						<height>380</height>
 						<aspectratio>stretch</aspectratio>
@@ -149,8 +149,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="image">
-						<posx>4</posx>
-						<posy>4</posy>
+						<left>4</left>
+						<top>4</top>
 						<width>200</width>
 						<height>230</height>
 						<aspectratio>stretch</aspectratio>
@@ -158,8 +158,8 @@
 						<colordiffuse>AAFFFFFF</colordiffuse>
 					</control>
 					<control type="list" id="49">
-						<posx>290</posx>
-						<posy>20</posy>
+						<left>290</left>
+						<top>20</top>
 						<width>740</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -170,8 +170,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -182,8 +182,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>565</width>
 								<height>30</height>
 								<font>font13</font>
@@ -196,8 +196,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>740</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -205,8 +205,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -217,8 +217,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>565</width>
 								<height>30</height>
 								<font>font13</font>
@@ -305,8 +305,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>290</posx>
-						<posy>370</posy>
+						<left>290</left>
+						<top>370</top>
 						<width>740</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -315,12 +315,12 @@
 				</control>
 				<control type="group">
 					<visible>Container.Content(TVShows) + !Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>270</width>
 						<height>380</height>
 						<aspectratio>stretch</aspectratio>
@@ -330,8 +330,8 @@
 						<visible>IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>270</width>
 						<height>380</height>
 						<aspectratio>stretch</aspectratio>
@@ -341,8 +341,8 @@
 						<visible>!IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>4</posx>
-						<posy>4</posy>
+						<left>4</left>
+						<top>4</top>
 						<width>200</width>
 						<height>230</height>
 						<aspectratio>stretch</aspectratio>
@@ -350,8 +350,8 @@
 						<colordiffuse>AAFFFFFF</colordiffuse>
 					</control>
 					<control type="list" id="49">
-						<posx>290</posx>
-						<posy>20</posy>
+						<left>290</left>
+						<top>20</top>
 						<width>740</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -362,8 +362,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -374,8 +374,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>565</width>
 								<height>30</height>
 								<font>font13</font>
@@ -388,8 +388,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>740</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -397,8 +397,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -409,8 +409,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>565</width>
 								<height>30</height>
 								<font>font13</font>
@@ -461,8 +461,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>290</posx>
-						<posy>370</posy>
+						<left>290</left>
+						<top>370</top>
 						<width>740</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -471,12 +471,12 @@
 				</control>
 				<control type="group">
 					<visible>container.content(episodes) + !Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>380</width>
 						<height>250</height>
 						<aspectratio aligny="bottom">keep</aspectratio>
@@ -485,8 +485,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>250</posy>
+						<left>0</left>
+						<top>250</top>
 						<width>380</width>
 						<height>250</height>
 						<aspectratio aligny="top">keep</aspectratio>
@@ -495,8 +495,8 @@
 						<texture background="true" flipy="true" diffuse="diffuse_mirror2.png">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="list" id="49">
-						<posx>390</posx>
-						<posy>20</posy>
+						<left>390</left>
+						<top>20</top>
 						<width>640</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -507,8 +507,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -519,8 +519,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -533,8 +533,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>640</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -542,8 +542,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -554,8 +554,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -636,8 +636,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>290</posx>
-						<posy>370</posy>
+						<left>290</left>
+						<top>370</top>
 						<width>740</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -646,12 +646,12 @@
 				</control>
 				<control type="group">
 					<visible>container.content(musicvideos) + !Control.HasFocus(12)</visible>
-					<posy>90</posy>
-					<posx>210</posx>
+					<top>90</top>
+					<left>210</left>
 					<include>VisibleFadeEffect</include>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>380</width>
 						<height>360</height>
 						<aspectratio>keep</aspectratio>
@@ -660,8 +660,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="list" id="49">
-						<posx>390</posx>
-						<posy>20</posy>
+						<left>390</left>
+						<top>20</top>
 						<width>640</width>
 						<height>330</height>
 						<onleft>49</onleft>
@@ -672,8 +672,8 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -684,8 +684,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -698,8 +698,8 @@
 						</itemlayout>
 						<focusedlayout height="30">
 							<control type="image">
-								<posx>0</posx>
-								<posy>0</posy>
+								<left>0</left>
+								<top>0</top>
 								<width>640</width>
 								<height>30</height>
 								<visible>Control.HasFocus(49)</visible>
@@ -707,8 +707,8 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<posx>165</posx>
-								<posy>0</posy>
+								<left>165</left>
+								<top>0</top>
 								<width>160</width>
 								<height>30</height>
 								<font>font13</font>
@@ -719,8 +719,8 @@
 								<info>ListItem.Label</info>
 							</control>
 							<control type="label">
-								<posx>175</posx>
-								<posy>0</posy>
+								<left>175</left>
+								<top>0</top>
 								<width>465</width>
 								<height>30</height>
 								<font>font13</font>
@@ -789,8 +789,8 @@
 						</content>
 					</control>
 					<control type="image">
-						<posx>390</posx>
-						<posy>370</posy>
+						<left>390</left>
+						<top>370</top>
 						<width>640</width>
 						<height>4</height>
 						<aspectratio>stretch</aspectratio>
@@ -798,8 +798,8 @@
 					</control>
 				</control>
 				<control type="label">
-					<posx>130r</posx>
-					<posy>480</posy>
+					<left>130r</left>
+					<top>480</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -812,8 +812,8 @@
 					<visible>Control.IsVisible(400)</visible>
 				</control>
 				<control type="label">
-					<posx>130r</posx>
-					<posy>480</posy>
+					<left>130r</left>
+					<top>480</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -827,8 +827,8 @@
 				</control>
 				<control type="spincontrol" id="61">
 					<description>Next page button</description>
-					<posx>120r</posx>
-					<posy>485</posy>
+					<left>120r</left>
+					<top>485</top>
 					<subtype>page</subtype>
 					<font>-</font>
 					<onleft>61</onleft>
@@ -840,8 +840,8 @@
 				</control>
 				<control type="textbox" id="400">
 					<description>Description Value for Movies</description>
-					<posx>210</posx>
-					<posy>515</posy>
+					<left>210</left>
+					<top>515</top>
 					<width>1030</width>
 					<height>120</height>
 					<font>font12</font>
@@ -854,8 +854,8 @@
 				</control>
 				<control type="image">
 					<description>Actor image</description>
-					<posx>210</posx>
-					<posy>480</posy>
+					<left>210</left>
+					<top>480</top>
 					<width>160</width>
 					<height>160</height>
 					<texture>$INFO[Container(50).Listitem.Icon]</texture>
@@ -863,8 +863,8 @@
 					<visible>Control.IsVisible(50)</visible>
 				</control>
 				<control type="panel" id="50">
-					<posx>380</posx>
-					<posy>520</posy>
+					<left>380</left>
+					<top>520</top>
 					<width>860</width>
 					<height>120</height>
 					<onleft>9000</onleft>
@@ -877,15 +877,15 @@
 					<orientation>vertical</orientation>
 					<itemlayout height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -897,24 +897,24 @@
 					</itemlayout>
 					<focusedlayout height="40" width="430">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>!Control.HasFocus(50)</visible>
 							<texture border="5">button-nofocus.png</texture>
 						</control>
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>430</width>
 							<height>40</height>
 							<visible>Control.HasFocus(50)</visible>
 							<texture border="5">button-focus2.png</texture>
 						</control>
 						<control type="label">
-							<posx>10</posx>
-							<posy>0</posy>
+							<left>10</left>
+							<top>0</top>
 							<width>410</width>
 							<height>40</height>
 							<font>font12</font>
@@ -926,8 +926,8 @@
 					</focusedlayout>
 				</control>
 				<control type="grouplist" id="9000">
-					<posx>210</posx>
-					<posy>660</posy>
+					<left>210</left>
+					<top>660</top>
 					<width>1030</width>
 					<height>40</height>
 					<itemgap>2</itemgap>

--- a/addons/skin.confluence.lite/720p/DialogVideoInfo.xml
+++ b/addons/skin.confluence.lite/720p/DialogVideoInfo.xml
@@ -170,7 +170,7 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -205,7 +205,7 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -362,7 +362,7 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -397,7 +397,7 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -507,7 +507,7 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -542,7 +542,7 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -672,7 +672,7 @@
 						<scrolltime>200</scrolltime>
 						<itemlayout height="30">
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>
@@ -707,7 +707,7 @@
 								<include>VisibleFadeEffect</include>
 							</control>
 							<control type="label">
-								<left>165</left>
+								<left>5</left>
 								<top>0</top>
 								<width>160</width>
 								<height>30</height>

--- a/addons/skin.confluence.lite/720p/DialogVolumeBar.xml
+++ b/addons/skin.confluence.lite/720p/DialogVolumeBar.xml
@@ -4,13 +4,13 @@
 		<animation effect="slide" start="0,0" end="0,-40" delay="400" time="100">WindowClose</animation>
 	<controls>
 		<control type="group">
-			<posx>820</posx>
-			<posy>0</posy>
+			<left>820</left>
+			<top>0</top>
 			<include>VisibleFadeEffect</include>
 			<visible>!Player.Muted</visible>
 			<control type="image">
-				<posx>0</posx>
-				<posy>-10</posy>
+				<left>0</left>
+				<top>-10</top>
 				<width>300</width>
 				<height>50</height>
 				<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
@@ -18,8 +18,8 @@
 			<control type="group">
 				<control type="image">
 					<description>Lite Volume Logo</description>
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>40</width>
 					<height>35</height>
 					<aspectratio>keep</aspectratio>
@@ -27,8 +27,8 @@
 				</control>
 				<control type="progress" id="1">
 					<description>progress control</description>
-					<posx>50</posx>
-					<posy>8</posy>
+					<left>50</left>
+					<top>8</top>
 					<width>230</width>
 					<height>18</height>
 					<info>Player.Volume</info>

--- a/addons/skin.confluence.lite/720p/FileBrowser.xml
+++ b/addons/skin.confluence.lite/720p/FileBrowser.xml
@@ -3,19 +3,19 @@
 	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="group">
-			<posx>580</posx>
+			<left>580</left>
 			<animation effect="slide" start="700,0" end="0,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
 			<animation effect="slide" start="-400,0" end="0,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowOpen</animation>
 			<animation effect="slide" start="0,0" end="700,0" time="400" tween="quadratic" easing="out" condition="![Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
 			<animation effect="slide" start="0,0" end="-400,0" time="400" tween="quadratic" easing="out" condition="[Window.IsVisible(MovieInformation) | Window.IsVisible(MusicInformation)]">WindowClose</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1100</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
@@ -25,8 +25,8 @@
 				<animation effect="fade" start="100" end="0" time="200">WindowClose</animation>
 				<control type="label" id="411">
 					<description>header label</description>
-					<posx>660</posx>
-					<posy>40</posy>
+					<left>660</left>
+					<top>40</top>
 					<width>630</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -38,8 +38,8 @@
 				</control>
 				<control type="label" id="412">
 					<description>Path label</description>
-					<posx>660</posx>
-					<posy>70</posy>
+					<left>660</left>
+					<top>70</top>
 					<width>630</width>
 					<height>30</height>
 					<font>font13</font>
@@ -50,8 +50,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="grouplist" id="9000">
-					<posx>20</posx>
-					<posy>460</posy>
+					<left>20</left>
+					<top>460</top>
 					<width>221</width>
 					<height>225</height>
 					<itemgap>5</itemgap>
@@ -90,15 +90,15 @@
 					</control>
 				</control>
 				<control type="image">
-					<posx>245</posx>
-					<posy>460</posy>
+					<left>245</left>
+					<top>460</top>
 					<width>420</width>
 					<height>210</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image"> 
-					<posx>250</posx> 
-					<posy>465</posy> 
+					<left>250</left> 
+					<top>465</top> 
 					<width>410</width> 
 					<height>200</height> 
 					<aspectratio>keep</aspectratio> 
@@ -106,8 +106,8 @@
 					<visible>!SubString(Control.GetLabel(416),*)</visible> 
 				</control> 
 				<control type="image"> 
-					<posx>250</posx> 
-					<posy>465</posy> 
+					<left>250</left> 
+					<top>465</top> 
 					<width>410</width> 
 					<height>200</height> 
 					<aspectratio>keep</aspectratio> 
@@ -115,8 +115,8 @@
 					<visible>SubString(Control.GetLabel(416),*)</visible> 
 				</control>
 				<control type="panel" id="450">
-					<posx>20</posx>
-					<posy>120</posy>
+					<left>20</left>
+					<top>120</top>
 					<width>640</width>
 					<height>321</height>
 					<onleft>9000</onleft>
@@ -127,22 +127,22 @@
 					<scrolltime>200</scrolltime>
 					<itemlayout height="40" width="640">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>2</posy>
+							<left>10</left>
+							<top>2</top>
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>55</posx>
-							<posy>0</posy>
+							<left>55</left>
+							<top>0</top>
 							<width>580</width>
 							<height>40</height>
 							<font>font13</font>
@@ -154,31 +154,31 @@
 					</itemlayout>
 					<focusedlayout height="40" width="640">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<visible>!Control.HasFocus(450)</visible>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<visible>Control.HasFocus(450)</visible>
 							<texture border="5">MenuItemFO.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>2</posy>
+							<left>10</left>
+							<top>2</top>
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>55</posx>
-							<posy>0</posy>
+							<left>55</left>
+							<top>0</top>
 							<width>580</width>
 							<height>40</height>
 							<font>font13</font>
@@ -190,8 +190,8 @@
 					</focusedlayout>
 				</control>
 				<control type="panel" id="451">
-					<posx>20</posx>
-					<posy>120</posy>
+					<left>20</left>
+					<top>120</top>
 					<width>640</width>
 					<height>321</height>
 					<onleft>9000</onleft>
@@ -202,22 +202,22 @@
 					<scrolltime>200</scrolltime>
 					<itemlayout height="40" width="640">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>2</posy>
+							<left>10</left>
+							<top>2</top>
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>55</posx>
-							<posy>0</posy>
+							<left>55</left>
+							<top>0</top>
 							<width>580</width>
 							<height>40</height>
 							<font>font13</font>
@@ -229,31 +229,31 @@
 					</itemlayout>
 					<focusedlayout height="40" width="640">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<visible>!Control.HasFocus(451)</visible>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>640</width>
 							<height>41</height>
 							<visible>Control.HasFocus(451)</visible>
 							<texture border="5">MenuItemFO.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>2</posy>
+							<left>10</left>
+							<top>2</top>
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>55</posx>
-							<posy>0</posy>
+							<left>55</left>
+							<top>0</top>
 							<width>580</width>
 							<height>40</height>
 							<font>font13</font>
@@ -266,8 +266,8 @@
 				</control>
 
 				<control type="scrollbar" id="60">
-					<posx>650</posx>
-					<posy>120</posy>
+					<left>650</left>
+					<top>120</top>
 					<width>25</width>
 					<height>320</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -282,8 +282,8 @@
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<posx>660</posx>
-					<posy>680</posy>
+					<left>660</left>
+					<top>680</top>
 					<width>560</width>
 					<height>30</height>
 					<align>right</align>
@@ -295,8 +295,8 @@
 				</control>
 				<control type="label">
 					<description>Page label</description>
-					<posx>660</posx>
-					<posy>680</posy>
+					<left>660</left>
+					<top>680</top>
 					<width>560</width>
 					<height>30</height>
 					<align>right</align>

--- a/addons/skin.confluence.lite/720p/FileBrowser.xml
+++ b/addons/skin.confluence.lite/720p/FileBrowser.xml
@@ -96,23 +96,23 @@
 					<height>210</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
-				<control type="image"> 
-					<left>250</left> 
-					<top>465</top> 
-					<width>410</width> 
-					<height>200</height> 
-					<aspectratio>keep</aspectratio> 
-					<texture background="true">$INFO[ListItem.Icon]</texture> 
-					<visible>!SubString(Control.GetLabel(416),*)</visible> 
-				</control> 
-				<control type="image"> 
-					<left>250</left> 
-					<top>465</top> 
-					<width>410</width> 
-					<height>200</height> 
-					<aspectratio>keep</aspectratio> 
-					<texture background="true" flipx="true">$INFO[ListItem.Icon]</texture> 
-					<visible>SubString(Control.GetLabel(416),*)</visible> 
+				<control type="image">
+					<left>250</left>
+					<top>465</top>
+					<width>410</width>
+					<height>200</height>
+					<aspectratio>keep</aspectratio>
+					<texture background="true">$INFO[ListItem.Icon]</texture>
+					<visible>!SubString(Control.GetLabel(416),*)</visible>
+				</control>
+				<control type="image">
+					<left>250</left>
+					<top>465</top>
+					<width>410</width>
+					<height>200</height>
+					<aspectratio>keep</aspectratio>
+					<texture background="true" flipx="true">$INFO[ListItem.Icon]</texture>
+					<visible>SubString(Control.GetLabel(416),*)</visible>
 				</control>
 				<control type="panel" id="450">
 					<left>20</left>
@@ -139,6 +139,7 @@
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
 							<left>55</left>
@@ -175,6 +176,7 @@
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
 							<left>55</left>
@@ -214,6 +216,7 @@
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
 							<left>55</left>
@@ -250,6 +253,7 @@
 							<width>38</width>
 							<height>38</height>
 							<texture>$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
 							<left>55</left>

--- a/addons/skin.confluence.lite/720p/FileManager.xml
+++ b/addons/skin.confluence.lite/720p/FileManager.xml
@@ -4,8 +4,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -14,16 +14,16 @@
 		</control>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -35,8 +35,8 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>30</posx>
-			<posy>40</posy>
+			<left>30</left>
+			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -46,22 +46,22 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>610</width>
 				<height>620</height>
 				<texture border="20">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>612</posy>
+				<left>0</left>
+				<top>612</top>
 				<width>610</width>
 				<height>64</height>
 				<texture border="10">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
-				<posx>510</posx>
-				<posy>20</posy>
+				<left>510</left>
+				<top>20</top>
 				<width>80</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
@@ -71,8 +71,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>30</posx>
-				<posy>30</posy>
+				<left>30</left>
+				<top>30</top>
 				<width>470</width>
 				<height>30</height>
 				<font>font35_title</font>
@@ -84,8 +84,8 @@
 			</control>
 			<control type="label" id="101">
 				<description>current directory text label</description>
-				<posx>30</posx>
-				<posy>70</posy>
+				<left>30</left>
+				<top>70</top>
 				<width>470</width>
 				<height>30</height>
 				<font>font12_title</font>
@@ -96,8 +96,8 @@
 				<aligny>center</aligny>
 			</control>
 			<control type="scrollbar" id="30">
-				<posx>10</posx>
-				<posy>110</posy>
+				<left>10</left>
+				<top>110</top>
 				<width>25</width>
 				<height>490</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -113,8 +113,8 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="list" id="20">
-				<posx>40</posx>
-				<posy>110</posy>
+				<left>40</left>
+				<top>110</top>
 				<width>540</width>
 				<height>491</height>
 				<onleft>30</onleft>
@@ -125,15 +125,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="35" width="540">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>500</width>
 						<height>36</height>
 						<font>font13</font>
@@ -144,8 +144,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>530</posx>
-						<posy>5</posy>
+						<left>530</left>
+						<top>5</top>
 						<width>200</width>
 						<height>24</height>
 						<font>font12</font>
@@ -158,32 +158,32 @@
 				</itemlayout>
 				<focusedlayout height="35" width="540">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<visible>!Control.HasFocus(20)</visible>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<visible>Control.HasFocus(20)</visible>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
 					</control>
 					<control type="image">
-						<posx>340</posx>
-						<posy>2</posy>
+						<left>340</left>
+						<top>2</top>
 						<width>200</width>
 						<height>31</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(20) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>500</width>
 						<height>36</height>
 						<font>font13</font>
@@ -194,8 +194,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>530</posx>
-						<posy>5</posy>
+						<left>530</left>
+						<top>5</top>
 						<width>200</width>
 						<height>24</height>
 						<font>font12</font>
@@ -209,8 +209,8 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>650</posx>
-			<posy>40</posy>
+			<left>650</left>
+			<top>40</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -220,22 +220,22 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>610</width>
 				<height>620</height>
 				<texture border="20">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>612</posy>
+				<left>0</left>
+				<top>612</top>
 				<width>610</width>
 				<height>64</height>
 				<texture border="10">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
-				<posx>20</posx>
-				<posy>20</posy>
+				<left>20</left>
+				<top>20</top>
 				<width>80</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
@@ -245,8 +245,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>580</posx>
-				<posy>30</posy>
+				<left>580</left>
+				<top>30</top>
 				<width>470</width>
 				<height>30</height>
 				<font>font35_title</font>
@@ -258,8 +258,8 @@
 			</control>
 			<control type="label" id="102">
 				<description>current directory text label</description>
-				<posx>580</posx>
-				<posy>70</posy>
+				<left>580</left>
+				<top>70</top>
 				<width>470</width>
 				<height>30</height>
 				<font>font12_title</font>
@@ -270,8 +270,8 @@
 				<aligny>center</aligny>
 			</control>
 			<control type="scrollbar" id="31">
-				<posx>575</posx>
-				<posy>110</posy>
+				<left>575</left>
+				<top>110</top>
 				<width>25</width>
 				<height>490</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -287,8 +287,8 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="list" id="21">
-				<posx>30</posx>
-				<posy>110</posy>
+				<left>30</left>
+				<top>110</top>
 				<width>540</width>
 				<height>491</height>
 				<onleft>20</onleft>
@@ -299,15 +299,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="35">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>500</width>
 						<height>36</height>
 						<font>font13</font>
@@ -318,8 +318,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>530</posx>
-						<posy>5</posy>
+						<left>530</left>
+						<top>5</top>
 						<width>200</width>
 						<height>24</height>
 						<font>font12</font>
@@ -332,32 +332,32 @@
 				</itemlayout>
 				<focusedlayout height="35">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<visible>!Control.HasFocus(21)</visible>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>540</width>
 						<height>36</height>
 						<visible>Control.HasFocus(21)</visible>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
 					</control>
 					<control type="image">
-						<posx>340</posx>
-						<posy>2</posy>
+						<left>340</left>
+						<top>2</top>
 						<width>200</width>
 						<height>31</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(21) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>500</width>
 						<height>36</height>
 						<font>font13</font>
@@ -368,8 +368,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>530</posx>
-						<posy>5</posy>
+						<left>530</left>
+						<top>5</top>
 						<width>200</width>
 						<height>24</height>
 						<font>font12</font>
@@ -384,8 +384,8 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in left list text label</description>
-			<posx>40</posx>
-			<posy>53r</posy>
+			<left>40</left>
+			<top>53r</top>
 			<width>570</width>
 			<font>font12</font>
 			<align>left</align>
@@ -396,8 +396,8 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in left list text label</description>
-			<posx>40r</posx>
-			<posy>53r</posy>
+			<left>40r</left>
+			<top>53r</top>
 			<width>570</width>
 			<font>font12</font>
 			<align>right</align>

--- a/addons/skin.confluence.lite/720p/FileManager.xml
+++ b/addons/skin.confluence.lite/720p/FileManager.xml
@@ -144,7 +144,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>530</left>
+						<left>330</left>
 						<top>5</top>
 						<width>200</width>
 						<height>24</height>
@@ -194,7 +194,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>530</left>
+						<left>330</left>
 						<top>5</top>
 						<width>200</width>
 						<height>24</height>
@@ -318,7 +318,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>530</left>
+						<left>330</left>
 						<top>5</top>
 						<width>200</width>
 						<height>24</height>
@@ -368,7 +368,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>530</left>
+						<left>330</left>
 						<top>5</top>
 						<width>200</width>
 						<height>24</height>

--- a/addons/skin.confluence.lite/720p/Home.xml
+++ b/addons/skin.confluence.lite/720p/Home.xml
@@ -403,7 +403,7 @@
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="label">
-						<left>150</left>
+						<left>5</left>
 						<top>0</top>
 						<width>290</width>
 						<height>60</height>
@@ -430,7 +430,7 @@
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="label">
-						<left>150</left>
+						<left>5</left>
 						<top>0</top>
 						<width>290</width>
 						<height>60</height>
@@ -441,7 +441,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>150</left>
+						<left>5</left>
 						<top>0</top>
 						<width>290</width>
 						<height>60</height>
@@ -780,5 +780,5 @@
 			<include>Window_OpenClose_Animation</include>
 			<animation effect="slide" start="0,0" end="-40,0" time="100" condition="Player.Muted">conditional</animation>
 		</control>
-	</controls>	
+	</controls>
 </window>

--- a/addons/skin.confluence.lite/720p/Home.xml
+++ b/addons/skin.confluence.lite/720p/Home.xml
@@ -4,8 +4,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>90r</posy>
+			<left>0</left>
+			<top>90r</top>
 			<width>1280</width>
 			<height>90</height>
 			<texture>floor.png</texture>
@@ -14,8 +14,8 @@
 		</control>
 		<control type="image">
 			<description>LOGO</description>
-			<posx>0</posx>
-			<posy>5</posy>
+			<left>0</left>
+			<top>5</top>
 			<width>170</width>
 			<height>100</height>
 			<aspectratio aligny="top" align="left">keep</aspectratio>
@@ -26,15 +26,15 @@
 		</control>
 		<!-- Music Info -->
 		<control type="group">
-			<posx>0</posx>
-			<posy>60</posy>
+			<left>0</left>
+			<top>60</top>
 			<visible>Player.HasAudio + !Skin.HasSetting(homepageMusicinfo)</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<description>Cover image</description>
-				<posx>20</posx>
-				<posy>45</posy>
+				<left>20</left>
+				<top>45</top>
 				<width>130</width>
 				<height>295</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
@@ -44,8 +44,8 @@
 			</control>
 			<control type="label">
 				<description>Album Label</description>
-				<posx>170</posx>
-				<posy>265</posy>
+				<left>170</left>
+				<top>265</top>
 				<height>25</height>
 				<width>1000</width>
 				<label>$INFO[MusicPlayer.Artist,, - ]$INFO[MusicPlayer.Album]$INFO[musicplayer.discnumber, - $LOCALIZE[427]:]</label>
@@ -57,8 +57,8 @@
 			</control>
 			<control type="label">
 				<description>Title label</description>
-				<posx>170</posx>
-				<posy>285</posy>
+				<left>170</left>
+				<top>285</top>
 				<height>30</height>
 				<width>1000</width>
 				<label>$INFO[MusicPlayer.Title]</label>
@@ -70,8 +70,8 @@
 			</control>
 			<control type="label">
 				<description>Time Label</description>
-				<posx>170</posx>
-				<posy>310</posy>
+				<left>170</left>
+				<top>310</top>
 				<height>30</height>
 				<width>300</width>
 				<label>$INFO[Player.Time]$INFO[Player.Duration,[COLOR=blue] / [/COLOR]]</label>
@@ -84,8 +84,8 @@
 		</control>
 		<!-- Video Info -->
 		<control type="group">
-			<posx>0</posx>
-			<posy>50</posy>
+			<left>0</left>
+			<top>50</top>
 			<visible>Player.HasVideo + !Skin.HasSetting(homepageVideoinfo)</visible>
 			<include>VisibleFadeEffect</include>
 			<include>Window_OpenClose_Animation</include>
@@ -93,8 +93,8 @@
 				<visible>!VideoPlayer.Content(Movies) + !VideoPlayer.Content(Episodes)</visible>
 				<control type="image">
 					<description>Cover image</description>
-					<posx>20</posx>
-					<posy>45</posy>
+					<left>20</left>
+					<top>45</top>
 					<width>120</width>
 					<height>300</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -104,8 +104,8 @@
 				</control>
 				<control type="label">
 					<description>Title label</description>
-					<posx>160</posx>
-					<posy>285</posy>
+					<left>160</left>
+					<top>285</top>
 					<height>30</height>
 					<width>1000</width>
 					<label>$INFO[VideoPlayer.Title]</label>
@@ -117,8 +117,8 @@
 				</control>
 				<control type="label">
 					<description>Time Label</description>
-					<posx>160</posx>
-					<posy>310</posy>
+					<left>160</left>
+					<top>310</top>
 					<height>30</height>
 					<width>300</width>
 					<label>$INFO[Player.Time]$INFO[Player.Duration,[COLOR=blue] / [/COLOR]]</label>
@@ -133,8 +133,8 @@
 				<visible>VideoPlayer.Content(Movies)</visible>
 				<control type="image">
 					<description>Cover image</description>
-					<posx>20</posx>
-					<posy>45</posy>
+					<left>20</left>
+					<top>45</top>
 					<width>120</width>
 					<height>300</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -144,8 +144,8 @@
 				</control>
 				<control type="label">
 					<description>Studio label</description>
-					<posx>160</posx>
-					<posy>265</posy>
+					<left>160</left>
+					<top>265</top>
 					<height>25</height>
 					<width>1000</width>
 					<label>$INFO[VideoPlayer.Studio]</label>
@@ -157,8 +157,8 @@
 				</control>
 				<control type="label">
 					<description>Title label</description>
-					<posx>160</posx>
-					<posy>285</posy>
+					<left>160</left>
+					<top>285</top>
 					<height>30</height>
 					<width>1000</width>
 					<label>$INFO[VideoPlayer.Title]$INFO[VideoPlayer.Year,[COLOR=grey] (,)[/COLOR]]</label>
@@ -170,8 +170,8 @@
 				</control>
 				<control type="label">
 					<description>Time Label</description>
-					<posx>160</posx>
-					<posy>310</posy>
+					<left>160</left>
+					<top>310</top>
 					<height>30</height>
 					<width>300</width>
 					<label>$INFO[Player.Time]$INFO[Player.Duration,[COLOR=blue] / [/COLOR]]</label>
@@ -186,8 +186,8 @@
 				<visible>VideoPlayer.Content(Episodes)</visible>
 				<control type="image">
 					<description>Cover image</description>
-					<posx>20</posx>
-					<posy>225</posy>
+					<left>20</left>
+					<top>225</top>
 					<width>180</width>
 					<height>120</height>
 					<aspectratio>scale</aspectratio>
@@ -197,8 +197,8 @@
 				</control>
 				<control type="label">
 					<description>TV Show Season Ep Label</description>
-					<posx>210</posx>
-					<posy>265</posy>
+					<left>210</left>
+					<top>265</top>
 					<height>25</height>
 					<width>1000</width>
 					<label>$INFO[VideoPlayer.TVShowTitle] ($LOCALIZE[20373] $INFO[VideoPlayer.Season] - $LOCALIZE[20359] $INFO[VideoPlayer.episode])</label>
@@ -210,8 +210,8 @@
 				</control>
 				<control type="label">
 					<description>Title label</description>
-					<posx>210</posx>
-					<posy>285</posy>
+					<left>210</left>
+					<top>285</top>
 					<height>30</height>
 					<width>1000</width>
 					<label>$INFO[VideoPlayer.Title]</label>
@@ -223,8 +223,8 @@
 				</control>
 				<control type="label">
 					<description>Time Label</description>
-					<posx>210</posx>
-					<posy>310</posy>
+					<left>210</left>
+					<top>310</top>
 					<height>30</height>
 					<width>300</width>
 					<label>$INFO[Player.Time]$INFO[Player.Duration,[COLOR=blue] / [/COLOR]]</label>
@@ -239,8 +239,8 @@
 		<include condition="!Skin.HasSetting(HomepageHideRecentlyAddedVideo) | !Skin.HasSetting(HomepageHideRecentlyAddedAlbums)">HomeRecentlyAddedInfo</include>
 		<control type="button" id="9003">
 			<description>Hidden Button to pass through navigation when recently added is disabled</description>
-			<posx>-20</posx>
-			<posy>-20</posy>
+			<left>-20</left>
+			<top>-20</top>
 			<width>1</width>
 			<height>1</height>
 			<label>-</label>
@@ -256,8 +256,8 @@
 		<include>CurrentlyPlayingMediaControls</include> <!-- Global Search and Currently Playing Media Control -->
 		<control type="button" id="610">
 			<description>Fake Button to pass through navigation when media isn't playing</description>
-			<posx>-20</posx>
-			<posy>-20</posy>
+			<left>-20</left>
+			<top>-20</top>
 			<width>1</width>
 			<height>1</height>
 			<label>-</label>
@@ -269,8 +269,8 @@
 		</control>
 		<control type="button" id="610">
 			<description>Fake Button to pass through navigation when media is playing</description>
-			<posx>-20</posx>
-			<posy>-20</posy>
+			<left>-20</left>
+			<top>-20</top>
 			<width>1</width>
 			<height>1</height>
 			<label>-</label>
@@ -281,7 +281,7 @@
 			<visible>Player.HasMedia</visible>
 		</control>
 		<control type="group">
-			<posy>400</posy>
+			<top>400</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -291,8 +291,8 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="group" id="9001">
-				<posx>0</posx>
-				<posy>70</posy>
+				<left>0</left>
+				<top>70</top>
 				<onup>9000</onup>
 				<ondown>9002</ondown>
 				<control type="grouplist" id="9010">
@@ -360,22 +360,22 @@
 				</control>
 			</control>
 			<control type="image">
-				<posx>-100</posx>
-				<posy>0</posy>
+				<left>-100</left>
+				<top>0</top>
 				<width>1480</width>
 				<height>75</height>
 				<texture border="0,6,0,6">HomeBack.png</texture>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>5</posy>
+				<left>0</left>
+				<top>5</top>
 				<width>1280</width>
 				<height>6</height>
 				<texture>HomeOverlay1.png</texture>
 			</control>
 			<control type="fixedlist" id="9000">
-				<posx>-110</posx>
-				<posy>5</posy>
+				<left>-110</left>
+				<top>5</top>
 				<width>1500</width>
 				<height>60</height>
 				<onleft>9000</onleft>
@@ -389,22 +389,22 @@
 				<orientation>Horizontal</orientation>
 				<itemlayout height="60" width="300">
 					<control type="image">
-						<posx>0</posx>
-						<posy>4</posy>
+						<left>0</left>
+						<top>4</top>
 						<width>1</width>
 						<height>52</height>
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="image">
-						<posx>299</posx>
-						<posy>4</posy>
+						<left>299</left>
+						<top>4</top>
 						<width>1</width>
 						<height>52</height>
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="label">
-						<posx>150</posx>
-						<posy>0</posy>
+						<left>150</left>
+						<top>0</top>
 						<width>290</width>
 						<height>60</height>
 						<font>font_MainMenu</font>
@@ -416,22 +416,22 @@
 				</itemlayout>
 				<focusedlayout height="60" width="300">
 					<control type="image">
-						<posx>0</posx>
-						<posy>4</posy>
+						<left>0</left>
+						<top>4</top>
 						<width>1</width>
 						<height>52</height>
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="image">
-						<posx>299</posx>
-						<posy>4</posy>
+						<left>299</left>
+						<top>4</top>
 						<width>1</width>
 						<height>52</height>
 						<texture>HomeSeperator.png</texture>
 					</control>
 					<control type="label">
-						<posx>150</posx>
-						<posy>0</posy>
+						<left>150</left>
+						<top>0</top>
 						<width>290</width>
 						<height>60</height>
 						<font>font_MainMenu</font>
@@ -441,8 +441,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>150</posx>
-						<posy>0</posy>
+						<left>150</left>
+						<top>0</top>
 						<width>290</width>
 						<height>60</height>
 						<font>font_MainMenu</font>
@@ -526,15 +526,15 @@
 				</content>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>6</posy>
+				<left>0</left>
+				<top>6</top>
 				<width>128</width>
 				<height>50</height>
 				<texture>SideFade.png</texture>
 			</control>
 			<control type="image">
-				<posx>128r</posx>
-				<posy>6</posy>
+				<left>128r</left>
+				<top>6</top>
 				<width>128</width>
 				<height>60</height>
 				<texture flipx="true">SideFade.png</texture>
@@ -542,8 +542,8 @@
 		</control>
 		<control type="button" id="9002">
 			<description>Hidden Button to pass through navigation when Plugin is not set</description>
-			<posx>-20</posx>
-			<posy>-20</posy>
+			<left>-20</left>
+			<top>-20</top>
 			<width>1</width>
 			<height>1</height>
 			<label>-</label>
@@ -613,14 +613,14 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>0</posx>
-			<posy>33r</posy>
+			<left>0</left>
+			<top>33r</top>
 			<visible>system.getbool(lookandfeel.enablerssfeeds)</visible>
 			<include>Window_OpenClose_Animation</include>
 			<control type="rss">
 				<description>RSS feed</description>
-				<posx>100</posx>
-				<posy>0</posy>
+				<left>100</left>
+				<top>0</top>
 				<height>30</height>
 				<width>1145</width>
 				<font>font12</font>
@@ -631,21 +631,21 @@
 			</control>
 			<control type="image">
 				<description>RSS background</description>
-				<posx>1250</posx>
-				<posy>2</posy>
+				<left>1250</left>
+				<top>2</top>
 				<width>24</width>
 				<height>24</height>
 				<texture>icon-rss.png</texture>
 			</control>
 		</control>
 		<control type="group" id="10">
-			<posx>20</posx>
-			<posy>55r</posy>
+			<left>20</left>
+			<top>55r</top>
 			<include>Window_OpenClose_Animation</include>
 			<control type="button" id="20">
 				<description>Power push button</description>
-				<posx>55</posx>
-				<posy>0</posy>
+				<left>55</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31003</label>
@@ -661,8 +661,8 @@
 			</control>
 			<control type="image">
 				<description>Power Icon</description>
-				<posx>60</posx>
-				<posy>5</posy>
+				<left>60</left>
+				<top>5</top>
 				<width>35</width>
 				<height>35</height>
 				<aspectratio>keep</aspectratio>
@@ -670,8 +670,8 @@
 			</control>
 			<control type="button" id="21">
 				<description>Favourites push button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>1036</label>
@@ -687,8 +687,8 @@
 			</control>
 			<control type="image">
 				<description>Favourites Icon</description>
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>35</width>
 				<height>35</height>
 				<aspectratio>keep</aspectratio>
@@ -696,14 +696,14 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>20</posx>
-			<posy>0</posy>
+			<left>20</left>
+			<top>0</top>
 			<visible>Skin.HasSetting(homepageWeatherinfo)</visible>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<description>Weather image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>60</width>
 				<height>60</height>
 				<aspectratio>keep</aspectratio>
@@ -711,8 +711,8 @@
 			</control>
 			<control type="label">
 				<description>Location label</description>
-				<posx>65</posx>
-				<posy>5</posy>
+				<left>65</left>
+				<top>5</top>
 				<width>500</width>
 				<height>15</height>
 				<align>left</align>
@@ -723,8 +723,8 @@
 				<label>$INFO[Window(Weather).Property(Location)]</label>
 			</control>
 			<control type="grouplist">
-				<posx>65</posx>
-				<posy>20</posy>
+				<left>65</left>
+				<top>20</top>
 				<width>1000</width>
 				<height>30</height>
 				<orientation>horizontal</orientation>
@@ -767,8 +767,8 @@
 		<include>Clock</include>
 		<control type="label">
 			<description>Date label</description>
-			<posx>20r</posx>
-			<posy>35</posy>
+			<left>20r</left>
+			<top>35</top>
 			<width>200</width>
 			<height>15</height>
 			<align>right</align>

--- a/addons/skin.confluence.lite/720p/IncludesBackgroundBuilding.xml
+++ b/addons/skin.confluence.lite/720p/IncludesBackgroundBuilding.xml
@@ -7,8 +7,8 @@
 				<visible>![Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)]</visible>
 				<control type="image">
 					<description>Normal Default Background Image</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>1280</width>
 					<height>720</height>
 					<aspectratio>scale</aspectratio>
@@ -18,8 +18,8 @@
 				</control>
 				<control type="image">
 					<description>User Set Background Image</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>1280</width>
 					<height>720</height>
 					<aspectratio>scale</aspectratio>
@@ -30,8 +30,8 @@
 			</control>
 			<control type="image">
 				<description>Fanart Image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>720</height>
 				<aspectratio>scale</aspectratio>
@@ -44,8 +44,8 @@
 			</control>
 			<control type="image">
 				<description>Media Overlay</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>720</height>
 				<texture background="true">special://skin/backgrounds/media-overlay.jpg</texture>
@@ -53,23 +53,23 @@
 			</control>
 		</control>
 		<control type="visualisation">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<visible>Player.HasAudio + !Skin.HasSetting(ShowBackgroundVis)</visible>
 		<!--<visible>!SubString(Window(videolibrary).Property(TvTunesIsAlive),True)</visible>-->
 		</control>
 		<control type="videowindow">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<visible>Player.HasVideo + !Skin.HasSetting(ShowBackgroundVideo)</visible>
 		</control>
 		<control type="image">
-			<posx>0</posx>
-			<posy>-40</posy>
+			<left>0</left>
+			<top>-40</top>
 			<width>1280</width>
 			<height>120</height>
 			<texture flipy="true">HomeNowPlayingBack.png</texture>
@@ -80,8 +80,8 @@
 	</include>
 	<include name="ContentPanelBackgrounds">
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -94,15 +94,15 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(50)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>60</posy>
+					<left>50</left>
+					<top>60</top>
 					<width>750</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>750</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -112,29 +112,29 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(504) | Control.IsVisible(550) | Control.IsVisible(512)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>60</posy>
+					<left>50</left>
+					<top>60</top>
 					<width>640</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>640</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
 				</control>
 				<control type="image">
-					<posx>700</posx>
-					<posy>60</posy>
+					<left>700</left>
+					<top>60</top>
 					<width>530</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>700</posx>
-					<posy>652</posy>
+					<left>700</left>
+					<top>652</top>
 					<width>530</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -144,29 +144,29 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(551) | Control.IsVisible(560) | Control.IsVisible(511) | Control.IsVisible(506) | Control.IsVisible(513)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>60</posy>
+					<left>50</left>
+					<top>60</top>
 					<width>840</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>840</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
 				</control>
 				<control type="image">
-					<posx>900</posx>
-					<posy>60</posy>
+					<left>900</left>
+					<top>60</top>
 					<width>330</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>900</posx>
-					<posy>652</posy>
+					<left>900</left>
+					<top>652</top>
 					<width>330</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -176,15 +176,15 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(501)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>50</posy>
+					<left>50</left>
+					<top>50</top>
 					<width>1180</width>
 					<height>610</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>1180</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -194,29 +194,29 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(503)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>230</posy>
+					<left>50</left>
+					<top>230</top>
 					<width>640</width>
 					<height>430</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>640</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
 				</control>
 				<control type="image">
-					<posx>700</posx>
-					<posy>230</posy>
+					<left>700</left>
+					<top>230</top>
 					<width>550</width>
 					<height>430</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>700</posx>
-					<posy>652</posy>
+					<left>700</left>
+					<top>652</top>
 					<width>550</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -226,15 +226,15 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(51) | Control.IsVisible(500) | Control.IsVisible(505)</visible>
 				<control type="image">
-					<posx>75</posx>
-					<posy>60</posy>
+					<left>75</left>
+					<top>60</top>
 					<width>1130</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>75</posx>
-					<posy>652</posy>
+					<left>75</left>
+					<top>652</top>
 					<width>1130</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -244,29 +244,29 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(514)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>60</posy>
+					<left>50</left>
+					<top>60</top>
 					<width>490</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>490</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
 				</control>
 				<control type="image">
-					<posx>550</posx>
-					<posy>60</posy>
+					<left>550</left>
+					<top>60</top>
 					<width>680</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>550</posx>
-					<posy>652</posy>
+					<left>550</left>
+					<top>652</top>
 					<width>680</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
@@ -276,29 +276,29 @@
 				<include>VisibleFadeEffect</include>
 				<visible>Control.IsVisible(515)</visible>
 				<control type="image">
-					<posx>50</posx>
-					<posy>60</posy>
+					<left>50</left>
+					<top>60</top>
 					<width>400</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>50</posx>
-					<posy>652</posy>
+					<left>50</left>
+					<top>652</top>
 					<width>400</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>
 				</control>
 				<control type="image">
-					<posx>460</posx>
-					<posy>60</posy>
+					<left>460</left>
+					<top>60</top>
 					<width>770</width>
 					<height>600</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>460</posx>
-					<posy>652</posy>
+					<left>460</left>
+					<top>652</top>
 					<width>770</width>
 					<height>64</height>
 					<texture border="15">ContentPanelMirror.png</texture>

--- a/addons/skin.confluence.lite/720p/IncludesHomeMenuItems.xml
+++ b/addons/skin.confluence.lite/720p/IncludesHomeMenuItems.xml
@@ -530,8 +530,8 @@
 	<include name="CurrentlyPlayingMediaControls">
 		<control type="group">
 			<description>Controls for currently playing media</description>
-			<posx>545r</posx>
-			<posy>370</posy>
+			<left>545r</left>
+			<top>370</top>
 			<animation effect="slide" start="0,0" end="365,0" time="300" condition="!Player.HasMedia">conditional</animation>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
@@ -543,8 +543,8 @@
 			</animation>
 			<control type="image">
 				<description>Background End image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>35</width>
 				<height>35</height>
 				<colordiffuse>CCFFFFFF</colordiffuse>
@@ -553,8 +553,8 @@
 			<control type="radiobutton" id="608">
 				<colordiffuse>CCFFFFFF</colordiffuse>
 				<description>Content Search</description>
-				<posx>35</posx>
-				<posy>0</posy>
+				<left>35</left>
+				<top>0</top>
 				<height>35</height>
 				<width>145</width>
 				<textwidth>150</textwidth>
@@ -577,23 +577,23 @@
 				<ondown>9000</ondown>
 			</control>
 			<control type="group" id="600">
-				<posx>180</posx>
+				<left>180</left>
 				<onup>9003</onup>
 				<ondown>9000</ondown>
 				<defaultcontrol>-</defaultcontrol>
 				<enable>Player.HasMedia</enable>
 				<control type="image">
 					<description>Background image</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>205</width>
 					<height>35</height>
 					<texture flipy="true" border="0,5,0,0">HomeSubNF.png</texture>
 					<colordiffuse>CCFFFFFF</colordiffuse>
 				</control>
 				<control type="button" id="601">
-					<posx>10</posx>
-					<posy>2</posy>
+					<left>10</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -606,8 +606,8 @@
 					<onclick>XBMC.PlayerControl(Previous)</onclick>
 				</control>
 				<control type="button" id="602">
-					<posx>40</posx>
-					<posy>2</posy>
+					<left>40</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -620,8 +620,8 @@
 					<onclick>XBMC.PlayerControl(Rewind)</onclick>
 				</control>
 				<control type="togglebutton" id="603">
-					<posx>70</posx>
-					<posy>2</posy>
+					<left>70</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -637,8 +637,8 @@
 					<onclick>XBMC.PlayerControl(Play)</onclick>
 				</control>
 				<control type="button" id="604">
-					<posx>100</posx>
-					<posy>2</posy>
+					<left>100</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -652,8 +652,8 @@
 					<onclick>XBMC.PlayerControl(Stop)</onclick>
 				</control>
 				<control type="button" id="605">
-					<posx>130</posx>
-					<posy>2</posy>
+					<left>130</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -666,8 +666,8 @@
 					<onclick>XBMC.PlayerControl(Forward)</onclick>
 				</control>
 				<control type="button" id="606">
-					<posx>160</posx>
-					<posy>2</posy>
+					<left>160</left>
+					<top>2</top>
 					<width>30</width>
 					<height>30</height>
 					<label>-</label>
@@ -683,8 +683,8 @@
 			<control type="radiobutton" id="607">
 				<colordiffuse>CCFFFFFF</colordiffuse>
 				<description>Go to fullscreen Playback</description>
-				<posx>385</posx>
-				<posy>0</posy>
+				<left>385</left>
+				<top>0</top>
 				<height>35</height>
 				<width>160</width>
 				<textwidth>150</textwidth>

--- a/addons/skin.confluence.lite/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence.lite/720p/IncludesHomeRecentlyAdded.xml
@@ -58,11 +58,12 @@
 							<width>160</width>
 							<height>170</height>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<left>90</left>
+							<left>15</left>
 							<top>185</top>
 							<width>150</width>
 							<height>20</height>
@@ -90,6 +91,7 @@
 							<width>160</width>
 							<height>170</height>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 							<bordertexture border="5">folder-focus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<visible>Control.HasFocus(8000)</visible>
@@ -100,12 +102,13 @@
 							<width>160</width>
 							<height>170</height>
 							<texture>$INFO[ListItem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<visible>!Control.HasFocus(8000)</visible>
 						</control>
 						<control type="label">
-							<left>90</left>
+							<left>15</left>
 							<top>185</top>
 							<width>150</width>
 							<height>20</height>
@@ -118,7 +121,7 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>90</left>
+							<left>15</left>
 							<top>185</top>
 							<width>150</width>
 							<height>20</height>
@@ -296,7 +299,7 @@
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<left>120</left>
+							<left>20</left>
 							<top>168</top>
 							<width>200</width>
 							<height>20</height>
@@ -309,7 +312,7 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<left>120</left>
+							<left>20</left>
 							<top>185</top>
 							<width>200</width>
 							<height>20</height>
@@ -354,7 +357,7 @@
 							<visible>!Control.HasFocus(8001)</visible>
 						</control>
 						<control type="label">
-							<left>120</left>
+							<left>20</left>
 							<top>168</top>
 							<width>200</width>
 							<height>20</height>
@@ -367,7 +370,7 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<left>120</left>
+							<left>20</left>
 							<top>185</top>
 							<width>200</width>
 							<height>20</height>
@@ -380,7 +383,7 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>120</left>
+							<left>20</left>
 							<top>185</top>
 							<width>200</width>
 							<height>20</height>
@@ -557,7 +560,7 @@
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<left>100</left>
+							<left>10</left>
 							<top>170</top>
 							<width>180</width>
 							<height>20</height>
@@ -570,7 +573,7 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<left>100</left>
+							<left>10</left>
 							<top>190</top>
 							<width>180</width>
 							<height>20</height>
@@ -615,7 +618,7 @@
 							<visible>!Control.HasFocus(8002)</visible>
 						</control>
 						<control type="label">
-							<left>100</left>
+							<left>10</left>
 							<top>170</top>
 							<width>180</width>
 							<height>20</height>
@@ -628,7 +631,7 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<left>100</left>
+							<left>10</left>
 							<top>190</top>
 							<width>180</width>
 							<height>20</height>
@@ -641,7 +644,7 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<left>100</left>
+							<left>10</left>
 							<top>190</top>
 							<width>180</width>
 							<height>20</height>
@@ -772,7 +775,7 @@
 					<include>VisibleFadeEffect</include>
 				</control>
 			</control>
-			
+
 		</control>
 	</include>
 </includes>

--- a/addons/skin.confluence.lite/720p/IncludesHomeRecentlyAdded.xml
+++ b/addons/skin.confluence.lite/720p/IncludesHomeRecentlyAdded.xml
@@ -8,15 +8,15 @@
 			<animation effect="fade" time="300" delay="1000">WindowOpen</animation>
 			<animation effect="fade" time="200">WindowClose</animation>
 			<control type="group">
-				<posx>190</posx>
-				<posy>50</posy>
+				<left>190</left>
+				<top>50</top>
 				<visible>Library.HasContent(Movies)</visible>
 				<visible>Container(9000).Hasfocus(10) + !Skin.HasSetting(HomepageHideRecentlyAddedVideo)</visible>
 				<include>VisibleFadeEffect</include>
 				<control type="label">
 					<description>Title label</description>
-					<posx>180</posx>
-					<posy>220</posy>
+					<left>180</left>
+					<top>220</top>
 					<height>20</height>
 					<width>540</width>
 					<label>20386</label>
@@ -31,8 +31,8 @@
 					<animation effect="slide" start="0,0" end="180,0" time="0" condition="StringCompare(Container(8000).NumItems,3)">conditional</animation>
 					<animation effect="slide" start="0,0" end="270,0" time="0" condition="StringCompare(Container(8000).NumItems,2)">conditional</animation>
 					<animation effect="slide" start="0,0" end="360,0" time="0" condition="StringCompare(Container(8000).NumItems,1)">conditional</animation>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>900</width>
 					<height>220</height>
 					<onleft>8000</onleft>
@@ -46,15 +46,15 @@
 					<itemlayout height="220" width="180">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>180</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>160</width>
 							<height>170</height>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
@@ -62,8 +62,8 @@
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<posx>90</posx>
-							<posy>185</posy>
+							<left>90</left>
+							<top>185</top>
 							<width>150</width>
 							<height>20</height>
 							<font>font12</font>
@@ -78,15 +78,15 @@
 					<focusedlayout height="220" width="180">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>180</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>160</width>
 							<height>170</height>
 							<texture background="true">$INFO[ListItem.Icon]</texture>
@@ -95,8 +95,8 @@
 							<visible>Control.HasFocus(8000)</visible>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>160</width>
 							<height>170</height>
 							<texture>$INFO[ListItem.Icon]</texture>
@@ -105,8 +105,8 @@
 							<visible>!Control.HasFocus(8000)</visible>
 						</control>
 						<control type="label">
-							<posx>90</posx>
-							<posy>185</posy>
+							<left>90</left>
+							<top>185</top>
 							<width>150</width>
 							<height>20</height>
 							<font>font12</font>
@@ -118,8 +118,8 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>90</posx>
-							<posy>185</posy>
+							<left>90</left>
+							<top>185</top>
 							<width>150</width>
 							<height>20</height>
 							<font>font12</font>
@@ -216,8 +216,8 @@
 				</control>
 				<control type="button">
 					<description>left Arrow</description>
-					<posx>-40</posx>
-					<posy>90</posy>
+					<left>-40</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-left.png</texturefocus>
@@ -228,8 +228,8 @@
 				</control>
 				<control type="button">
 					<description>right Arrow</description>
-					<posx>910</posx>
-					<posy>90</posy>
+					<left>910</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-right.png</texturefocus>
@@ -240,15 +240,15 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>160</posx>
-				<posy>50</posy>
+				<left>160</left>
+				<top>50</top>
 				<visible>Library.HasContent(TVShows)</visible>
 				<visible>Container(9000).Hasfocus(11) + !Skin.HasSetting(HomepageHideRecentlyAddedVideo)</visible>
 				<include>VisibleFadeEffect</include>
 				<control type="label">
 					<description>Title label</description>
-					<posx>240</posx>
-					<posy>220</posy>
+					<left>240</left>
+					<top>220</top>
 					<height>20</height>
 					<width>480</width>
 					<label>20387</label>
@@ -262,8 +262,8 @@
 					<animation effect="slide" start="0,0" end="120,0" time="0" condition="StringCompare(Container(8001).NumItems,3)">conditional</animation>
 					<animation effect="slide" start="0,0" end="240,0" time="0" condition="StringCompare(Container(8001).NumItems,2)">conditional</animation>
 					<animation effect="slide" start="0,0" end="360,0" time="0" condition="StringCompare(Container(8001).NumItems,1)">conditional</animation>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>960</width>
 					<height>240</height>
 					<onleft>8001</onleft>
@@ -279,15 +279,15 @@
 					<itemlayout height="220" width="240">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>240</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
@@ -296,8 +296,8 @@
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<posx>120</posx>
-							<posy>168</posy>
+							<left>120</left>
+							<top>168</top>
 							<width>200</width>
 							<height>20</height>
 							<font>font10</font>
@@ -309,8 +309,8 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<posx>120</posx>
-							<posy>185</posy>
+							<left>120</left>
+							<top>185</top>
 							<width>200</width>
 							<height>20</height>
 							<font>font12</font>
@@ -325,15 +325,15 @@
 					<focusedlayout height="220" width="240">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>240</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
@@ -343,8 +343,8 @@
 							<visible>Control.HasFocus(8001)</visible>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>220</width>
 							<height>155</height>
 							<aspectratio>scale</aspectratio>
@@ -354,8 +354,8 @@
 							<visible>!Control.HasFocus(8001)</visible>
 						</control>
 						<control type="label">
-							<posx>120</posx>
-							<posy>168</posy>
+							<left>120</left>
+							<top>168</top>
 							<width>200</width>
 							<height>20</height>
 							<font>font10</font>
@@ -367,8 +367,8 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<posx>120</posx>
-							<posy>185</posy>
+							<left>120</left>
+							<top>185</top>
 							<width>200</width>
 							<height>20</height>
 							<font>font12</font>
@@ -380,8 +380,8 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>120</posx>
-							<posy>185</posy>
+							<left>120</left>
+							<top>185</top>
 							<width>200</width>
 							<height>20</height>
 							<font>font12</font>
@@ -478,8 +478,8 @@
 				</control>
 				<control type="button">
 					<description>left Arrow</description>
-					<posx>-40</posx>
-					<posy>90</posy>
+					<left>-40</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-left.png</texturefocus>
@@ -490,8 +490,8 @@
 				</control>
 				<control type="button">
 					<description>right Arrow</description>
-					<posx>970</posx>
-					<posy>90</posy>
+					<left>970</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-right.png</texturefocus>
@@ -503,15 +503,15 @@
 			</control>
 
 			<control type="group">
-				<posx>240</posx>
-				<posy>50</posy>
+				<left>240</left>
+				<top>50</top>
 				<visible>Library.HasContent(Music)</visible>
 				<visible>Container(9000).Hasfocus(3) + !Skin.HasSetting(HomepageHideRecentlyAddedAlbums)</visible>
 				<include>VisibleFadeEffect</include>
 				<control type="label">
 					<description>Title label</description>
-					<posx>160</posx>
-					<posy>220</posy>
+					<left>160</left>
+					<top>220</top>
 					<height>20</height>
 					<width>480</width>
 					<label>359</label>
@@ -525,8 +525,8 @@
 					<animation effect="slide" start="0,0" end="100,0" time="0" condition="StringCompare(Container(8002).NumItems,3)">conditional</animation>
 					<animation effect="slide" start="0,0" end="200,0" time="0" condition="StringCompare(Container(8002).NumItems,2)">conditional</animation>
 					<animation effect="slide" start="0,0" end="300,0" time="0" condition="StringCompare(Container(8002).NumItems,1)">conditional</animation>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>800</width>
 					<height>240</height>
 					<onleft>8002</onleft>
@@ -540,15 +540,15 @@
 					<itemlayout height="220" width="200">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>200</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>180</width>
 							<height>155</height>
 							<aspectratio>keep</aspectratio>
@@ -557,8 +557,8 @@
 							<bordersize>5</bordersize>
 						</control>
 						<control type="label">
-							<posx>100</posx>
-							<posy>170</posy>
+							<left>100</left>
+							<top>170</top>
 							<width>180</width>
 							<height>20</height>
 							<font>font10</font>
@@ -570,8 +570,8 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<posx>100</posx>
-							<posy>190</posy>
+							<left>100</left>
+							<top>190</top>
 							<width>180</width>
 							<height>20</height>
 							<font>font12</font>
@@ -586,15 +586,15 @@
 					<focusedlayout height="220" width="200">
 						<control type="image">
 							<description>background</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>200</width>
 							<height>220</height>
 							<texture border="15">RecentAddedBack.png</texture>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>180</width>
 							<height>155</height>
 							<aspectratio>keep</aspectratio>
@@ -604,8 +604,8 @@
 							<visible>Control.HasFocus(8002)</visible>
 						</control>
 						<control type="image">
-							<posx>10</posx>
-							<posy>10</posy>
+							<left>10</left>
+							<top>10</top>
 							<width>180</width>
 							<height>155</height>
 							<aspectratio>keep</aspectratio>
@@ -615,8 +615,8 @@
 							<visible>!Control.HasFocus(8002)</visible>
 						</control>
 						<control type="label">
-							<posx>100</posx>
-							<posy>170</posy>
+							<left>100</left>
+							<top>170</top>
 							<width>180</width>
 							<height>20</height>
 							<font>font10</font>
@@ -628,8 +628,8 @@
 							<label>$INFO[ListItem.Label2]</label>
 						</control>
 						<control type="label">
-							<posx>100</posx>
-							<posy>190</posy>
+							<left>100</left>
+							<top>190</top>
 							<width>180</width>
 							<height>20</height>
 							<font>font12</font>
@@ -641,8 +641,8 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>100</posx>
-							<posy>190</posy>
+							<left>100</left>
+							<top>190</top>
 							<width>180</width>
 							<height>20</height>
 							<font>font12</font>
@@ -749,8 +749,8 @@
 				</control>
 				<control type="button">
 					<description>left Arrow</description>
-					<posx>-40</posx>
-					<posy>90</posy>
+					<left>-40</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-left.png</texturefocus>
@@ -761,8 +761,8 @@
 				</control>
 				<control type="button">
 					<description>right Arrow</description>
-					<posx>810</posx>
-					<posy>90</posy>
+					<left>810</left>
+					<top>90</top>
 					<width>30</width>
 					<height>40</height>
 					<texturefocus>arrow-big-right.png</texturefocus>

--- a/addons/skin.confluence.lite/720p/LoginScreen.xml
+++ b/addons/skin.confluence.lite/720p/LoginScreen.xml
@@ -3,16 +3,16 @@
 	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">
 			<include>Window_OpenClose_Animation</include>		
 			<control type="image">
-				<posx>0</posx>
-				<posy>100r</posy>
+				<left>0</left>
+				<top>100r</top>
 				<width>1280</width>
 				<height>100</height>
 				<texture>floor.png</texture>
@@ -21,8 +21,8 @@
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>0</posx>
-				<posy>5</posy>
+				<left>0</left>
+				<top>5</top>
 				<width>170</width>
 				<height>100</height>
 				<aspectratio aligny="top" align="left">keep</aspectratio>
@@ -30,22 +30,22 @@
 				<include>Window_OpenClose_Animation</include>
 			</control>
 			<control type="image">
-				<posx>265</posx>
-				<posy>60</posy>
+				<left>265</left>
+				<top>60</top>
 				<width>750</width>
 				<height>600</height>
 				<texture border="10">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>265</posx>
-				<posy>652</posy>
+				<left>265</left>
+				<top>652</top>
 				<width>750</width>
 				<height>64</height>
 				<texture border="10">ContentPanelMirror.png</texture>
 			</control>
 			<control type="label">
-				<posx>295</posx>
-				<posy>100</posy>
+				<left>295</left>
+				<top>100</top>
 				<width>690</width>
 				<height>40</height>
 				<font>font13</font>
@@ -55,8 +55,8 @@
 				<label>$LOCALIZE[31421]</label>
 			</control>
 			<control type="list" id="52">
-				<posx>295</posx>
-				<posy>170</posy>
+				<left>295</left>
+				<top>170</top>
 				<width>690</width>
 				<height>401</height>
 				<onleft>20</onleft>
@@ -68,22 +68,22 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="100" width="690">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>95</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>10</posy>
+						<left>10</left>
+						<top>10</top>
 						<width>80</width>
 						<height>75</height>
 						<texture>$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>110</posx>
-						<posy>10</posy>
+						<left>110</left>
+						<top>10</top>
 						<width>580</width>
 						<height>40</height>
 						<font>font24_title</font>
@@ -94,8 +94,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<width>580</width>
 						<height>25</height>
 						<font>font13</font>
@@ -108,8 +108,8 @@
 				</itemlayout>
 				<focusedlayout height="100" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>95</height>
 						<texture border="5">button-nofocus.png</texture>
@@ -117,8 +117,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>95</height>
 						<texture border="5">button-focus2.png</texture>
@@ -126,15 +126,15 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>10</posy>
+						<left>10</left>
+						<top>10</top>
 						<width>80</width>
 						<height>75</height>
 						<texture>$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>110</posx>
-						<posy>10</posy>
+						<left>110</left>
+						<top>10</top>
 						<width>580</width>
 						<height>40</height>
 						<font>font24_title</font>
@@ -145,8 +145,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<width>580</width>
 						<height>25</height>
 						<font>font13</font>
@@ -160,19 +160,19 @@
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>265</posx>
-				<posy>580</posy>
+				<left>265</left>
+				<top>580</top>
 				<width>220</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
 				<texture>Confluence_Logo.png</texture>
 			</control>
 			<control type="group">
-				<posx>940</posx>
-				<posy>600</posy>
+				<left>940</left>
+				<top>600</top>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>580</width>
 					<height>45</height>
 					<font>font12</font>
@@ -183,8 +183,8 @@
 				</control>
 				<control type="button" id="20">
 					<description>Power push button</description>
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>45</width>
 					<height>45</height>
 					<label>-</label>
@@ -201,16 +201,16 @@
 				</control>
 				<control type="image">
 					<description>Power Icon</description>
-					<posx>15</posx>
-					<posy>5</posy>
+					<left>15</left>
+					<top>5</top>
 					<width>35</width>
 					<height>35</height>
 					<aspectratio>keep</aspectratio>
 					<texture>icon_power.png</texture>
 				</control>
 				<control type="image">
-					<posx>13</posx>
-					<posy>3</posy>
+					<left>13</left>
+					<top>3</top>
 					<width>30</width>
 					<height>29</height>
 					<texture>home-power-focus.gif</texture>
@@ -221,8 +221,8 @@
 		<include>Clock</include>
 		<control type="label">
 			<description>Date label</description>
-			<posx>20r</posx>
-			<posy>35</posy>
+			<left>20r</left>
+			<top>35</top>
 			<width>200</width>
 			<height>15</height>
 			<align>right</align>

--- a/addons/skin.confluence.lite/720p/LoginScreen.xml
+++ b/addons/skin.confluence.lite/720p/LoginScreen.xml
@@ -9,7 +9,7 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">
-			<include>Window_OpenClose_Animation</include>		
+			<include>Window_OpenClose_Animation</include>
 			<control type="image">
 				<left>0</left>
 				<top>100r</top>
@@ -80,6 +80,7 @@
 						<width>80</width>
 						<height>75</height>
 						<texture>$INFO[ListItem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
 						<left>110</left>
@@ -131,6 +132,7 @@
 						<width>80</width>
 						<height>75</height>
 						<texture>$INFO[ListItem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
 						<left>110</left>

--- a/addons/skin.confluence.lite/720p/MusicKaraokeLyrics.xml
+++ b/addons/skin.confluence.lite/720p/MusicKaraokeLyrics.xml
@@ -2,16 +2,16 @@
 	<controls>
 		<control type="karvisualisation" id="1">
 			<description>visualisation</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<visibility>false</visibility>
 		</control>
 		<control type="image" id="2">
 			<description>fullscreen image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<visibility>false</visibility>
@@ -19,19 +19,19 @@
 		<control type="group">
 			<visible>MusicPlayer.Offset(number).Exists + !IntegerGreaterThan(Player.TimeRemaining,20)</visible>
 			<animation effect="slide" start="0,-40" end="0,0" time="100">Visible</animation>
-			<posx>420</posx>
-			<posy>0</posy>
+			<left>420</left>
+			<top>0</top>
 			<control type="image">
-				<posx>0</posx>
-				<posy>-10</posy>
+				<left>0</left>
+				<top>-10</top>
 				<width>470</width>
 				<height>55</height>
 				<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
 			</control>
 			<control type="label" id="402">
 				<description>Next Song Name</description>
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>470</width>
 				<height>25</height>
 				<font>font13_title</font>

--- a/addons/skin.confluence.lite/720p/MusicOSD.xml
+++ b/addons/skin.confluence.lite/720p/MusicOSD.xml
@@ -3,14 +3,14 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="button" id="1000">
 			<description>Close Window button</description>
-			<posx>84r</posx>
-			<posy>0</posy>
+			<left>84r</left>
+			<top>0</top>
 			<width>64</width>
 			<height>32</height>
 			<label>-</label>
@@ -28,8 +28,8 @@
 		</control>
 		<control type="slider" id="87">
 			<description>Seek Slider</description>
-			<posx>430</posx>
-			<posy>72r</posy>
+			<left>430</left>
+			<top>72r</top>
 			<width>720</width>
 			<height>16</height>
 			<onup>702</onup>
@@ -42,13 +42,13 @@
 			<visible>![Window.IsVisible(PluginSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList)]</visible>
 		</control>
 		<control type="group" id="100">
-			<posx>325</posx>
-			<posy>50r</posy>
+			<left>325</left>
+			<top>50r</top>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<visible>![Window.IsVisible(PluginSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList)]</visible>
 			<control type="button" id="600">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>210</label>
@@ -62,8 +62,8 @@
 				<onclick>PlayerControl(Previous)</onclick>
 			</control>
 			<control type="button" id="601">
-				<posx>45</posx>
-				<posy>0</posy>
+				<left>45</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31354</label>
@@ -77,8 +77,8 @@
 				<onclick>PlayerControl(Rewind)</onclick>
 			</control>
 			<control type="togglebutton" id="602">
-				<posx>90</posx>
-				<posy>0</posy>
+				<left>90</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31351</label>
@@ -96,8 +96,8 @@
 				<onclick>PlayerControl(Play)</onclick>
 			</control>
 			<control type="button" id="603">
-				<posx>135</posx>
-				<posy>0</posy>
+				<left>135</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31352</label>
@@ -111,8 +111,8 @@
 				<onclick>PlayerControl(Stop)</onclick>
 			</control>
 			<control type="button" id="604">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31353</label>
@@ -126,8 +126,8 @@
 				<onclick>PlayerControl(Forward)</onclick>
 			</control>
 			<control type="button" id="605">
-				<posx>225</posx>
-				<posy>0</posy>
+				<left>225</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>209</label>
@@ -141,8 +141,8 @@
 				<onclick>PlayerControl(Next)</onclick>
 			</control>
 			<control type="button" id="606">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>$LOCALIZE[486]$INFO[Playlist.Repeat, : ]</label>
@@ -156,8 +156,8 @@
 				<ondown>1000</ondown>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatNF.png</texture>
@@ -165,8 +165,8 @@
 				<visible>!Control.HasFocus(606)</visible>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatFO.png</texture>
@@ -174,8 +174,8 @@
 				<visible>Control.HasFocus(606)</visible>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatOneNF.png</texture>
@@ -183,8 +183,8 @@
 				<visible>!Control.HasFocus(606)</visible>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatOneFO.png</texture>
@@ -192,8 +192,8 @@
 				<visible>Control.HasFocus(606)</visible>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatAllNF.png</texture>
@@ -201,8 +201,8 @@
 				<visible>!Control.HasFocus(606)</visible>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>0</posy>
+				<left>270</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<texture>OSDRepeatAllFO.png</texture>
@@ -210,8 +210,8 @@
 				<visible>Control.HasFocus(606)</visible>
 			</control>
 			<control type="togglebutton" id="607">
-				<posx>315</posx>
-				<posy>0</posy>
+				<left>315</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>$LOCALIZE[590]$INFO[Playlist.Random, : ]</label>
@@ -229,14 +229,14 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>250r</posx>
-			<posy>50r</posy>
+			<left>250r</left>
+			<top>50r</top>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<animation effect="slide" start="0,0" end="-100,0" delay="0" time="0" condition="LastFM.RadioPlaying">conditional</animation>
 			<visible>![Window.IsVisible(PluginSettings) | Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList)]</visible>
 			<control type="togglebutton" id="701">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31128</label>
@@ -257,8 +257,8 @@
 				<usealttexture>IsEmpty(Skin.String(LyricScript_Path))</usealttexture>
 			</control>
 			<control type="button" id="500">
-				<posx>45</posx>
-				<posy>0</posy>
+				<left>45</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>12006</label>
@@ -271,8 +271,8 @@
 				<ondown>1000</ondown>
 			</control>
 			<control type="button" id="702">
-				<posx>90</posx>
-				<posy>0</posy>
+				<left>90</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>$LOCALIZE[250] $LOCALIZE[21417]</label>
@@ -286,8 +286,8 @@
 				<onclick>Addon.Default.OpenSettings(xbmc.player.musicviz)</onclick>
 			</control>
 			<control type="button" id="703">
-				<posx>135</posx>
-				<posy>0</posy>
+				<left>135</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31048</label>
@@ -301,8 +301,8 @@
 				<onclick>ActivateWindow(122)</onclick>
 			</control>
 			<control type="button" id="704">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>264</label>
@@ -318,8 +318,8 @@
 				<animation effect="fade" start="100" end="50" time="100" condition="!Player.CanRecord">Conditional</animation>
 			</control>
 			<control type="button" id="705">
-				<posx>230</posx>
-				<posy>5</posy>
+				<left>230</left>
+				<top>5</top>
 				<width>35</width>
 				<height>35</height>
 				<label>31001</label>
@@ -336,8 +336,8 @@
 				<visible>LastFM.RadioPlaying</visible>
 			</control>
 			<control type="button" id="706">
-				<posx>275</posx>
-				<posy>5</posy>
+				<left>275</left>
+				<top>5</top>
 				<width>35</width>
 				<height>35</height>
 				<label>31002</label>

--- a/addons/skin.confluence.lite/720p/MusicVisualisation.xml
+++ b/addons/skin.confluence.lite/720p/MusicVisualisation.xml
@@ -5,16 +5,16 @@
 		<control type="visualisation" id="2">
 			<!-- FIX ME Music Visualization needs to have an id of 2 in this window to be able to lock or change preset -->
 			<description>visualisation</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 		</control>
 
 		<control type="image">
 			<description>Fanart Image for Artist</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<texture background="true">$INFO[Player.Art(fanart)]</texture>
@@ -28,16 +28,16 @@
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<visible>[Player.ShowInfo | Window.IsActive(MusicOSD)] + ![Window.IsVisible(SelectDialog) | Window.IsVisible(VisualisationPresetList)]</visible>
 			<control type="image">
-				<posx>0</posx>
-				<posy>-150</posy>
+				<left>0</left>
+				<top>-150</top>
 				<width>1280</width>
 				<height>256</height>
 				<texture flipy="true">HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="label">
 				<description>Partymode Header label</description>
-				<posx>30</posx>
-				<posy>5</posy>
+				<left>30</left>
+				<top>5</top>
 				<width>800</width>
 				<height>25</height>
 				<align>left</align>
@@ -50,8 +50,8 @@
 			</control>
 			<control type="label">
 				<description>Normal Header label</description>
-				<posx>30</posx>
-				<posy>5</posy>
+				<left>30</left>
+				<top>5</top>
 				<width>800</width>
 				<height>25</height>
 				<align>left</align>
@@ -64,8 +64,8 @@
 			</control>
 			<control type="label">
 				<description>Clock label</description>
-				<posx>1250</posx>
-				<posy>5</posy>
+				<left>1250</left>
+				<top>5</top>
 				<width>800</width>
 				<height>25</height>
 				<align>right</align>
@@ -77,16 +77,16 @@
 				<animation effect="slide" start="0,0" end="-70,0" time="0" condition="Window.IsVisible(MusicOSD)">conditional</animation>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>230r</posy>
+				<left>0</left>
+				<top>230r</top>
 				<width>1280</width>
 				<height>230</height>
 				<texture>HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="image">
 				<description>cover image</description>
-				<posx>20</posx>
-				<posy>250r</posy>
+				<left>20</left>
+				<top>250r</top>
 				<width>300</width>
 				<height>230</height>
 				<texture fallback="DefaultAlbumCover.png">$INFO[Player.Art(thumb)]</texture>
@@ -95,12 +95,12 @@
 				<bordersize>8</bordersize>
 			</control>
 			<control type="group">
-				<posx>330</posx>
-				<posy>175r</posy>
+				<left>330</left>
+				<top>175r</top>
 				<control type="label" id="1">
 					<description>Heading label</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -112,8 +112,8 @@
 				</control>
 				<control type="label" id="1">
 					<description>Artist label</description>
-					<posx>20</posx>
-					<posy>30</posy>
+					<left>20</left>
+					<top>30</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -123,8 +123,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="grouplist">
-					<posx>20</posx>
-					<posy>60</posy>
+					<left>20</left>
+					<top>60</top>
 					<width>910</width>
 					<height>35</height>
 					<itemgap>5</itemgap>
@@ -152,8 +152,8 @@
 						<height>35</height>
 						<control type="image">
 							<description>rating back</description>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>110</width>
 							<height>35</height>
 							<aspectratio align="left">stretch</aspectratio>
@@ -161,8 +161,8 @@
 						</control>
 						<control type="image">
 							<description>Rating</description>
-							<posx>5</posx>
-							<posy>0</posy>
+							<left>5</left>
+							<top>0</top>
 							<width>100</width>
 							<height>35</height>
 							<aspectratio align="center">keep</aspectratio>
@@ -171,8 +171,8 @@
 					</control>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>120</posy>
+					<left>0</left>
+					<top>120</top>
 					<width>910</width>
 					<height>25</height>
 					<label>$LOCALIZE[209]: $INFO[MusicPlayer.offset(1).Artist,, - ]$INFO[MusicPlayer.offset(1).Title]</label>
@@ -186,11 +186,11 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>330</posx>
-				<posy>85r</posy>
+				<left>330</left>
+				<top>85r</top>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>100</width>
 					<height>40</height>
 					<font>font13</font>
@@ -200,15 +200,15 @@
 				</control>
 				<control type="progress">
 					<description>Progressbar</description>
-					<posx>100</posx>
-					<posy>15</posy>
+					<left>100</left>
+					<top>15</top>
 					<width>720</width>
 					<height>16</height>
 					<info>Player.Progress</info>
 				</control>
 				<control type="label">
-					<posx>920</posx>
-					<posy>0</posy>
+					<left>920</left>
+					<top>0</top>
 					<width>100</width>
 					<height>40</height>
 					<font>font13</font>
@@ -220,14 +220,14 @@
 		</control>
 		<!-- codec & viz infos -->
 		<control type="group" id="0">
-			<posx>0</posx>
-			<posy>50</posy>
+			<left>0</left>
+			<top>50</top>
 			<visible>Player.ShowCodec + ![Window.IsVisible(script-XBMC_Lyrics-main.xml) | Window.IsVisible(VisualisationSettings) | Window.IsVisible(VisualisationPresetList)]</visible>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<control type="image">
 				<description>media info background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>105</height>
 				<colordiffuse>AAFFFFFF</colordiffuse>
@@ -235,8 +235,8 @@
 			</control>
 			<control type="label">
 				<description>row 1 label</description>
-				<posx>50</posx>
-				<posy>10</posy>
+				<left>50</left>
+				<top>10</top>
 				<label>-</label>
 				<align>left</align>
 				<label>$INFO[musicplayer.Codec,$LOCALIZE[21446]: ,]$INFO[musicplayer.Bitrate, · $LOCALIZE[623]: ,kbps]$INFO[musicplayer.bitspersample, · $LOCALIZE[612]: ,bit]$INFO[musicplayer.Samplerate, · $LOCALIZE[613]: ,kHz]$INFO[musicplayer.Channels, · $LOCALIZE[21444]: ]</label>
@@ -244,8 +244,8 @@
 			</control>
 			<control type="label">
 				<description>row 2 label</description>
-				<posx>50</posx>
-				<posy>40</posy>
+				<left>50</left>
+				<top>40</top>
 				<label>-</label>
 				<align>left</align>
 				<label>$INFO[Visualisation.Name,, [I][COLOR=orange]($LOCALIZE[20166])[/COLOR][/I] · ]fps: $INFO[System.FPS]</label>
@@ -254,8 +254,8 @@
 			</control>
 			<control type="label">
 				<description>Unlocked row 2 label</description>
-				<posx>50</posx>
-				<posy>40</posy>
+				<left>50</left>
+				<top>40</top>
 				<label>-</label>
 				<align>left</align>
 				<label>$INFO[Visualisation.Name,, · ]fps: $INFO[System.FPS]</label>
@@ -264,8 +264,8 @@
 			</control>
 			<control type="label">
 				<description>row 3 label</description>
-				<posx>50</posx>
-				<posy>70</posy>
+				<left>50</left>
+				<top>70</top>
 				<label>-</label>
 				<align>left</align>
 				<label>$INFO[Visualisation.Preset,$LOCALIZE[13388]: ]</label>

--- a/addons/skin.confluence.lite/720p/MyGameSaves.xml
+++ b/addons/skin.confluence.lite/720p/MyGameSaves.xml
@@ -17,16 +17,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_addons.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -43,11 +43,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyMusicNav.xml
+++ b/addons/skin.confluence.lite/720p/MyMusicNav.xml
@@ -23,16 +23,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_music.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -49,11 +49,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>60</posy>
+				<left>0</left>
+				<top>60</top>
 				<width>250</width>
 				<height>650</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyMusicPlaylist.xml
+++ b/addons/skin.confluence.lite/720p/MyMusicPlaylist.xml
@@ -18,16 +18,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_music.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -44,11 +44,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence.lite/720p/MyMusicPlaylistEditor.xml
@@ -207,7 +207,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>395</left>
+						<left>35</left>
 						<top>0</top>
 						<width>360</width>
 						<height>30</height>
@@ -242,7 +242,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>395</left>
+						<left>35</left>
 						<top>0</top>
 						<width>360</width>
 						<height>30</height>
@@ -347,7 +347,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>395</left>
+						<left>35</left>
 						<top>0</top>
 						<width>360</width>
 						<height>30</height>
@@ -382,7 +382,7 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<left>395</left>
+						<left>35</left>
 						<top>0</top>
 						<width>360</width>
 						<height>30</height>

--- a/addons/skin.confluence.lite/720p/MyMusicPlaylistEditor.xml
+++ b/addons/skin.confluence.lite/720p/MyMusicPlaylistEditor.xml
@@ -5,18 +5,18 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="group">
-			<posy>10</posy>
+			<top>10</top>
 			<include>Window_OpenClose_Animation</include>
 			<control type="image">
-				<posx>445</posx>
-				<posy>40</posy>
+				<left>445</left>
+				<top>40</top>
 				<width>390</width>
 				<height>640</height>
 				<texture>black-back.png</texture>
 			</control>
 			<control type="label">
-				<posx>475</posx>
-				<posy>45</posy>
+				<left>475</left>
+				<top>45</top>
 				<width>330</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -27,12 +27,12 @@
 				<label>$LOCALIZE[31061]</label>
 			</control>
 			<control type="group" id="9000">
-				<posx>475</posx>
-				<posy>550</posy>
+				<left>475</left>
+				<top>550</top>
 				<control type="button" id="6">
 					<description>Open Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>330</width>
 					<label>31055</label>
 					<align>center</align>
@@ -44,8 +44,8 @@
 				</control>
 				<control type="button" id="7">
 					<description>Save Button</description>
-					<posx>0</posx>
-					<posy>40</posy>
+					<left>0</left>
+					<top>40</top>
 					<width>330</width>
 					<label>31056</label>
 					<align>center</align>
@@ -57,8 +57,8 @@
 				</control>
 				<control type="button" id="8">
 					<description>Clear button</description>
-					<posx>0</posx>
-					<posy>80</posy>
+					<left>0</left>
+					<top>80</top>
 					<width>330</width>
 					<label>31057</label>
 					<align>center</align>
@@ -73,16 +73,16 @@
 				<visible>Control.HasFocus(50)</visible>
 				<include>VisibleFadeEffect</include>
 				<control type="image">
-					<posx>480</posx>
-					<posy>90</posy>
+					<left>480</left>
+					<top>90</top>
 					<width>320</width>
 					<height>200</height>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[Container(50).ListItem.Icon]</texture>
 				</control>
 				<control type="textbox">
-					<posx>480</posx>
-					<posy>300</posy>
+					<left>480</left>
+					<top>300</top>
 					<width>320</width>
 					<height>220</height>
 					<font>font11</font>
@@ -97,16 +97,16 @@
 				<visible>Control.HasFocus(100)</visible>
 				<include>VisibleFadeEffect</include>
 				<control type="image">
-					<posx>465</posx>
-					<posy>90</posy>
+					<left>465</left>
+					<top>90</top>
 					<width>350</width>
 					<height>200</height>
 					<aspectratio>keep</aspectratio>
 					<texture>$INFO[Container(100).ListItem.Icon]</texture>
 				</control>
 				<control type="textbox">
-					<posx>465</posx>
-					<posy>300</posy>
+					<left>465</left>
+					<top>300</top>
 					<width>350</width>
 					<height>220</height>
 					<font>font11</font>
@@ -122,15 +122,15 @@
 			<animation effect="slide" start="-480,0" end="0,0" time="500" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" end="-480,0" start="0,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>480</width>
 				<height>720</height>
 				<texture border="0,0,15,0">MediaBladeSub.png</texture>
 			</control>
 			<control type="label">
-				<posx>30</posx>
-				<posy>40</posy>
+				<left>30</left>
+				<top>40</top>
 				<width>410</width>
 				<height>30</height>
 				<font>font24_title</font>
@@ -141,23 +141,23 @@
 				<label>31058</label>
 			</control>
 			<control type="image">
-				<posx>10</posx>
-				<posy>80</posy>
+				<left>10</left>
+				<top>80</top>
 				<width>460</width>
 				<height>4</height>
 				<texture>separator.png</texture>
 			</control>
 			<control type="image">
-				<posx>10</posx>
-				<posy>50r</posy>
+				<left>10</left>
+				<top>50r</top>
 				<width>460</width>
 				<height>4</height>
 				<texture>separator.png</texture>
 			</control>
 			<control type="label">
 				<description>number of files/pages in left list text label</description>
-				<posx>30</posx>
-				<posy>38r</posy>
+				<left>30</left>
+				<top>38r</top>
 				<width>410</width>
 				<font>font12</font>
 				<align>left</align>
@@ -167,8 +167,8 @@
 				<label>($INFO[Container(50).NumItems]) $LOCALIZE[31025] - $LOCALIZE[31024] ($INFO[Container(50).CurrentPage]/$INFO[Container(50).NumPages])</label>
 			</control>
 			<control type="scrollbar" id="30">
-				<posx>20</posx>
-				<posy>100</posy>
+				<left>20</left>
+				<top>100</top>
 				<width>25</width>
 				<height>540</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -182,8 +182,8 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="list" id="50">
-				<posx>50</posx>
-				<posy>100</posy>
+				<left>50</left>
+				<top>100</top>
 				<width>400</width>
 				<height>540</height>
 				<onleft>30</onleft>
@@ -195,8 +195,8 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="30" width="400">
 					<control type="label">
-						<posx>5</posx>
-						<posy>0</posy>
+						<left>5</left>
+						<top>0</top>
 						<width>380</width>
 						<height>30</height>
 						<font>font12</font>
@@ -207,8 +207,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>395</posx>
-						<posy>0</posy>
+						<left>395</left>
+						<top>0</top>
 						<width>360</width>
 						<height>30</height>
 						<font>font12</font>
@@ -221,8 +221,8 @@
 				</itemlayout>
 				<focusedlayout height="30" width="400">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>400</width>
 						<height>30</height>
 						<texture border="7">MenuItemFO.png</texture>
@@ -230,8 +230,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="label">
-						<posx>5</posx>
-						<posy>0</posy>
+						<left>5</left>
+						<top>0</top>
 						<width>380</width>
 						<height>30</height>
 						<font>font12</font>
@@ -242,8 +242,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>395</posx>
-						<posy>0</posy>
+						<left>395</left>
+						<top>0</top>
 						<width>360</width>
 						<height>30</height>
 						<font>font12</font>
@@ -259,17 +259,17 @@
 		<control type="group">
 			<animation effect="slide" start="480,0" end="0,0" time="500" tween="quadratic" easing="out">WindowOpen</animation>
 			<animation effect="slide" end="480,0" start="0,0" time="500" tween="quadratic" easing="out">WindowClose</animation>
-			<posx>800</posx>
+			<left>800</left>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>480</width>
 				<height>720</height>
 				<texture border="15,0,0,0" flipx="true">MediaBladeSub.png</texture>
 			</control>
 			<control type="label">
-				<posx>440</posx>
-				<posy>40</posy>
+				<left>440</left>
+				<top>40</top>
 				<width>410</width>
 				<height>30</height>
 				<font>font24_title</font>
@@ -280,23 +280,23 @@
 				<label>31059</label>
 			</control>
 			<control type="image">
-				<posx>10</posx>
-				<posy>80</posy>
+				<left>10</left>
+				<top>80</top>
 				<width>460</width>
 				<height>4</height>
 				<texture>separator.png</texture>
 			</control>
 			<control type="image">
-				<posx>10</posx>
-				<posy>50r</posy>
+				<left>10</left>
+				<top>50r</top>
 				<width>460</width>
 				<height>4</height>
 				<texture>separator.png</texture>
 			</control>
 			<control type="label">
 				<description>Page Count Label</description>
-				<posx>440</posx>
-				<posy>38r</posy>
+				<left>440</left>
+				<top>38r</top>
 				<width>300</width>
 				<height>20</height>
 				<font>font12</font>
@@ -307,8 +307,8 @@
 				<label>($INFO[Container(100).NumItems]) $LOCALIZE[31025] - $LOCALIZE[31024] ($INFO[Container(100).CurrentPage]/$INFO[Container(100).NumPages])</label>
 			</control>
 			<control type="scrollbar" id="31">
-				<posx>430</posx>
-				<posy>100</posy>
+				<left>430</left>
+				<top>100</top>
 				<width>25</width>
 				<height>550</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -322,8 +322,8 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="list" id="100">
-				<posx>20</posx>
-				<posy>100</posy>
+				<left>20</left>
+				<top>100</top>
 				<width>400</width>
 				<height>550</height>
 				<onleft>9000</onleft>
@@ -335,8 +335,8 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="30" width="400">
 					<control type="label">
-						<posx>5</posx>
-						<posy>0</posy>
+						<left>5</left>
+						<top>0</top>
 						<width>380</width>
 						<height>30</height>
 						<font>font12</font>
@@ -347,8 +347,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>395</posx>
-						<posy>0</posy>
+						<left>395</left>
+						<top>0</top>
 						<width>360</width>
 						<height>30</height>
 						<font>font12</font>
@@ -361,8 +361,8 @@
 				</itemlayout>
 				<focusedlayout height="30" width="400">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>400</width>
 						<height>30</height>
 						<texture border="7">MenuItemFO.png</texture>
@@ -370,8 +370,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="label">
-						<posx>5</posx>
-						<posy>0</posy>
+						<left>5</left>
+						<top>0</top>
 						<width>380</width>
 						<height>30</height>
 						<font>font12</font>
@@ -382,8 +382,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="label">
-						<posx>395</posx>
-						<posy>0</posy>
+						<left>395</left>
+						<top>0</top>
 						<width>360</width>
 						<height>30</height>
 						<font>font12</font>
@@ -398,16 +398,16 @@
 		</control>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_music.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>

--- a/addons/skin.confluence.lite/720p/MyMusicSongs.xml
+++ b/addons/skin.confluence.lite/720p/MyMusicSongs.xml
@@ -19,16 +19,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_music.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -45,11 +45,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyPics.xml
+++ b/addons/skin.confluence.lite/720p/MyPics.xml
@@ -6,8 +6,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>625</height>
 			<texture background="true">$INFO[ListItem.FilenameAndPath]</texture>
@@ -32,16 +32,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_pictures.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -58,11 +58,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyPrograms.xml
+++ b/addons/skin.confluence.lite/720p/MyPrograms.xml
@@ -19,16 +19,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_addons.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -45,11 +45,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyVideo.xml
+++ b/addons/skin.confluence.lite/720p/MyVideo.xml
@@ -28,16 +28,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_video.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -54,11 +54,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyVideoNav.xml
+++ b/addons/skin.confluence.lite/720p/MyVideoNav.xml
@@ -29,16 +29,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_video.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -55,11 +55,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>60</posy>
+				<left>0</left>
+				<top>60</top>
 				<width>250</width>
 				<height>650</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyVideoPlaylist.xml
+++ b/addons/skin.confluence.lite/720p/MyVideoPlaylist.xml
@@ -17,16 +17,16 @@
 		<include>ScrollOffsetLabel</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_video.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -43,11 +43,11 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>110</posy>
+				<left>0</left>
+				<top>110</top>
 				<width>250</width>
 				<height>600</height>
 				<onleft>9000</onleft>

--- a/addons/skin.confluence.lite/720p/MyWeather.xml
+++ b/addons/skin.confluence.lite/720p/MyWeather.xml
@@ -5,8 +5,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="multiimage">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<imagepath background="true">$INFO[Skin.String(WeatherFanartDir)]$INFO[Window(Weather).Property(Current.FanartCode)]</imagepath>
@@ -19,16 +19,16 @@
 		</control>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_weather.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -40,8 +40,8 @@
 			</control>
 		</control>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -61,18 +61,18 @@
 			</animation>			
 			<include>VisibleFadeEffect</include>
 			<control type="group">
-				<posx>100</posx>
-				<posy>50</posy>
+				<left>100</left>
+				<top>50</top>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>500</width>
 					<height>620</height>
 					<texture border="20">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>20</posx>
-					<posy>10</posy>
+					<left>20</left>
+					<top>10</top>
 					<width>460</width>
 					<height>90</height>
 					<aspectratio>stretch</aspectratio>
@@ -80,8 +80,8 @@
 				</control>
 				<control type="label">
 					<description>header label</description>
-					<posx>20</posx>
-					<posy>18</posy>
+					<left>20</left>
+					<top>18</top>
 					<width>460</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -93,8 +93,8 @@
 				</control>
 				<control type="label">
 					<description>weather location label</description>
-					<posx>20</posx>
-					<posy>60</posy>
+					<left>20</left>
+					<top>60</top>
 					<width>460</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -107,8 +107,8 @@
 				</control>
 				<control type="label">
 					<description>update label</description>
-					<posx>20</posx>
-					<posy>80</posy>
+					<left>20</left>
+					<top>80</top>
 					<width>460</width>
 					<height>35</height>
 					<font>font12</font>
@@ -119,8 +119,8 @@
 				</control>
 				<control type="label">
 					<description>current temp Value</description>
-					<posx>195</posx>
-					<posy>175</posy>
+					<left>195</left>
+					<top>175</top>
 					<width>180</width>
 					<height>40</height>
 					<font>WeatherTemp</font>
@@ -132,8 +132,8 @@
 				</control>
 				<control type="label">
 					<description>current temp Value Units</description>
-					<posx>190</posx>
-					<posy>185</posy>
+					<left>190</left>
+					<top>185</top>
 					<width>100</width>
 					<height>40</height>
 					<font>font16caps</font>
@@ -145,8 +145,8 @@
 				</control>
 				<control type="image">
 					<description>current weather icon</description>
-					<posx>230</posx>
-					<posy>135</posy>
+					<left>230</left>
+					<top>135</top>
 					<width>230</width>
 					<height>180</height>
 					<info>Window.Property(Current.ConditionIcon)</info>
@@ -154,8 +154,8 @@
 				</control>
 				<control type="label">
 					<description>current condition label</description>
-					<posx>20</posx>
-					<posy>320</posy>
+					<left>20</left>
+					<top>320</top>
 					<width>460</width>
 					<height>30</height>
 					<info>Window.Property(Current.Condition)</info>
@@ -167,16 +167,16 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="image">
-					<posx>20</posx>
-					<posy>390</posy>
+					<left>20</left>
+					<top>390</top>
 					<width>460</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="label">
 					<description>current feels like label</description>
-					<posx>170</posx>
-					<posy>400</posy>
+					<left>170</left>
+					<top>400</top>
 					<width>170</width>
 					<height>35</height>
 					<font>font13</font>
@@ -188,8 +188,8 @@
 				</control>
 				<control type="label">
 					<description>current dew label</description>
-					<posx>170</posx>
-					<posy>430</posy>
+					<left>170</left>
+					<top>430</top>
 					<width>170</width>
 					<height>35</height>
 					<font>font13</font>
@@ -201,8 +201,8 @@
 				</control>
 				<control type="label">
 					<description>current humidity label</description>
-					<posx>170</posx>
-					<posy>460</posy>
+					<left>170</left>
+					<top>460</top>
 					<width>170</width>
 					<height>35</height>
 					<font>font13</font>
@@ -214,8 +214,8 @@
 				</control>
 				<control type="label">
 					<description>current UV Index label</description>
-					<posx>170</posx>
-					<posy>490</posy>
+					<left>170</left>
+					<top>490</top>
 					<width>170</width>
 					<height>35</height>
 					<font>font13</font>
@@ -227,8 +227,8 @@
 				</control>
 				<control type="label">
 					<description>current Wind label</description>
-					<posx>170</posx>
-					<posy>520</posy>
+					<left>170</left>
+					<top>520</top>
 					<width>170</width>
 					<height>35</height>
 					<font>font13</font>
@@ -240,8 +240,8 @@
 				</control>
 				<control type="label">
 					<description>current feels like Value</description>
-					<posx>185</posx>
-					<posy>400</posy>
+					<left>185</left>
+					<top>400</top>
 					<width>300</width>
 					<height>35</height>
 					<font>font13</font>
@@ -253,8 +253,8 @@
 				</control>
 				<control type="label">
 					<description>current dew Value</description>
-					<posx>185</posx>
-					<posy>430</posy>
+					<left>185</left>
+					<top>430</top>
 					<width>300</width>
 					<height>35</height>
 					<font>font13</font>
@@ -266,8 +266,8 @@
 				</control>
 				<control type="label">
 					<description>current humidity Value</description>
-					<posx>185</posx>
-					<posy>460</posy>
+					<left>185</left>
+					<top>460</top>
 					<width>300</width>
 					<height>35</height>
 					<font>font13</font>
@@ -279,8 +279,8 @@
 				</control>
 				<control type="label">
 					<description>current UV Index Value</description>
-					<posx>185</posx>
-					<posy>490</posy>
+					<left>185</left>
+					<top>490</top>
 					<width>300</width>
 					<height>35</height>
 					<font>font13</font>
@@ -292,8 +292,8 @@
 				</control>
 				<control type="label">
 					<description>current Wind Value</description>
-					<posx>185</posx>
-					<posy>520</posy>
+					<left>185</left>
+					<top>520</top>
 					<width>300</width>
 					<height>35</height>
 					<font>font13</font>
@@ -305,18 +305,18 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>680</posx>
-				<posy>50</posy>
+				<left>680</left>
+				<top>50</top>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>500</width>
 					<height>620</height>
 					<texture border="20">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>20</posx>
-					<posy>10</posy>
+					<left>20</left>
+					<top>10</top>
 					<width>460</width>
 					<height>90</height>
 					<aspectratio>stretch</aspectratio>
@@ -324,8 +324,8 @@
 				</control>
 				<control type="label">
 					<description>header label</description>
-					<posx>20</posx>
-					<posy>18</posy>
+					<left>20</left>
+					<top>18</top>
 					<width>460</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -337,12 +337,12 @@
 				</control>
 				<control type="group">
 					<description>day 0</description>
-					<posx>20</posx>
-					<posy>60</posy>
+					<left>20</left>
+					<top>60</top>
 					<control type="label">
 						<description>Day label</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>460</width>
 						<height>35</height>
 						<font>font13_title</font>
@@ -354,8 +354,8 @@
 					</control>
 					<control type="image">
 						<description>day icon</description>
-						<posx>370</posx>
-						<posy>40</posy>
+						<left>370</left>
+						<top>40</top>
 						<height>80</height>
 						<width>80</width>
 						<info>Window.Property(Day0.OutlookIcon)</info>
@@ -363,8 +363,8 @@
 					</control>
 					<control type="label">
 						<description>high label</description>
-						<posx>40</posx>
-						<posy>50</posy>
+						<left>40</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -376,8 +376,8 @@
 					</control>
 					<control type="label">
 						<description>high value</description>
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day0.HighTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -389,8 +389,8 @@
 					</control>
 					<control type="label">
 						<description>low label</description>
-						<posx>220</posx>
-						<posy>50</posy>
+						<left>220</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -402,8 +402,8 @@
 					</control>
 					<control type="label">
 						<description>low value</description>
-						<posx>290</posx>
-						<posy>50</posy>
+						<left>290</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day0.LowTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -415,8 +415,8 @@
 					</control>
 					<control type="label">
 						<description>conditions label</description>
-						<posx>40</posx>
-						<posy>80</posy>
+						<left>40</left>
+						<top>80</top>
 						<width>320</width>
 						<height>20</height>
 						<info>Window.Property(Day0.Outlook)</info>
@@ -427,8 +427,8 @@
 						<shadowcolor>black</shadowcolor>
 					</control>
 					<control type="image">
-						<posx>20</posx>
-						<posy>120</posy>
+						<left>20</left>
+						<top>120</top>
 						<width>460</width>
 						<height>4</height>
 						<texture>separator.png</texture>
@@ -436,12 +436,12 @@
 				</control>
 				<control type="group">
 					<description>day 1</description>
-					<posx>20</posx>
-					<posy>190</posy>
+					<left>20</left>
+					<top>190</top>
 					<control type="label">
 						<description>Day label</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>460</width>
 						<height>35</height>
 						<font>font13_title</font>
@@ -453,8 +453,8 @@
 					</control>
 					<control type="image">
 						<description>day icon</description>
-						<posx>370</posx>
-						<posy>40</posy>
+						<left>370</left>
+						<top>40</top>
 						<height>80</height>
 						<width>80</width>
 						<info>Window.Property(Day1.OutlookIcon)</info>
@@ -462,8 +462,8 @@
 					</control>
 					<control type="label">
 						<description>high label</description>
-						<posx>40</posx>
-						<posy>50</posy>
+						<left>40</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -475,8 +475,8 @@
 					</control>
 					<control type="label">
 						<description>high value</description>
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day1.HighTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -488,8 +488,8 @@
 					</control>
 					<control type="label">
 						<description>low label</description>
-						<posx>220</posx>
-						<posy>50</posy>
+						<left>220</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -501,8 +501,8 @@
 					</control>
 					<control type="label">
 						<description>low value</description>
-						<posx>290</posx>
-						<posy>50</posy>
+						<left>290</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day1.LowTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -514,8 +514,8 @@
 					</control>
 					<control type="label">
 						<description>conditions label</description>
-						<posx>40</posx>
-						<posy>80</posy>
+						<left>40</left>
+						<top>80</top>
 						<width>320</width>
 						<height>20</height>
 						<info>Window.Property(Day1.Outlook)</info>
@@ -526,8 +526,8 @@
 						<shadowcolor>black</shadowcolor>
 					</control>
 					<control type="image">
-						<posx>20</posx>
-						<posy>120</posy>
+						<left>20</left>
+						<top>120</top>
 						<width>460</width>
 						<height>4</height>
 						<texture>separator.png</texture>
@@ -535,12 +535,12 @@
 				</control>
 				<control type="group">
 					<description>day 2</description>
-					<posx>20</posx>
-					<posy>320</posy>
+					<left>20</left>
+					<top>320</top>
 					<control type="label">
 						<description>Day label</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>460</width>
 						<height>35</height>
 						<font>font13_title</font>
@@ -552,8 +552,8 @@
 					</control>
 					<control type="image">
 						<description>day icon</description>
-						<posx>370</posx>
-						<posy>40</posy>
+						<left>370</left>
+						<top>40</top>
 						<height>80</height>
 						<width>80</width>
 						<info>Window.Property(Day2.OutlookIcon)</info>
@@ -561,8 +561,8 @@
 					</control>
 					<control type="label">
 						<description>high label</description>
-						<posx>40</posx>
-						<posy>50</posy>
+						<left>40</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -574,8 +574,8 @@
 					</control>
 					<control type="label">
 						<description>high value</description>
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day2.HighTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -587,8 +587,8 @@
 					</control>
 					<control type="label">
 						<description>low label</description>
-						<posx>220</posx>
-						<posy>50</posy>
+						<left>220</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -600,8 +600,8 @@
 					</control>
 					<control type="label">
 						<description>low value</description>
-						<posx>290</posx>
-						<posy>50</posy>
+						<left>290</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day2.LowTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -613,8 +613,8 @@
 					</control>
 					<control type="label">
 						<description>conditions label</description>
-						<posx>40</posx>
-						<posy>80</posy>
+						<left>40</left>
+						<top>80</top>
 						<width>320</width>
 						<height>20</height>
 						<info>Window.Property(Day2.Outlook)</info>
@@ -625,8 +625,8 @@
 						<textcolor>white</textcolor>
 					</control>
 					<control type="image">
-						<posx>20</posx>
-						<posy>120</posy>
+						<left>20</left>
+						<top>120</top>
 						<width>460</width>
 						<height>4</height>
 						<texture>separator.png</texture>
@@ -634,12 +634,12 @@
 				</control>
 				<control type="group">
 					<description>day 3</description>
-					<posx>20</posx>
-					<posy>450</posy>
+					<left>20</left>
+					<top>450</top>
 					<control type="label">
 						<description>Day label</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>460</width>
 						<height>35</height>
 						<font>font13_title</font>
@@ -651,8 +651,8 @@
 					</control>
 					<control type="image">
 						<description>day icon</description>
-						<posx>370</posx>
-						<posy>40</posy>
+						<left>370</left>
+						<top>40</top>
 						<height>80</height>
 						<width>80</width>
 						<info>Window.Property(Day3.OutlookIcon)</info>
@@ -660,8 +660,8 @@
 					</control>
 					<control type="label">
 						<description>high label</description>
-						<posx>40</posx>
-						<posy>50</posy>
+						<left>40</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -673,8 +673,8 @@
 					</control>
 					<control type="label">
 						<description>high value</description>
-						<posx>110</posx>
-						<posy>50</posy>
+						<left>110</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day3.HighTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -686,8 +686,8 @@
 					</control>
 					<control type="label">
 						<description>low label</description>
-						<posx>220</posx>
-						<posy>50</posy>
+						<left>220</left>
+						<top>50</top>
 						<height>20</height>
 						<font>font13</font>
 						<align>left</align>
@@ -699,8 +699,8 @@
 					</control>
 					<control type="label">
 						<description>low value</description>
-						<posx>290</posx>
-						<posy>50</posy>
+						<left>290</left>
+						<top>50</top>
 						<height>20</height>
 						<label>$INFO[Window.Property(Day3.LowTemp)]$INFO[System.TemperatureUnits]</label>
 						<font>font13_title</font>
@@ -712,8 +712,8 @@
 					</control>
 					<control type="label">
 						<description>conditions label</description>
-						<posx>40</posx>
-						<posy>80</posy>
+						<left>40</left>
+						<top>80</top>
 						<width>320</width>
 						<height>20</height>
 						<info>Window.Property(Day3.Outlook)</info>
@@ -729,11 +729,11 @@
 		
 		<include>CommonNowPlaying</include>
 		<control type="group">
-			<posx>-250</posx>
+			<left>-250</left>
 			<include>SideBladeLeft</include>
 			<control type="grouplist" id="9000">
-				<posx>0</posx>
-				<posy>60</posy>
+				<left>0</left>
+				<top>60</top>
 				<width>250</width>
 				<height>650</height>
 				<onleft>9000</onleft>
@@ -756,8 +756,8 @@
 					<height>40</height>
 					<control type="spincontrolex" id="3">
 						<description>change location button</description>
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<font>-</font>
 						<include>ButtonCommonValues</include>
 						<onleft>50</onleft>
@@ -767,8 +767,8 @@
 						<onback>50</onback>
 					</control>
 					<control type="label" id="301">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>200</width>
 						<height>40</height>
 						<font>font13</font>

--- a/addons/skin.confluence.lite/720p/PlayerControls.xml
+++ b/addons/skin.confluence.lite/720p/PlayerControls.xml
@@ -4,23 +4,23 @@
 	<visible>Player.HasMedia + Window.IsActive(PlayerControls) + !Window.IsActive(FullscreenVideo) + !Window.IsActive(Visualisation)</visible>
 	<coordinates>
 		<system>1</system>
-		<posx>390</posx>
-		<posy>250</posy>
+		<left>390</left>
+		<top>250</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>5</posx>
-			<posy>156</posy>
+			<left>5</left>
+			<top>156</top>
 			<width>483</width>
 			<height>53</height>
 			<texture flipy="true" border="20,20,20,2">InfoMessagePanel.png</texture>
 		</control>
 		<control type="group" id="100">
-			<posx>25</posx>
-			<posy>162</posy>
+			<left>25</left>
+			<top>162</top>
 			<control type="button" id="600">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -33,8 +33,8 @@
 				<onclick>XBMC.PlayerControl(Previous)</onclick>
 			</control>
 			<control type="button" id="601">
-				<posx>40</posx>
-				<posy>0</posy>
+				<left>40</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -47,8 +47,8 @@
 				<onclick>XBMC.PlayerControl(Rewind)</onclick>
 			</control>
 			<control type="togglebutton" id="603">
-				<posx>80</posx>
-				<posy>0</posy>
+				<left>80</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -64,8 +64,8 @@
 				<onclick>XBMC.PlayerControl(Play)</onclick>
 			</control>
 			<control type="button" id="602">
-				<posx>120</posx>
-				<posy>0</posy>
+				<left>120</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -79,8 +79,8 @@
 				<onclick>XBMC.PlayerControl(Stop)</onclick>
 			</control>
 			<control type="button" id="604">
-				<posx>160</posx>
-				<posy>0</posy>
+				<left>160</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -93,8 +93,8 @@
 				<onclick>XBMC.PlayerControl(Forward)</onclick>
 			</control>
 			<control type="button" id="605">
-				<posx>200</posx>
-				<posy>0</posy>
+				<left>200</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -107,8 +107,8 @@
 				<onclick>XBMC.PlayerControl(Next)</onclick>
 			</control>
 			<control type="button" id="606">
-				<posx>240</posx>
-				<posy>0</posy>
+				<left>240</left>
+				<top>0</top>
 				<width>40</width>
 				<height>40</height>
 				<label>-</label>
@@ -125,8 +125,8 @@
 			<control type="group">
 				<animation effect="slide" start="0,0" end="40,0" time="0" condition="!Player.HasAudio">Conditional</animation>
 				<control type="button" id="607">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<label>-</label>
@@ -139,8 +139,8 @@
 					<ondown>100</ondown>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatNF.png</texture>
@@ -148,8 +148,8 @@
 					<visible>!Control.HasFocus(607)</visible>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatFO.png</texture>
@@ -157,8 +157,8 @@
 					<visible>Control.HasFocus(607)</visible>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatOneNF.png</texture>
@@ -166,8 +166,8 @@
 					<visible>!Control.HasFocus(607)</visible>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatOneFO.png</texture>
@@ -175,8 +175,8 @@
 					<visible>Control.HasFocus(607)</visible>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatAllNF.png</texture>
@@ -184,8 +184,8 @@
 					<visible>!Control.HasFocus(607)</visible>
 				</control>
 				<control type="image">
-					<posx>325</posx>
-					<posy>0</posy>
+					<left>325</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<texture>OSDRepeatAllFO.png</texture>
@@ -193,8 +193,8 @@
 					<visible>Control.HasFocus(607)</visible>
 				</control>
 				<control type="togglebutton" id="608">
-					<posx>365</posx>
-					<posy>0</posy>
+					<left>365</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<label>-</label>
@@ -210,8 +210,8 @@
 					<ondown>100</ondown>
 				</control>
 				<control type="togglebutton" id="609">
-					<posx>405</posx>
-					<posy>0</posy>
+					<left>405</left>
+					<top>0</top>
 					<width>40</width>
 					<height>40</height>
 					<label>31128</label>
@@ -237,8 +237,8 @@
 		<!-- Music Info -->
 		<control type="image">
 			<description>gradient</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>500</width>
 			<height>165</height>
 			<colordiffuse>CCFFFFFF</colordiffuse>

--- a/addons/skin.confluence.lite/720p/Pointer.xml
+++ b/addons/skin.confluence.lite/720p/Pointer.xml
@@ -2,38 +2,38 @@
 	<defaultcontrol>-</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="image" id="1">
 			<description>Pointer Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>32</width>
 			<height>32</height>
 			<texture>pointer-nofocus.png</texture>
 		</control>
 		<control type="image" id="2">
 			<description>Pointer Focus Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>32</width>
 			<height>32</height>
 			<texture>pointer-focus.png</texture>
 		</control>
 		<control type="image" id="3">
 			<description>Pointer Drag Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>32</width>
 			<height>32</height>
 			<texture>pointer-focus-drag.png</texture>
 		</control>
 		<control type="image" id="4">
 			<description>Pointer Click Image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>32</width>
 			<height>32</height>
 			<texture>pointer-focus-click.png</texture>

--- a/addons/skin.confluence.lite/720p/Settings.xml
+++ b/addons/skin.confluence.lite/720p/Settings.xml
@@ -5,8 +5,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -14,8 +14,8 @@
 			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<posx>90</posx>
-			<posy>30</posy>
+			<left>90</left>
+			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -25,31 +25,31 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>1090</width>
 				<height>630</height>
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>625</posy>
+				<left>5</left>
+				<top>625</top>
 				<width>1090</width>
 				<height>64</height>
 				<texture border="15">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>30</posx>
-				<posy>15</posy>
+				<left>30</left>
+				<top>15</top>
 				<width>220</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
 				<texture>Confluence_Logo.png</texture>
 			</control>
 			<control type="list" id="9000">
-				<posx>10</posx>
-				<posy>82</posy>
+				<left>10</left>
+				<top>82</top>
 				<width>260</width>
 				<height>541</height>
 				<onleft>9000</onleft>
@@ -60,15 +60,15 @@
 				<scrolltime>300</scrolltime>
 				<itemlayout height="54" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>55</height>
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>240</width>
 						<height>55</height>
 						<font>font24_title</font>
@@ -80,15 +80,15 @@
 				</itemlayout>
 				<focusedlayout height="54" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>55</height>
 						<texture border="5">MenuItemFO.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>240</width>
 						<height>55</height>
 						<font>font24_title</font>
@@ -150,23 +150,23 @@
 				</content>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>804</width>
 				<height>50</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>804</width>
 				<height>54</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>300</posx>
-				<posy>20</posy>
+				<left>300</left>
+				<top>20</top>
 				<width>740</width>
 				<height>30</height>
 				<font>font16</font>
@@ -177,15 +177,15 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="image">
-				<posx>270</posx>
-				<posy>60</posy>
+				<left>270</left>
+				<top>60</top>
 				<width>800</width>
 				<height>450</height>
 				<texture border="5">button-nofocus.png</texture>
 			</control>
 			<control type="image">
-				<posx>272</posx>
-				<posy>62</posy>
+				<left>272</left>
+				<top>62</top>
 				<width>796</width>
 				<height>446</height>
 				<aspectratio>stretch</aspectratio>
@@ -193,8 +193,8 @@
 				<texture background="true">special://skin/backgrounds/settings.jpg</texture>
 			</control>
 			<control type="image">
-				<posx>272</posx>
-				<posy>62</posy>
+				<left>272</left>
+				<top>62</top>
 				<width>600</width>
 				<height>340</height>
 				<aspectratio>stretch</aspectratio>
@@ -202,16 +202,16 @@
 				<colordiffuse>AAFFFFFF</colordiffuse>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>510</posy>
+				<left>268</left>
+				<top>510</top>
 				<width>804</width>
 				<height>118</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="textbox">
 				<description>Appearance Description</description>
-				<posx>300</posx>
-				<posy>520</posy>
+				<left>300</left>
+				<top>520</top>
 				<width>740</width>
 				<height>100</height>
 				<font>font12</font>
@@ -225,16 +225,16 @@
 		<include>BehindDialogFadeOut</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>

--- a/addons/skin.confluence.lite/720p/SettingsCategory.xml
+++ b/addons/skin.confluence.lite/720p/SettingsCategory.xml
@@ -222,8 +222,8 @@
 		</control>
     <control type="sliderex" id="13">
 			<description>Default Slider</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<height>40</height>
 			<font>font13</font>
 			<textcolor>grey2</textcolor>

--- a/addons/skin.confluence.lite/720p/SettingsProfile.xml
+++ b/addons/skin.confluence.lite/720p/SettingsProfile.xml
@@ -67,9 +67,9 @@
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>0</top>
-						<width>380</width>
+						<width>240</width>
 						<height>55</height>
 						<font>font24_title</font>
 						<textcolor>grey3</textcolor>
@@ -88,9 +88,9 @@
 						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>0</top>
-						<width>380</width>
+						<width>240</width>
 						<height>55</height>
 						<font>font24_title</font>
 						<textcolor>white</textcolor>
@@ -301,9 +301,10 @@
 							<bordertexture border="5">button-nofocus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<texture fallback="DefaultUser.png">$INFO[Listitem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
-							<left>94</left>
+							<left>6</left>
 							<top>145</top>
 							<width>178</width>
 							<height>25</height>
@@ -324,9 +325,10 @@
 							<bordertexture border="5">folder-focus.png</bordertexture>
 							<bordersize>5</bordersize>
 							<texture fallback="DefaultUser.png">$INFO[Listitem.Icon]</texture>
+							<aspectratio>keep</aspectratio>
 						</control>
 						<control type="label">
-							<left>94</left>
+							<left>6</left>
 							<top>145</top>
 							<width>178</width>
 							<height>25</height>

--- a/addons/skin.confluence.lite/720p/SettingsProfile.xml
+++ b/addons/skin.confluence.lite/720p/SettingsProfile.xml
@@ -5,8 +5,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -14,8 +14,8 @@
 			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<posx>90</posx>
-			<posy>30</posy>
+			<left>90</left>
+			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300"/>
 				<effect type="fade" start="0" end="100" time="300"/>
@@ -25,31 +25,31 @@
 				<effect type="fade" start="100" end="0" time="300"/>
 			</animation>
 			<control type="image">
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>1090</width>
 				<height>630</height>
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>625</posy>
+				<left>5</left>
+				<top>625</top>
 				<width>1090</width>
 				<height>64</height>
 				<texture border="15">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>30</posx>
-				<posy>15</posy>
+				<left>30</left>
+				<top>15</top>
 				<width>220</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
 				<texture>Confluence_Logo.png</texture>
 			</control>
 			<control type="list" id="9000">
-				<posx>10</posx>
-				<posy>82</posy>
+				<left>10</left>
+				<top>82</top>
 				<width>260</width>
 				<height>541</height>
 				<onleft>9010</onleft>
@@ -60,15 +60,15 @@
 				<scrolltime>300</scrolltime>
 				<itemlayout height="54" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>55</height>
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>0</posy>
+						<left>250</left>
+						<top>0</top>
 						<width>380</width>
 						<height>55</height>
 						<font>font24_title</font>
@@ -80,16 +80,16 @@
 				</itemlayout>
 				<focusedlayout height="54" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>55</height>
 						<texture border="5">MenuItemFO.png</texture>
 						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>0</posy>
+						<left>250</left>
+						<top>0</top>
 						<width>380</width>
 						<height>55</height>
 						<font>font24_title</font>
@@ -114,11 +114,11 @@
 			</control>
 			<control type="group">
 				<visible>Container(9000).Hasfocus(2)</visible>
-				<posx>20</posx>
-				<posy>260</posy>
+				<left>20</left>
+				<top>260</top>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>240</width>
 					<height>200</height>
 					<aspectratio>keep</aspectratio>
@@ -127,8 +127,8 @@
 					<texture fallback="DefaultUser.png">$INFO[Container(2).Listitem.Icon]</texture>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>210</posy>
+					<left>0</left>
+					<top>210</top>
 					<width>240</width>
 					<height>20</height>
 					<font>font12_title</font>
@@ -138,8 +138,8 @@
 					<label>$LOCALIZE[31319]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>235</posy>
+					<left>0</left>
+					<top>235</top>
 					<width>240</width>
 					<height>20</height>
 					<font>font13</font>
@@ -149,8 +149,8 @@
 					<label>$INFO[Container(2).ListItem.Label]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>265</posy>
+					<left>0</left>
+					<top>265</top>
 					<width>240</width>
 					<height>30</height>
 					<font>font12_title</font>
@@ -160,8 +160,8 @@
 					<label>$LOCALIZE[31320]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>290</posy>
+					<left>0</left>
+					<top>290</top>
 					<width>240</width>
 					<height>30</height>
 					<font>font13</font>
@@ -172,15 +172,15 @@
 				</control>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>790</width>
 				<height>618</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>804</width>
 				<height>70</height>
 				<aspectratio>stretch</aspectratio>
@@ -188,8 +188,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>300</posx>
-				<posy>20</posy>
+				<left>300</left>
+				<top>20</top>
 				<width>740</width>
 				<height>30</height>
 				<font>font16</font>
@@ -202,8 +202,8 @@
 			<control type="group" id="9010">
 				<control type="grouplist" id="9001">
 					<visible>Container(9000).Hasfocus(1)</visible>
-					<posx>290</posx>
-					<posy>60</posy>
+					<left>290</left>
+					<top>60</top>
 					<width>750</width>
 					<height>440</height>
 					<itemgap>-1</itemgap>
@@ -239,14 +239,14 @@
 				</control>
 				<control type="group">
 					<visible>Container(9000).Hasfocus(1)</visible>
-					<posx>290</posx>
-					<posy>500</posy>
+					<left>290</left>
+					<top>500</top>
 					<width>750</width>
 					<height>40</height>
 					<control type="image">
 						<description>separator image</description>
-						<posx>0</posx>
-						<posy>25</posy>
+						<left>0</left>
+						<top>25</top>
 						<width>750</width>
 						<height>2</height>
 						<texture>separator2.png</texture>
@@ -254,8 +254,8 @@
 					</control>
 					<control type="textbox">
 						<description>description area</description>
-						<posx>7</posx>
-						<posy>30</posy>
+						<left>7</left>
+						<top>30</top>
 						<width>736</width>
 						<height>85</height>
 						<font>font12</font>
@@ -267,8 +267,8 @@
 					</control>
 					<control type="textbox">
 						<description>description area</description>
-						<posx>7</posx>
-						<posy>30</posy>
+						<left>7</left>
+						<top>30</top>
 						<width>736</width>
 						<height>85</height>
 						<font>font12</font>
@@ -281,8 +281,8 @@
 				</control>
 				<control type="panel" id="2">
 					<visible>Container(9000).Hasfocus(2)</visible>
-					<posx>290</posx>
-					<posy>72</posy>
+					<left>290</left>
+					<top>72</top>
 					<width>760</width>
 					<height>540</height>
 					<onleft>9000</onleft>
@@ -294,8 +294,8 @@
 					<scrolltime>200</scrolltime>
 					<itemlayout height="180" width="190">
 						<control type="image">
-							<posx>1</posx>
-							<posy>0</posy>
+							<left>1</left>
+							<top>0</top>
 							<width>188</width>
 							<height>145</height>
 							<bordertexture border="5">button-nofocus.png</bordertexture>
@@ -303,8 +303,8 @@
 							<texture fallback="DefaultUser.png">$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>94</posx>
-							<posy>145</posy>
+							<left>94</left>
+							<top>145</top>
 							<width>178</width>
 							<height>25</height>
 							<font>font11</font>
@@ -317,8 +317,8 @@
 					</itemlayout>
 					<focusedlayout height="180" width="190">
 						<control type="image">
-							<posx>1</posx>
-							<posy>0</posy>
+							<left>1</left>
+							<top>0</top>
 							<width>188</width>
 							<height>145</height>
 							<bordertexture border="5">folder-focus.png</bordertexture>
@@ -326,8 +326,8 @@
 							<texture fallback="DefaultUser.png">$INFO[Listitem.Icon]</texture>
 						</control>
 						<control type="label">
-							<posx>94</posx>
-							<posy>145</posy>
+							<left>94</left>
+							<top>145</top>
 							<width>178</width>
 							<height>25</height>
 							<font>font11</font>
@@ -340,8 +340,8 @@
 					</focusedlayout>
 				</control>
 				<control type="scrollbar" id="60">
-					<posx>1060</posx>
-					<posy>60</posy>
+					<left>1060</left>
+					<top>60</top>
 					<width>25</width>
 					<height>530</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -360,16 +360,16 @@
 		<include>BehindDialogFadeOut</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>

--- a/addons/skin.confluence.lite/720p/SettingsScreenCalibration.xml
+++ b/addons/skin.confluence.lite/720p/SettingsScreenCalibration.xml
@@ -3,8 +3,8 @@
 	<controls>
 		<control type="videowindow" id="20">
 			<description>videowindow</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<visible>Player.HasVideo</visible>
@@ -15,8 +15,8 @@
 		</control>
 		<control type="image">
 			<description>Overlay</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
@@ -24,8 +24,8 @@
 		</control>
 		<control type="mover" id="8">
 			<description>top left mover</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>128</width>
 			<height>128</height>
 			<texturefocus>CalibrateTopLeft.png</texturefocus>
@@ -33,8 +33,8 @@
 		</control>
 		<control type="mover" id="9">
 			<description>right bottom mover</description>
-			<posx>700</posx>
-			<posy>500</posy>
+			<left>700</left>
+			<top>500</top>
 			<width>128</width>
 			<height>128</height>
 			<texturefocus>CalibrateBottomRight.png</texturefocus>
@@ -42,8 +42,8 @@
 		</control>
 		<control type="mover" id="10">
 			<description>subtitle position mover</description>
-			<posx>200</posx>
-			<posy>500</posy>
+			<left>200</left>
+			<top>500</top>
 			<width>512</width>
 			<height>128</height>
 			<texturefocus>CalibrateSubtitles.png</texturefocus>
@@ -51,20 +51,20 @@
 		</control>
 		<control type="resize" id="11">
 			<description>pixel aspect ratio box</description>
-			<posx>0</posx>
-			<posy>232</posy>
+			<left>0</left>
+			<top>232</top>
 			<width>256</width>
 			<height>256</height>
 			<texturefocus>CalibratePixelRatio.png</texturefocus>
 			<texturenofocus>-</texturenofocus>
 		</control>
 		<control type="group">
-			<posx>20</posx>
-			<posy>80</posy>
+			<left>20</left>
+			<top>80</top>
 			<control type="label" id="2">
 				<description>coordinates label</description>
-				<posx>0</posx>
-				<posy>10</posy>
+				<left>0</left>
+				<top>10</top>
 				<width>1240</width>
 				<label>-</label>
 				<align>center</align>
@@ -72,8 +72,8 @@
 			</control>
 			<control type="label" id="3">
 				<description>help information</description>
-				<posx>0</posx>
-				<posy>40</posy>
+				<left>0</left>
+				<top>40</top>
 				<width>1240</width>
 				<label>-</label>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/SettingsSystemInfo.xml
+++ b/addons/skin.confluence.lite/720p/SettingsSystemInfo.xml
@@ -4,8 +4,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -13,8 +13,8 @@
 			<animation effect="slide" start="0,0" end="0,10" time="200" condition="Window.Next(Home)">WindowClose</animation>
 		</control>
 		<control type="group">
-			<posx>90</posx>
-			<posy>30</posy>
+			<left>90</left>
+			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -24,31 +24,31 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>1090</width>
 				<height>630</height>
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>625</posy>
+				<left>5</left>
+				<top>625</top>
 				<width>1090</width>
 				<height>64</height>
 				<texture border="15">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>30</posx>
-				<posy>15</posy>
+				<left>30</left>
+				<top>15</top>
 				<width>220</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
 				<texture>Confluence_Logo.png</texture>
 			</control>
 			<control type="grouplist" id="9000">
-				<posx>10</posx>
-				<posy>90</posy>
+				<left>10</left>
+				<top>90</top>
 				<width>260</width>
 				<height>481</height>
 				<itemgap>-1</itemgap>
@@ -161,15 +161,15 @@
 				</control>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>790</width>
 				<height>618</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>804</width>
 				<height>100</height>
 				<aspectratio>stretch</aspectratio>
@@ -177,8 +177,8 @@
 			</control>
 			<control type="label" id="40">
 				<description>header label</description>
-				<posx>300</posx>
-				<posy>20</posy>
+				<left>300</left>
+				<top>20</top>
 				<width>740</width>
 				<height>30</height>
 				<font>font16</font>
@@ -189,92 +189,92 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="group">
-				<posx>290</posx>
-				<posy>100</posy>
+				<left>290</left>
+				<top>100</top>
 				<control type="label" id="2">
 					<description>Label 2</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="3">
 					<description>Label 3</description>
-					<posx>0</posx>
-					<posy>35</posy>
+					<left>0</left>
+					<top>35</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="4">
 					<description>Label 4</description>
-					<posx>0</posx>
-					<posy>70</posy>
+					<left>0</left>
+					<top>70</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="5">
 					<description>Label 5</description>
-					<posx>0</posx>
-					<posy>105</posy>
+					<left>0</left>
+					<top>105</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="6">
 					<description>Label 6</description>
-					<posx>0</posx>
-					<posy>140</posy>
+					<left>0</left>
+					<top>140</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="7">
 					<description>Label 7</description>
-					<posx>0</posx>
-					<posy>175</posy>
+					<left>0</left>
+					<top>175</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="8">
 					<description>Label 8</description>
-					<posx>0</posx>
-					<posy>210</posy>
+					<left>0</left>
+					<top>210</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="9">
 					<description>Label 9</description>
-					<posx>0</posx>
-					<posy>245</posy>
+					<left>0</left>
+					<top>245</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="10">
 					<description>Label 10</description>
-					<posx>0</posx>
-					<posy>280</posy>
+					<left>0</left>
+					<top>280</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="11">
 					<description>Label 11</description>
-					<posx>0</posx>
-					<posy>315</posy>
+					<left>0</left>
+					<top>315</top>
 					<width>750</width>
 					<label>-</label>
 					<font>font13</font>
 				</control>
 				<control type="label" id="52">
 					<description>XBMC BUILD Version</description>
-					<posx>750</posx>
-					<posy>400</posy>
+					<left>750</left>
+					<top>400</top>
 					<width>730</width>
 					<label>144</label>
 					<align>right</align>
@@ -284,8 +284,8 @@
 				</control>
 				<control type="label">
 					<description>CPU Text</description>
-					<posx>420</posx>
-					<posy>450</posy>
+					<left>420</left>
+					<top>450</top>
 					<width>350</width>
 					<height>25</height>
 					<label>$LOCALIZE[13271] $INFO[System.CPUUsage]</label>
@@ -297,16 +297,16 @@
 				</control>
 				<control type="progress">
 					<description>CPU BAR</description>
-					<posx>430</posx>
-					<posy>455</posy>
+					<left>430</left>
+					<top>455</top>
 					<width>320</width>
 					<height>16</height>
 					<info>System.CPUUsage</info>
 				</control>
 				<control type="label">
 					<description>Memory Text</description>
-					<posx>420</posx>
-					<posy>480</posy>
+					<left>420</left>
+					<top>480</top>
 					<width>350</width>
 					<height>25</height>
 					<label>$LOCALIZE[31309] $INFO[system.memory(used.percent)]</label>
@@ -318,8 +318,8 @@
 				</control>
 				<control type="progress">
 					<description>Memory BAR</description>
-					<posx>430</posx>
-					<posy>485</posy>
+					<left>430</left>
+					<top>485</top>
 					<width>320</width>
 					<height>16</height>
 					<info>system.memory(used)</info>
@@ -329,16 +329,16 @@
 		<include>CommonNowPlaying</include>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>

--- a/addons/skin.confluence.lite/720p/SkinSettings.xml
+++ b/addons/skin.confluence.lite/720p/SkinSettings.xml
@@ -91,9 +91,9 @@
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>15</top>
-						<width>380</width>
+						<width>240</width>
 						<height>25</height>
 						<font>font24_title</font>
 						<textcolor>grey3</textcolor>
@@ -102,9 +102,9 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>42</top>
-						<width>870</width>
+						<width>240</width>
 						<height>25</height>
 						<font>font13</font>
 						<textcolor>grey2</textcolor>
@@ -123,9 +123,9 @@
 						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>15</top>
-						<width>380</width>
+						<width>240</width>
 						<height>25</height>
 						<font>font24_title</font>
 						<textcolor>white</textcolor>
@@ -134,9 +134,9 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>250</left>
+						<left>10</left>
 						<top>42</top>
-						<width>870</width>
+						<width>240</width>
 						<height>25</height>
 						<font>font13</font>
 						<textcolor>grey2</textcolor>

--- a/addons/skin.confluence.lite/720p/SkinSettings.xml
+++ b/addons/skin.confluence.lite/720p/SkinSettings.xml
@@ -3,8 +3,8 @@
 	<controls>
 		<include>CommonBackground</include>
 		<control type="image">
-			<posx>0</posx>
-			<posy>100r</posy>
+			<left>0</left>
+			<top>100r</top>
 			<width>1280</width>
 			<height>100</height>
 			<texture>floor.png</texture>
@@ -12,16 +12,16 @@
 		</control>
 		<control type="image">
 			<description>Section header image</description>
-			<posx>20</posx>
-			<posy>3</posy>
+			<left>20</left>
+			<top>3</top>
 			<width>35</width>
 			<height>35</height>
 			<aspectratio>keep</aspectratio>
 			<texture>icon_system.png</texture>
 		</control>
 		<control type="grouplist">
-			<posx>65</posx>
-			<posy>5</posy>
+			<left>65</left>
+			<top>5</top>
 			<width>1000</width>
 			<height>30</height>
 			<orientation>horizontal</orientation>
@@ -38,8 +38,8 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>90</posx>
-			<posy>30</posy>
+			<left>90</left>
+			<top>30</top>
 			<animation type="WindowOpen" reversible="false">
 				<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 				<effect type="fade" start="0" end="100" time="300" />
@@ -49,31 +49,31 @@
 				<effect type="fade" start="100" end="0" time="300" />
 			</animation>
 			<control type="image">
-				<posx>5</posx>
-				<posy>5</posy>
+				<left>5</left>
+				<top>5</top>
 				<width>1090</width>
 				<height>630</height>
 				<texture border="15">ContentPanel.png</texture>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>625</posy>
+				<left>5</left>
+				<top>625</top>
 				<width>1090</width>
 				<height>64</height>
 				<texture border="15">ContentPanelMirror.png</texture>
 			</control>
 			<control type="image">
 				<description>LOGO</description>
-				<posx>30</posx>
-				<posy>15</posy>
+				<left>30</left>
+				<top>15</top>
 				<width>220</width>
 				<height>80</height>
 				<aspectratio>keep</aspectratio>
 				<texture>Confluence_Logo.png</texture>
 			</control>
 			<control type="list" id="9000">
-				<posx>10</posx>
-				<posy>90</posy>
+				<left>10</left>
+				<top>90</top>
 				<width>260</width>
 				<height>481</height>
 				<onleft>9010</onleft>
@@ -84,15 +84,15 @@
 				<scrolltime>300</scrolltime>
 				<itemlayout height="80" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>81</height>
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>15</posy>
+						<left>250</left>
+						<top>15</top>
 						<width>380</width>
 						<height>25</height>
 						<font>font24_title</font>
@@ -102,8 +102,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>42</posy>
+						<left>250</left>
+						<top>42</top>
 						<width>870</width>
 						<height>25</height>
 						<font>font13</font>
@@ -115,16 +115,16 @@
 				</itemlayout>
 				<focusedlayout height="80" width="260">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>260</width>
 						<height>81</height>
 						<texture border="5">MenuItemFO.png</texture>
 						<animation effect="fade" start="100" end="30" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>15</posy>
+						<left>250</left>
+						<top>15</top>
 						<width>380</width>
 						<height>25</height>
 						<font>font24_title</font>
@@ -134,8 +134,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>250</posx>
-						<posy>42</posy>
+						<left>250</left>
+						<top>42</top>
 						<width>870</width>
 						<height>25</height>
 						<font>font13</font>
@@ -169,15 +169,15 @@
 				</content>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>790</width>
 				<height>618</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="image">
-				<posx>268</posx>
-				<posy>10</posy>
+				<left>268</left>
+				<top>10</top>
 				<width>804</width>
 				<height>100</height>
 				<aspectratio>stretch</aspectratio>
@@ -185,8 +185,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>300</posx>
-				<posy>20</posy>
+				<left>300</left>
+				<top>20</top>
 				<width>740</width>
 				<height>30</height>
 				<font>font16</font>
@@ -199,8 +199,8 @@
 			<control type="group" id="9010">
 				<control type="grouplist" id="9001">
 					<visible>Container(9000).Hasfocus(1)</visible>
-					<posx>290</posx>
-					<posy>60</posy>
+					<left>290</left>
+					<top>60</top>
 					<width>750</width>
 					<height>530</height>
 					<itemgap>-1</itemgap>
@@ -342,8 +342,8 @@
 					</control>
 				</control>
 				<control type="scrollbar" id="60">
-					<posx>1060</posx>
-					<posy>60</posy>
+					<left>1060</left>
+					<top>60</top>
 					<width>25</width>
 					<height>530</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -359,8 +359,8 @@
 				</control>
 				<control type="grouplist" id="9002">
 					<visible>Container(9000).Hasfocus(2)</visible>
-					<posx>290</posx>
-					<posy>60</posy>
+					<left>290</left>
+					<top>60</top>
 					<width>750</width>
 					<height>530</height>
 					<itemgap>-1</itemgap>
@@ -565,8 +565,8 @@
 					</control>
 				</control>
 				<control type="scrollbar" id="60">
-					<posx>1060</posx>
-					<posy>60</posy>
+					<left>1060</left>
+					<top>60</top>
 					<width>25</width>
 					<height>530</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -582,8 +582,8 @@
 				</control>
 				<control type="grouplist" id="9003">
 					<visible>Container(9000).Hasfocus(3)</visible>
-					<posx>290</posx>
-					<posy>60</posy>
+					<left>290</left>
+					<top>60</top>
 					<width>750</width>
 					<height>530</height>
 					<itemgap>-1</itemgap>
@@ -688,8 +688,8 @@
 				</control>
 				<control type="grouplist" id="9004">
 					<visible>Container(9000).Hasfocus(4)</visible>
-					<posx>290</posx>
-					<posy>60</posy>
+					<left>290</left>
+					<top>60</top>
 					<width>750</width>
 					<height>530</height>
 					<itemgap>-1</itemgap>
@@ -1035,8 +1035,8 @@
 					</control>
 				</control>
 				<control type="scrollbar" id="60">
-					<posx>1060</posx>
-					<posy>60</posy>
+					<left>1060</left>
+					<top>60</top>
 					<width>25</width>
 					<height>530</height>
 					<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>

--- a/addons/skin.confluence.lite/720p/SlideShow.xml
+++ b/addons/skin.confluence.lite/720p/SlideShow.xml
@@ -2,12 +2,12 @@
 	<defaultcontrol>2</defaultcontrol>
 	<controls>
 		<control type="group" id="13">
-			<posx>130r</posx>
-			<posy>10</posy>
+			<left>130r</left>
+			<top>10</top>
 			<visible>!Skin.HasSetting(Show_SlideShow_Paused)</visible>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>120</width>
 				<height>35</height>
 				<texture>black-back.png</texture>
@@ -16,8 +16,8 @@
 			</control>
 			<control type="label">
 				<description>paused label</description>
-				<posx>10</posx>
-				<posy>0</posy>
+				<left>10</left>
+				<top>0</top>
 				<width>100</width>
 				<height>35</height>
 				<align>center</align>
@@ -29,8 +29,8 @@
 		</control>
 		<!-- media infos -->
 		<control type="group">
-			<posx>20</posx>
-			<posy>180r</posy>
+			<left>20</left>
+			<top>180r</top>
 			<visible>Player.ShowInfo + Player.HasMedia</visible>
 			<include>VisibleFadeEffect</include>
 			<include>SmallMusicInfo</include>
@@ -38,8 +38,8 @@
 		<control type="button">
 			<visible>SlideShow.IsVideo + [!SlideShow.IsActive | SlideShow.IsPaused]</visible>
 			<description>Video Play Button</description>
-			<posx>540</posx>
-			<posy>260</posy>
+			<left>540</left>
+			<top>260</top>
 			<width>200</width>
 			<height>200</height>
 			<font>-</font>

--- a/addons/skin.confluence.lite/720p/SmartPlaylistEditor.xml
+++ b/addons/skin.confluence.lite/720p/SmartPlaylistEditor.xml
@@ -3,8 +3,8 @@
 	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-    <posy>22</posy>
+		<left>240</left>
+    <top>22</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
@@ -13,24 +13,24 @@
 			<include>VisibleFadeEffect</include>
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>800</width>
         <height>675</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>720</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label" id="2">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -41,8 +41,8 @@
 			</control>
 			<control type="spincontrolex" id="22">
 				<description>Set Playlist type</description>
-				<posx>30</posx>
-				<posy>70</posy>
+				<left>30</left>
+				<top>70</top>
 				<width>740</width>
 				<height>40</height>
 				<label>467</label>
@@ -56,8 +56,8 @@
 			</control>
 			<control type="label">
 				<description>Name Label</description>
-				<posx>30</posx>
-				<posy>120</posy>
+				<left>30</left>
+				<top>120</top>
 				<width>740</width>
 				<label>21433</label>
 				<font>font12</font>
@@ -66,8 +66,8 @@
 			</control>
 			<control type="edit" id="12">
 				<description>Name Button</description>
-				<posx>30</posx>
-				<posy>145</posy>
+				<left>30</left>
+				<top>145</top>
 				<width>740</width>
 				<height>40</height>
 				<textoffsetx>10</textoffsetx>
@@ -83,8 +83,8 @@
 			</control>
 			<control type="label">
 				<description>rules label</description>
-				<posx>30</posx>
-				<posy>200</posy>
+				<left>30</left>
+				<top>200</top>
 				<width>740</width>
 				<align>left</align>
 				<label>21434</label>
@@ -94,8 +94,8 @@
 			</control>
 			<control type="list" id="10">
 				<description>Rules List Control</description>
-				<posx>30</posx>
-				<posy>225</posy>
+				<left>30</left>
+				<top>225</top>
 				<width>550</width>
 				<height>135</height>
 				<onup>12</onup>
@@ -104,15 +104,15 @@
 				<ondown>16</ondown>
 				<itemlayout width="560" height="45">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>530</width>
 						<height>40</height>
 						<aligny>center</aligny>
@@ -123,24 +123,24 @@
 				</itemlayout>
 				<focusedlayout width="560" height="45">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>40</height>
 						<texture border="5">button-focus2.png</texture>
 						<visible>Control.HasFocus(10)</visible>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
 						<visible>!Control.HasFocus(10)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>530</width>
 						<height>40</height>
 						<aligny>center</aligny>
@@ -151,12 +151,12 @@
 				</focusedlayout>
 			</control>
 			<control type="group" id="9000">
-				<posx>590</posx>
-				<posy>225</posy>
+				<left>590</left>
+				<top>225</top>
 				<control type="button" id="13">
 					<description>Add Rule Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>180</width>
 					<height>40</height>
 					<label>15019</label>
@@ -170,8 +170,8 @@
 				</control>
 				<control type="button" id="14">
 					<description>Remove Rule Button</description>
-					<posx>0</posx>
-					<posy>45</posy>
+					<left>0</left>
+					<top>45</top>
 					<height>40</height>
 					<width>180</width>
 					<label>1210</label>
@@ -185,8 +185,8 @@
 				</control>
 				<control type="button" id="15">
 					<description>Edit Rule Button</description>
-					<posx>0</posx>
-					<posy>90</posy>
+					<left>0</left>
+					<top>90</top>
 					<height>40</height>
 					<width>180</width>
 					<label>21435</label>
@@ -202,8 +202,8 @@
 
 			<control type="label">
 				<description>Name Label</description>
-				<posx>30</posx>
-				<posy>370</posy>
+				<left>30</left>
+				<top>370</top>
 				<width>740</width>
 				<label>31325</label>
 				<font>font12</font>
@@ -211,8 +211,8 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="spincontrolex" id="16">
-				<posx>30</posx>
-				<posy>395</posy>
+				<left>30</left>
+				<top>395</top>
 				<width>740</width>
 				<height>40</height>
 				<label>21424</label>
@@ -226,8 +226,8 @@
 			</control>
 
 			<control type="spincontrolex" id="17">
-				<posx>30</posx>
-				<posy>440</posy>
+				<left>30</left>
+				<top>440</top>
 				<width>740</width>
 				<height>40</height>
 				<label>21427</label>
@@ -241,8 +241,8 @@
 			</control>
 
 			<control type="spincontrolex" id="18">
-				<posx>30</posx>
-				<posy>485</posy>
+				<left>30</left>
+				<top>485</top>
 				<width>550</width>
 				<height>40</height>
 				<label>21429</label>
@@ -256,8 +256,8 @@
 			</control>
 
 			<control type="togglebutton" id="19">
-				<posx>590</posx>
-				<posy>485</posy>
+				<left>590</left>
+				<top>485</top>
 				<width>180</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -276,8 +276,8 @@
 			</control>
 
 			<control type="spincontrolex" id="23">
-				<posx>30</posx>
-				<posy>530</posy>
+				<left>30</left>
+				<top>530</top>
 				<width>550</width>
 				<height>40</height>
 				<label>21458</label>
@@ -291,8 +291,8 @@
 			</control>
 
 			<control type="radiobutton" id="24">
-				<posx>590</posx>
-				<posy>530</posy>
+				<left>590</left>
+				<top>530</top>
 				<width>180</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -310,8 +310,8 @@
 			<control type="group" id="9001">
 				<control type="button" id="20">
 					<description>Ok Button</description>
-					<posx>195</posx>
-					<posy>605</posy>
+					<left>195</left>
+					<top>605</top>
 					<width>200</width>
 					<height>40</height>
 					<align>center</align>
@@ -325,8 +325,8 @@
 				</control>
 				<control type="button" id="21">
 					<description>Cancel Button</description>
-					<posx>405</posx>
-					<posy>605</posy>
+					<left>405</left>
+					<top>605</top>
 					<width>200</width>
 					<height>40</height>
 					<align>center</align>

--- a/addons/skin.confluence.lite/720p/SmartPlaylistRule.xml
+++ b/addons/skin.confluence.lite/720p/SmartPlaylistRule.xml
@@ -3,31 +3,31 @@
 	<allowoverlay>no</allowoverlay>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>220</posy>
+		<left>240</left>
+		<top>220</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>280</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -39,8 +39,8 @@
 		</control>
 		<control type="label">
 			<description>Rule match label</description>
-			<posx>40</posx>
-			<posy>60</posy>
+			<left>40</left>
+			<top>60</top>
 			<width>720</width>
 			<height>35</height>
 			<align>center</align>
@@ -53,8 +53,8 @@
 		<control type="group" id="9001">
 			<control type="spincontrolex" id="15">
 				<description>Rule Field</description>
-				<posx>30</posx>
-				<posy>100</posy>
+				<left>30</left>
+				<top>100</top>
 				<width>365</width>
 				<height>40</height>
 				<font>-</font>
@@ -67,8 +67,8 @@
 			</control>
 			<control type="label">
 				<description>Rule Field label</description>
-				<posx>35</posx>
-				<posy>100</posy>
+				<left>35</left>
+				<top>100</top>
 				<width>300</width>
 				<height>40</height>
 				<font>font13</font>
@@ -80,8 +80,8 @@
 			</control>
 			<control type="spincontrolex" id="16">
 				<description>Rule operator</description>
-				<posx>405</posx>
-				<posy>100</posy>
+				<left>405</left>
+				<top>100</top>
 				<width>365</width>
 				<height>40</height>
 				<font>-</font>
@@ -94,8 +94,8 @@
 			</control>
 			<control type="label">
 				<description>Rule Field label</description>
-				<posx>410</posx>
-				<posy>100</posy>
+				<left>410</left>
+				<top>100</top>
 				<width>300</width>
 				<height>40</height>
 				<font>font13</font>
@@ -108,8 +108,8 @@
 		</control>
 		<control type="button" id="17">
 			<description>Value Button</description>
-			<posx>30</posx>
-			<posy>145</posy>
+			<left>30</left>
+			<top>145</top>
 			<width>565</width>
 			<height>40</height>
 			<font>font13</font>
@@ -125,8 +125,8 @@
 		</control>
 		<control type="button" id="20">
 			<description>Browse Button</description>
-			<posx>600</posx>
-			<posy>145</posy>
+			<left>600</left>
+			<top>145</top>
 			<width>170</width>
 			<height>40</height>
 			<align>center</align>
@@ -143,8 +143,8 @@
 		<control type="group" id="9000">
 			<control type="button" id="18">
 				<description>Ok Button</description>
-				<posx>195</posx>
-				<posy>210</posy>
+				<left>195</left>
+				<top>210</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -158,8 +158,8 @@
 			</control>
 			<control type="button" id="19">
 				<description>Cancel Button</description>
-				<posx>405</posx>
-				<posy>210</posy>
+				<left>405</left>
+				<top>210</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/TrainerSettings.xml
+++ b/addons/skin.confluence.lite/720p/TrainerSettings.xml
@@ -2,22 +2,22 @@
 	<defaultcontrol>5</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>290</posx>
-		<posy>75</posy>
+		<left>290</left>
+		<top>75</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>700</width>
 			<height>570</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
-			<posx>80</posx>
-			<posy>10</posy>
+			<left>80</left>
+			<top>10</top>
 			<width>450</width>
 			<height>90</height>
 			<aspectratio>stretch</aspectratio>
@@ -25,8 +25,8 @@
 		</control>
 		<control type="label">
 			<description>header label</description>
-			<posx>20</posx>
-			<posy>18</posy>
+			<left>20</left>
+			<top>18</top>
 			<width>660</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -37,16 +37,16 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="image">
-			<posx>40</posx>
-			<posy>56</posy>
+			<left>40</left>
+			<top>56</top>
 			<width>660</width>
 			<height>2</height>
 			<texture>separator.png</texture>
 		</control>
 		<control type="label" id="3">
 			<description>No Settings Label</description>
-			<posx>40</posx>
-			<posy>148</posy>
+			<left>40</left>
+			<top>148</top>
 			<width>660</width>
 			<align>center</align>
 			<label>$LOCALIZE[38713]</label>
@@ -55,8 +55,8 @@
 		
 		<control type="grouplist" id="5">
 			<description>control area</description>
-			<posx>20</posx>
-			<posy>80</posy>
+			<left>20</left>
+			<top>80</top>
 			<width>660</width>
 			<height>400</height>
 			<itemgap>-1</itemgap>
@@ -68,8 +68,8 @@
 		</control>
 		<control type="button" id="7">
 			<description>Default Button</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<height>40</height>
 			<font>font13</font>
 			<textcolor>grey2</textcolor>
@@ -79,8 +79,8 @@
 		</control>
 		<control type="radiobutton" id="8">
 			<description>Default RadioButton</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<height>40</height>
 			<font>font13</font>
 			<textcolor>grey2</textcolor>
@@ -90,8 +90,8 @@
 		</control>
 		<control type="spincontrolex" id="9">
 			<description>Default SpinControlex</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<height>40</height>
 			<font>font13</font>
 			<textcolor>grey2</textcolor>
@@ -108,8 +108,8 @@
 		</control>
 		<control type="button" id="28">
 			<description>Ok Button</description>
-			<posx>145</posx>
-			<posy>500</posy>
+			<left>145</left>
+			<top>500</top>
 			<width>200</width>
 			<height>40</height>
 			<align>center</align>
@@ -125,8 +125,8 @@
 		</control>
 		<control type="button" id="29">
 			<description>Cancel Button</description>
-			<posx>355</posx>
-			<posy>500</posy>
+			<left>355</left>
+			<top>500</top>
 			<width>200</width>
 			<height>40</height>
 			<align>center</align>

--- a/addons/skin.confluence.lite/720p/VideoFullScreen.xml
+++ b/addons/skin.confluence.lite/720p/VideoFullScreen.xml
@@ -7,16 +7,16 @@
 			<visible>[Player.ShowInfo | Window.IsActive(VideoOSD)] + ![Window.IsVisible(123) | Window.IsVisible(124) | Window.IsVisible(125)]</visible>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<control type="image" id="1">
-				<posx>0</posx>
-				<posy>-150</posy>
+				<left>0</left>
+				<top>-150</top>
 				<width>1280</width>
 				<height>256</height>
 				<texture flipy="true">HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="label" id="1">
 				<description>Chapter Count Header label</description>
-				<posx>30</posx>
-				<posy>5</posy>
+				<left>30</left>
+				<top>5</top>
 				<width>1000</width>
 				<height>25</height>
 				<align>left</align>
@@ -29,8 +29,8 @@
 			</control>
 			<control type="label" id="1">
 				<description>Clock label</description>
-				<posx>20r</posx>
-				<posy>5</posy>
+				<left>20r</left>
+				<top>5</top>
 				<width>200</width>
 				<height>30</height>
 				<align>right</align>
@@ -41,16 +41,16 @@
 				<label>$INFO[System.Time]</label>
 			</control>
 			<control type="image" id="1">
-				<posx>0</posx>
-				<posy>230r</posy>
+				<left>0</left>
+				<top>230r</top>
 				<width>1280</width>
 				<height>230</height>
 				<texture>HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="image" id="1">
 				<description>cover image</description>
-				<posx>20</posx>
-				<posy>260r</posy>
+				<left>20</left>
+				<top>260r</top>
 				<width>300</width>
 				<height>230</height>
 				<texture fallback="DefaultVideoCover.png">$INFO[Player.Art(thumb)]</texture>
@@ -61,8 +61,8 @@
 			</control>
 			<control type="image" id="1">
 				<description>Movie cover image</description>
-				<posx>20</posx>
-				<posy>350r</posy>
+				<left>20</left>
+				<top>350r</top>
 				<width>300</width>
 				<height>330</height>
 				<texture fallback="DefaultVideoCover.png">$INFO[Player.Art(thumb)]</texture>
@@ -72,12 +72,12 @@
 				<visible>VideoPlayer.Content(Movies)</visible>
 			</control>
 			<control type="group" id="1">
-				<posx>330</posx>
-				<posy>175r</posy>
+				<left>330</left>
+				<top>175r</top>
 				<control type="label" id="1">
 					<description>Heading label</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -89,8 +89,8 @@
 				</control>
 				<control type="label" id="1">
 					<description>Studio label</description>
-					<posx>20</posx>
-					<posy>30</posy>
+					<left>20</left>
+					<top>30</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -102,8 +102,8 @@
 				</control>
 				<control type="label" id="1">
 					<description>TV Show label</description>
-					<posx>20</posx>
-					<posy>30</posy>
+					<left>20</left>
+					<top>30</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -115,8 +115,8 @@
 				</control>
 				<control type="label" id="1">
 					<description>Music Info label</description>
-					<posx>20</posx>
-					<posy>30</posy>
+					<left>20</left>
+					<top>30</top>
 					<width>910</width>
 					<height>25</height>
 					<align>left</align>
@@ -127,8 +127,8 @@
 					<visible>VideoPlayer.Content(MusicVideos)</visible>
 				</control>
 				<control type="grouplist" id="1">
-					<posx>20</posx>
-					<posy>60</posy>
+					<left>20</left>
+					<top>60</top>
 					<width>910</width>
 					<height>35</height>
 					<itemgap>5</itemgap>
@@ -183,8 +183,8 @@
 					</control>
 				</control>
 				<control type="label" id="1">
-					<posx>0</posx>
-					<posy>120</posy>
+					<left>0</left>
+					<top>120</top>
 					<width>910</width>
 					<height>25</height>
 					<label>$LOCALIZE[31049] $INFO[Player.FinishTime]</label>
@@ -198,11 +198,11 @@
 				</control>
 			</control>
 			<control type="group" id="1">
-				<posx>330</posx>
-				<posy>85r</posy>
+				<left>330</left>
+				<top>85r</top>
 				<control type="label" id="1">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>100</width>
 					<height>40</height>
 					<font>font13</font>
@@ -212,8 +212,8 @@
 				</control>
 				<control type="progress" id="1">
 					<description>ProgressbarCache</description>
-					<posx>100</posx>
-					<posy>15</posy>
+					<left>100</left>
+					<top>15</top>
 					<width>720</width>
 					<height>16</height>
 					<info>Player.ProgressCache</info>
@@ -221,15 +221,15 @@
 				</control>
 				<control type="progress" id="1">
 					<description>Progressbar</description>
-					<posx>100</posx>
-					<posy>15</posy>
+					<left>100</left>
+					<top>15</top>
 					<width>720</width>
 					<height>16</height>
 					<info>Player.Progress</info>
 				</control>
 				<control type="label" id="1">
-					<posx>920</posx>
-					<posy>0</posy>
+					<left>920</left>
+					<top>0</top>
 					<width>100</width>
 					<height>40</height>
 					<font>font13</font>
@@ -241,13 +241,13 @@
 		</control>
 		<!-- codec info -->
 		<control type="group" id="0">
-			<posx>0</posx>
-			<posy>20</posy>
+			<left>0</left>
+			<top>20</top>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<control type="image">
 				<description>media info background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>140</height>
 				<colordiffuse>AAFFFFFF</colordiffuse>
@@ -255,8 +255,8 @@
 			</control>
 			<control type="label" id="10">
 				<description>row 1 label</description>
-				<posx>50</posx>
-				<posy>10</posy>
+				<left>50</left>
+				<top>10</top>
 				<width>1180</width>
 				<height>30</height>
 				<align>left</align>
@@ -266,8 +266,8 @@
 			</control>
 			<control type="label" id="11">
 				<description>row 2 label</description>
-				<posx>50</posx>
-				<posy>55</posy>
+				<left>50</left>
+				<top>55</top>
 				<width>1180</width>
 				<height>30</height>
 				<align>left</align>
@@ -277,8 +277,8 @@
 			</control>
 			<control type="label" id="12">
 				<description>row 3 label</description>
-				<posx>50</posx>
-				<posy>100</posy>
+				<left>50</left>
+				<top>100</top>
 				<width>1180</width>
 				<height>30</height>
 				<align>left</align>

--- a/addons/skin.confluence.lite/720p/VideoOSD.xml
+++ b/addons/skin.confluence.lite/720p/VideoOSD.xml
@@ -3,14 +3,14 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="button" id="1000">
 			<description>Close Window button</description>
-			<posx>188r</posx>
-			<posy>0</posy>
+			<left>188r</left>
+			<top>0</top>
 			<width>64</width>
 			<height>32</height>
 			<label>-</label>
@@ -28,8 +28,8 @@
 		</control>
 		<control type="slider" id="87">
 			<description>Seek Slider</description>
-			<posx>430</posx>
-			<posy>72r</posy>
+			<left>430</left>
+			<top>72r</top>
 			<width>720</width>
 			<height>16</height>
 			<onup>702</onup>
@@ -42,13 +42,13 @@
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 		</control>
 		<control type="group" id="100">
-			<posx>325</posx>
-			<posy>50r</posy>
+			<left>325</left>
+			<top>50r</top>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 			<control type="button" id="600">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>210</label>
@@ -62,8 +62,8 @@
 				<onclick>PlayerControl(Previous)</onclick>
 			</control>
 			<control type="button" id="601">
-				<posx>45</posx>
-				<posy>0</posy>
+				<left>45</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31354</label>
@@ -77,8 +77,8 @@
 				<onclick>PlayerControl(Rewind)</onclick>
 			</control>
 			<control type="togglebutton" id="602">
-				<posx>90</posx>
-				<posy>0</posy>
+				<left>90</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31351</label>
@@ -96,8 +96,8 @@
 				<onclick>PlayerControl(Play)</onclick>
 			</control>
 			<control type="button" id="603">
-				<posx>135</posx>
-				<posy>0</posy>
+				<left>135</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31352</label>
@@ -111,8 +111,8 @@
 				<onclick>PlayerControl(Stop)</onclick>
 			</control>
 			<control type="button" id="604">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31353</label>
@@ -126,8 +126,8 @@
 				<onclick>PlayerControl(Forward)</onclick>
 			</control>
 			<control type="button" id="605">
-				<posx>225</posx>
-				<posy>0</posy>
+				<left>225</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>209</label>
@@ -142,13 +142,13 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>250r</posx>
-			<posy>50r</posy>
+			<left>250r</left>
+			<top>50r</top>
 			<animation effect="fade" time="200">VisibleChange</animation>
 			<visible>![Window.IsVisible(SliderDialog) | Window.IsVisible(OSDVideoSettings) | Window.IsVisible(OSDAudioSettings) | Window.IsVisible(VideoBookmarks)]</visible>
 			<control type="togglebutton" id="701">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31356</label>
@@ -166,8 +166,8 @@
 				<onclick>ActivateWindow(SubtitleSearch)</onclick>
 			</control>
 			<control type="button" id="702">
-				<posx>45</posx>
-				<posy>0</posy>
+				<left>45</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>13395</label>
@@ -181,8 +181,8 @@
 				<onclick>ActivateWindow(OSDVideoSettings)</onclick>
 			</control>
 			<control type="button" id="703">
-				<posx>90</posx>
-				<posy>0</posy>
+				<left>90</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>13396</label>
@@ -196,8 +196,8 @@
 				<onclick>ActivateWindow(OSDAudioSettings)</onclick>
 			</control>
 			<control type="button" id="704">
-				<posx>135</posx>
-				<posy>0</posy>
+				<left>135</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31355</label>
@@ -211,8 +211,8 @@
 				<onclick>ActivateWindow(VideoBookmarks)</onclick>
 			</control>
 			<control type="button" id="705">
-				<posx>180</posx>
-				<posy>0</posy>
+				<left>180</left>
+				<top>0</top>
 				<width>45</width>
 				<height>45</height>
 				<label>31355</label>

--- a/addons/skin.confluence.lite/720p/VideoOSDBookmarks.xml
+++ b/addons/skin.confluence.lite/720p/VideoOSDBookmarks.xml
@@ -2,31 +2,31 @@
 	<defaultcontrol always="true">2</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>60</posy>
+		<left>240</left>
+		<top>60</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>600</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -38,8 +38,8 @@
 		</control>
 		<control type="label">
 			<description>number of files/pages in list text label</description>
-			<posx>760</posx>
-			<posy>495</posy>
+			<left>760</left>
+			<top>495</top>
 			<width>300</width>
 			<height>35</height>
 			<font>font12</font>
@@ -50,8 +50,8 @@
 			<label>([COLOR=blue]$INFO[Container(11).NumItems][/COLOR]) $LOCALIZE[31025] - $LOCALIZE[31024] ([COLOR=blue]$INFO[Container(11).CurrentPage]/$INFO[Container(11).NumPages][/COLOR])</label>
 		</control>
 		<control type="panel" id="11">
-			<posx>40</posx>
-			<posy>65</posy>
+			<left>40</left>
+			<top>65</top>
 			<width>720</width>
 			<height>430</height>
 			<onleft>2</onleft>
@@ -64,23 +64,23 @@
 			<orientation>vertical</orientation>
 			<itemlayout height="215" width="240">
 				<control type="image">
-					<posx>2</posx>
-					<posy>2</posy>
+					<left>2</left>
+					<top>2</top>
 					<width>235</width>
 					<height>211</height>
 					<texture border="3">button-nofocus.png</texture>
 				</control>
 				<control type="image">
-					<posx>7</posx>
-					<posy>20</posy>
+					<left>7</left>
+					<top>20</top>
 					<width>220</width>
 					<height>150</height>
 					<aspectratio>scale</aspectratio>
 					<info>ListItem.Icon</info>
 				</control>
 				<control type="label">
-					<posx>112</posx>
-					<posy>185</posy>
+					<left>112</left>
+					<top>185</top>
 					<width>225</width>
 					<height>15</height>
 					<font>font12</font>
@@ -92,23 +92,23 @@
 			</itemlayout>
 			<focusedlayout height="215" width="240">
 				<control type="image">
-					<posx>2</posx>
-					<posy>2</posy>
+					<left>2</left>
+					<top>2</top>
 					<width>235</width>
 					<height>211</height>
 					<texture border="3">folder-focus.png</texture>
 				</control>
 				<control type="image">
-					<posx>7</posx>
-					<posy>20</posy>
+					<left>7</left>
+					<top>20</top>
 					<width>220</width>
 					<height>150</height>
 					<aspectratio>scale</aspectratio>
 					<info>ListItem.Icon</info>
 				</control>
 				<control type="label">
-					<posx>112</posx>
-					<posy>185</posy>
+					<left>112</left>
+					<top>185</top>
 					<width>225</width>
 					<height>15</height>
 					<font>font12</font>
@@ -120,8 +120,8 @@
 			</focusedlayout>
 		</control>
 		<control type="grouplist" id="9000">
-			<posx>20</posx>
-			<posy>535</posy>
+			<left>20</left>
+			<top>535</top>
 			<width>760</width>
 			<height>40</height>
 			<itemgap>5</itemgap>

--- a/addons/skin.confluence.lite/720p/VideoOSDBookmarks.xml
+++ b/addons/skin.confluence.lite/720p/VideoOSDBookmarks.xml
@@ -79,9 +79,9 @@
 					<info>ListItem.Icon</info>
 				</control>
 				<control type="label">
-					<left>112</left>
+					<left>7</left>
 					<top>185</top>
-					<width>225</width>
+					<width>226</width>
 					<height>15</height>
 					<font>font12</font>
 					<selectedcolor>selected</selectedcolor>
@@ -107,9 +107,9 @@
 					<info>ListItem.Icon</info>
 				</control>
 				<control type="label">
-					<left>112</left>
+					<left>7</left>
 					<top>185</top>
-					<width>225</width>
+					<width>226</width>
 					<height>15</height>
 					<font>font12</font>
 					<selectedcolor>selected</selectedcolor>

--- a/addons/skin.confluence.lite/720p/ViewsAddonBrowser.xml
+++ b/addons/skin.confluence.lite/720p/ViewsAddonBrowser.xml
@@ -38,7 +38,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>555</left>
+						<left>55</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -90,7 +90,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>555</left>
+						<left>55</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -270,6 +270,7 @@
 						<bordersize>5</bordersize>
 						<fadetime>100</fadetime>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="image">
 						<left>1</left>
@@ -281,12 +282,13 @@
 						<fadetime>100</fadetime>
 						<colordiffuse>ff333333</colordiffuse>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!IsEmpty(ListItem.Property(Addon.broken))</visible>
 					</control>
 					<control type="label">
-						<left>96</left>
+						<left>1</left>
 						<top>70</top>
-						<width>190</width>
+						<width>191</width>
 						<height>25</height>
 						<font>font13_title</font>
 						<textcolor>ffaa0000</textcolor>
@@ -299,9 +301,9 @@
 						<visible>!IsEmpty(ListItem.Property(Addon.broken))</visible>
 					</control>
 					<control type="label">
-						<left>96</left>
+						<left>1</left>
 						<top>160</top>
-						<width>190</width>
+						<width>191</width>
 						<height>25</height>
 						<font>font12</font>
 						<textcolor>grey2</textcolor>
@@ -321,6 +323,7 @@
 						<bordersize>5</bordersize>
 						<fadetime>100</fadetime>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="image">
 						<left>1</left>
@@ -332,12 +335,13 @@
 						<fadetime>100</fadetime>
 						<colordiffuse>ff333333</colordiffuse>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!IsEmpty(ListItem.Property(Addon.broken))</visible>
 					</control>
 					<control type="label">
-						<left>96</left>
+						<left>1</left>
 						<top>70</top>
-						<width>190</width>
+						<width>191</width>
 						<height>25</height>
 						<font>font13_title</font>
 						<textcolor>ffaa0000</textcolor>
@@ -350,9 +354,9 @@
 						<visible>!IsEmpty(ListItem.Property(Addon.broken))</visible>
 					</control>
 					<control type="label">
-						<left>96</left>
+						<left>1</left>
 						<top>160</top>
-						<width>190</width>
+						<width>191</width>
 						<height>25</height>
 						<font>font12</font>
 						<textcolor>white</textcolor>

--- a/addons/skin.confluence.lite/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence.lite/720p/ViewsFileMode.xml
@@ -4,8 +4,8 @@
 			<visible>Control.IsVisible(50)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="50">
-				<posx>70</posx>
-				<posy>78</posy>
+				<left>70</left>
+				<top>78</top>
 				<width>690</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -17,15 +17,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>660</width>
 						<height>40</height>
 						<font>font13</font>
@@ -36,8 +36,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>680</posx>
-						<posy>0</posy>
+						<left>680</left>
+						<top>0</top>
 						<width>400</width>
 						<height>40</height>
 						<font>font12</font>
@@ -49,8 +49,8 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<posx>620</posx>
-						<posy>0</posy>
+						<left>620</left>
+						<top>0</top>
 						<width>400</width>
 						<height>40</height>
 						<font>font12</font>
@@ -63,24 +63,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>625</posx>
-						<posy>8</posy>
+						<left>625</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>665</posx>
-						<posy>14</posy>
+						<left>665</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>665</posx>
-						<posy>14</posy>
+						<left>665</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -89,8 +89,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -98,8 +98,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>690</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -107,16 +107,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>490</posx>
-						<posy>4</posy>
+						<left>490</left>
+						<top>4</top>
 						<width>200</width>
 						<height>33</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(50) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>660</width>
 						<height>40</height>
 						<font>font13</font>
@@ -127,8 +127,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>680</posx>
-						<posy>0</posy>
+						<left>680</left>
+						<top>0</top>
 						<width>400</width>
 						<height>40</height>
 						<font>font12</font>
@@ -140,8 +140,8 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<posx>620</posx>
-						<posy>0</posy>
+						<left>620</left>
+						<top>0</top>
 						<width>400</width>
 						<height>40</height>
 						<font>font12</font>
@@ -154,24 +154,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>625</posx>
-						<posy>8</posy>
+						<left>625</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>665</posx>
-						<posy>14</posy>
+						<left>665</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>665</posx>
-						<posy>14</posy>
+						<left>665</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -180,8 +180,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>760</posx>
-				<posy>85</posy>
+				<left>760</left>
+				<top>85</top>
 				<width>25</width>
 				<height>550</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -196,12 +196,12 @@
 				<visible>Control.IsVisible(50)</visible>
 			</control>
 			<control type="group">
-				<posx>850</posx>
-				<posy>100</posy>
+				<left>850</left>
+				<top>100</top>
 				<visible>Control.IsVisible(50)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>360</width>
 					<height>540</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -211,8 +211,8 @@
 					<bordersize>8</bordersize>
 				</control>
 				<control type="image">
-					<posx>8</posx>
-					<posy>532</posy>
+					<left>8</left>
+					<top>532</top>
 					<width>344</width>
 					<height>524</height>
 					<aspectratio aligny="top">keep</aspectratio>
@@ -227,8 +227,8 @@
 			<visible>Control.IsVisible(500)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="panel" id="500">
-				<posx>90</posx>
-				<posy>80</posy>
+				<left>90</left>
+				<top>80</top>
 				<width>1080</width>
 				<height>558</height>
 				<onleft>2</onleft>
@@ -241,8 +241,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout condition="!Container.Content(Movies) + !Container.Content(Seasons) + !Container.Content(TVShows) + !Container.Content(Sets)" height="186" width="216">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>160</height>
 						<bordertexture border="5">button-nofocus.png</bordertexture>
@@ -251,8 +251,8 @@
 						<visible>!Container.Content(Episodes)</visible>
 					</control>
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>160</height>
 						<aspectratio>scale</aspectratio>
@@ -262,8 +262,8 @@
 						<visible>Container.Content(Episodes)</visible>
 					</control>
 					<control type="label">
-						<posx>108</posx>
-						<posy>160</posy>
+						<left>108</left>
+						<top>160</top>
 						<width>200</width>
 						<height>25</height>
 						<font>font12</font>
@@ -274,8 +274,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="image">
-						<posx>170</posx>
-						<posy>130</posy>
+						<left>170</left>
+						<top>130</top>
 						<width>30</width>
 						<height>30</height>
 						<aspectratio>keep</aspectratio>
@@ -284,8 +284,8 @@
 				</itemlayout>
 				<focusedlayout condition="!Container.Content(Movies) + !Container.Content(Seasons) + !Container.Content(TVShows)+ !Container.Content(Sets)" height="186" width="216">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>160</height>
 						<bordertexture border="5">folder-focus.png</bordertexture>
@@ -294,8 +294,8 @@
 						<visible>!Container.Content(Episodes)</visible>
 					</control>
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>160</height>
 						<aspectratio>scale</aspectratio>
@@ -305,8 +305,8 @@
 						<visible>Container.Content(Episodes)</visible>
 					</control>
 					<control type="label">
-						<posx>108</posx>
-						<posy>160</posy>
+						<left>108</left>
+						<top>160</top>
 						<width>200</width>
 						<height>25</height>
 						<font>font12</font>
@@ -317,8 +317,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="image">
-						<posx>180</posx>
-						<posy>130</posy>
+						<left>180</left>
+						<top>130</top>
 						<width>30</width>
 						<height>30</height>
 						<aspectratio>keep</aspectratio>
@@ -327,8 +327,8 @@
 				</focusedlayout>
 				<itemlayout condition="Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows) | Container.Content(Sets)" height="279" width="216">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>240</height>
 						<bordertexture border="5">button-nofocus.png</bordertexture>
@@ -336,8 +336,8 @@
 						<texture background="true">$INFO[Listitem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>108</posx>
-						<posy>240</posy>
+						<left>108</left>
+						<top>240</top>
 						<width>200</width>
 						<height>25</height>
 						<font>font12</font>
@@ -348,8 +348,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="image">
-						<posx>170</posx>
-						<posy>210</posy>
+						<left>170</left>
+						<top>210</top>
 						<width>30</width>
 						<height>30</height>
 						<aspectratio>keep</aspectratio>
@@ -358,8 +358,8 @@
 				</itemlayout>
 				<focusedlayout condition="Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows) | Container.Content(Sets)" height="276" width="216">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>214</width>
 						<height>240</height>
 						<bordertexture border="5">folder-focus.png</bordertexture>
@@ -367,8 +367,8 @@
 						<texture background="true">$INFO[Listitem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>108</posx>
-						<posy>240</posy>
+						<left>108</left>
+						<top>240</top>
 						<width>200</width>
 						<height>25</height>
 						<font>font12</font>
@@ -379,8 +379,8 @@
 						<info>ListItem.Label</info>
 					</control>
 					<control type="image">
-						<posx>170</posx>
-						<posy>210</posy>
+						<left>170</left>
+						<top>210</top>
 						<width>30</width>
 						<height>30</height>
 						<aspectratio>keep</aspectratio>
@@ -389,8 +389,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>1170</posx>
-				<posy>80</posy>
+				<left>1170</left>
+				<top>80</top>
 				<width>25</width>
 				<height>550</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -412,8 +412,8 @@
 			<include>VisibleFadeEffect</include>
 			<control type="panel" id="505">
 				<visible>!Container.Content(Movies) + !Container.Content(Episodes) + !Container.Content(Seasons) + !Container.Content(MusicVideos) + !Container.Content(Addons)</visible>
-				<posx>95</posx>
-				<posy>80</posy>
+				<left>95</left>
+				<top>80</top>
 				<width>1080</width>
 				<height>550</height>
 				<onleft>2</onleft>
@@ -426,8 +426,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout height="110" width="540">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>538</width>
 						<height>105</height>
 						<bordertexture border="5">button-nofocus.png</bordertexture>
@@ -436,8 +436,8 @@
 						<visible>IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>538</width>
 						<height>105</height>
 						<bordertexture border="5">button-nofocus.png</bordertexture>
@@ -446,8 +446,8 @@
 						<visible>!IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
-						<posx>500</posx>
-						<posy>70</posy>
+						<left>500</left>
+						<top>70</top>
 						<width>35</width>
 						<height>35</height>
 						<aspectratio>keep</aspectratio>
@@ -456,8 +456,8 @@
 				</itemlayout>
 				<focusedlayout height="110" width="540">
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>538</width>
 						<height>105</height>
 						<bordertexture border="5">folder-focus.png</bordertexture>
@@ -466,8 +466,8 @@
 						<visible>IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
-						<posx>1</posx>
-						<posy>0</posy>
+						<left>1</left>
+						<top>0</top>
 						<width>538</width>
 						<height>105</height>
 						<bordertexture border="5">folder-focus.png</bordertexture>
@@ -476,8 +476,8 @@
 						<visible>!IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
-						<posx>500</posx>
-						<posy>70</posy>
+						<left>500</left>
+						<top>70</top>
 						<width>35</width>
 						<height>35</height>
 						<aspectratio>keep</aspectratio>
@@ -486,8 +486,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>1170</posx>
-				<posy>80</posy>
+				<left>1170</left>
+				<top>80</top>
 				<width>25</width>
 				<height>550</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -508,8 +508,8 @@
 			<visible>Control.IsVisible(51)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="51">
-				<posx>95</posx>
-				<posy>78</posy>
+				<left>95</left>
+				<top>78</top>
 				<width>1080</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -521,22 +521,22 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="40" width="1080">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>1080</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>4</posy>
+						<left>10</left>
+						<top>4</top>
 						<width>40</width>
 						<height>32</height>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>60</posx>
-						<posy>0</posy>
+						<left>60</left>
+						<top>0</top>
 						<width>950</width>
 						<height>40</height>
 						<font>font13</font>
@@ -547,8 +547,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>1060</posx>
-						<posy>0</posy>
+						<left>1060</left>
+						<top>0</top>
 						<width>1000</width>
 						<height>40</height>
 						<font>font12</font>
@@ -560,8 +560,8 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<posx>1005</posx>
-						<posy>0</posy>
+						<left>1005</left>
+						<top>0</top>
 						<width>940</width>
 						<height>40</height>
 						<font>font12</font>
@@ -574,24 +574,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>1010</posx>
-						<posy>8</posy>
+						<left>1010</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>1050</posx>
-						<posy>14</posy>
+						<left>1050</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>1050</posx>
-						<posy>14</posy>
+						<left>1050</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -600,8 +600,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="1080">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>1080</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -609,8 +609,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>1080</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -618,23 +618,23 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>875</posx>
-						<posy>4</posy>
+						<left>875</left>
+						<top>4</top>
 						<width>200</width>
 						<height>33</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(51) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>4</posy>
+						<left>10</left>
+						<top>4</top>
 						<width>40</width>
 						<height>32</height>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="label">
-						<posx>60</posx>
-						<posy>0</posy>
+						<left>60</left>
+						<top>0</top>
 						<width>950</width>
 						<height>40</height>
 						<font>font13</font>
@@ -645,8 +645,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>1060</posx>
-						<posy>0</posy>
+						<left>1060</left>
+						<top>0</top>
 						<width>1000</width>
 						<height>40</height>
 						<font>font12</font>
@@ -658,8 +658,8 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<posx>1005</posx>
-						<posy>0</posy>
+						<left>1005</left>
+						<top>0</top>
 						<width>940</width>
 						<height>40</height>
 						<font>font12</font>
@@ -672,24 +672,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>1010</posx>
-						<posy>8</posy>
+						<left>1010</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>1050</posx>
-						<posy>14</posy>
+						<left>1050</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>1050</posx>
-						<posy>14</posy>
+						<left>1050</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -698,8 +698,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>1170</posx>
-				<posy>80</posy>
+				<left>1170</left>
+				<top>80</top>
 				<width>25</width>
 				<height>550</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>

--- a/addons/skin.confluence.lite/720p/ViewsFileMode.xml
+++ b/addons/skin.confluence.lite/720p/ViewsFileMode.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <includes>
 	<include name="CommonRootView">
 		<control type="group">
@@ -36,7 +37,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>680</left>
+						<left>280</left>
 						<top>0</top>
 						<width>400</width>
 						<height>40</height>
@@ -49,7 +50,7 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<left>620</left>
+						<left>220</left>
 						<top>0</top>
 						<width>400</width>
 						<height>40</height>
@@ -68,6 +69,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -76,6 +78,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -127,7 +130,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>680</left>
+						<left>280</left>
 						<top>0</top>
 						<width>400</width>
 						<height>40</height>
@@ -140,7 +143,7 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<left>620</left>
+						<left>220</left>
 						<top>0</top>
 						<width>400</width>
 						<height>40</height>
@@ -159,6 +162,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -167,6 +171,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -248,6 +253,7 @@
 						<bordertexture border="5">button-nofocus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!Container.Content(Episodes)</visible>
 					</control>
 					<control type="image">
@@ -262,7 +268,7 @@
 						<visible>Container.Content(Episodes)</visible>
 					</control>
 					<control type="label">
-						<left>108</left>
+						<left>8</left>
 						<top>160</top>
 						<width>200</width>
 						<height>25</height>
@@ -282,7 +288,7 @@
 						<texture>$INFO[ListItem.Overlay]</texture>
 					</control>
 				</itemlayout>
-				<focusedlayout condition="!Container.Content(Movies) + !Container.Content(Seasons) + !Container.Content(TVShows)+ !Container.Content(Sets)" height="186" width="216">
+				<focusedlayout condition="!Container.Content(Movies) + !Container.Content(Seasons) + !Container.Content(TVShows) + !Container.Content(Sets)" height="186" width="216">
 					<control type="image">
 						<left>1</left>
 						<top>0</top>
@@ -291,6 +297,7 @@
 						<bordertexture border="5">folder-focus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!Container.Content(Episodes)</visible>
 					</control>
 					<control type="image">
@@ -305,7 +312,7 @@
 						<visible>Container.Content(Episodes)</visible>
 					</control>
 					<control type="label">
-						<left>108</left>
+						<left>8</left>
 						<top>160</top>
 						<width>200</width>
 						<height>25</height>
@@ -334,9 +341,10 @@
 						<bordertexture border="5">button-nofocus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
-						<left>108</left>
+						<left>8</left>
 						<top>240</top>
 						<width>200</width>
 						<height>25</height>
@@ -365,9 +373,10 @@
 						<bordertexture border="5">folder-focus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
-						<left>108</left>
+						<left>8</left>
 						<top>240</top>
 						<width>200</width>
 						<height>25</height>
@@ -433,6 +442,7 @@
 						<bordertexture border="5">button-nofocus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
@@ -443,6 +453,7 @@
 						<bordertexture border="5">button-nofocus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Art(banner)]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
@@ -463,6 +474,7 @@
 						<bordertexture border="5">folder-focus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
@@ -473,6 +485,7 @@
 						<bordertexture border="5">folder-focus.png</bordertexture>
 						<bordersize>5</bordersize>
 						<texture background="true">$INFO[Listitem.Art(banner)]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!IsEmpty(ListItem.Art(banner))</visible>
 					</control>
 					<control type="image">
@@ -533,6 +546,7 @@
 						<width>40</width>
 						<height>32</height>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
 						<left>60</left>
@@ -547,7 +561,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>1060</left>
+						<left>60</left>
 						<top>0</top>
 						<width>1000</width>
 						<height>40</height>
@@ -560,7 +574,7 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<left>1005</left>
+						<left>65</left>
 						<top>0</top>
 						<width>940</width>
 						<height>40</height>
@@ -579,6 +593,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -587,6 +602,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -631,6 +647,7 @@
 						<width>40</width>
 						<height>32</height>
 						<texture background="true">$INFO[ListItem.Icon]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 					<control type="label">
 						<left>60</left>
@@ -645,7 +662,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>1060</left>
+						<left>60</left>
 						<top>0</top>
 						<width>1000</width>
 						<height>40</height>
@@ -658,7 +675,7 @@
 						<visible>!Window.IsVisible(Videos)</visible>
 					</control>
 					<control type="label">
-						<left>1005</left>
+						<left>65</left>
 						<top>0</top>
 						<width>940</width>
 						<height>40</height>
@@ -677,6 +694,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -685,6 +703,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + !ListItem.IsResumable</visible>
 					</control>
 					<control type="image">

--- a/addons/skin.confluence.lite/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence.lite/720p/ViewsMusicLibrary.xml
@@ -37,7 +37,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>760</left>
+						<left>60</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>
@@ -89,7 +89,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>760</left>
+						<left>60</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>
@@ -518,7 +518,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>730</left>
+						<left>30</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>
@@ -535,6 +535,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</itemlayout>
 				<focusedlayout height="40" width="760">
@@ -577,7 +578,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>730</left>
+						<left>30</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>
@@ -594,6 +595,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 					</control>
 				</focusedlayout>
 			</control>
@@ -948,7 +950,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>760</left>
+						<left>60</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>
@@ -1000,7 +1002,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>760</left>
+						<left>60</left>
 						<top>0</top>
 						<width>700</width>
 						<height>40</height>

--- a/addons/skin.confluence.lite/720p/ViewsMusicLibrary.xml
+++ b/addons/skin.confluence.lite/720p/ViewsMusicLibrary.xml
@@ -4,8 +4,8 @@
 			<visible>Control.IsVisible(506)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="506">
-				<posx>70</posx>
-				<posy>75</posy>
+				<left>70</left>
+				<top>75</top>
 				<width>780</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -18,15 +18,15 @@
 				<visible>Window.IsVisible(MusicFiles) | Window.IsVisible(MusicPlaylist) |  Container.Content(Songs) | Container.Content(Albums)</visible>
 				<itemlayout height="40" width="780">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>780</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>730</width>
 						<height>40</height>
 						<font>font13</font>
@@ -37,8 +37,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>760</posx>
-						<posy>0</posy>
+						<left>760</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -51,8 +51,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="760">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>760</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -60,8 +60,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>780</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -69,16 +69,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>580</posx>
-						<posy>5</posy>
+						<left>580</left>
+						<top>5</top>
 						<width>200</width>
 						<height>31</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(506) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>730</width>
 						<height>40</height>
 						<font>font13</font>
@@ -89,8 +89,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>760</posx>
-						<posy>0</posy>
+						<left>760</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -103,8 +103,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>850</posx>
-				<posy>78</posy>
+				<left>850</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -120,11 +120,11 @@
 			</control>
 			<control type="group">
 				<visible>Control.IsVisible(506)</visible>
-				<posx>910</posx>
-				<posy>80</posy>
+				<left>910</left>
+				<top>80</top>
 				<control type="image">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>290</width>
 					<height>290</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -134,8 +134,8 @@
 					<bordersize>8</bordersize>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>300</posy>
+					<left>10</left>
+					<top>300</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Artist]</label>
@@ -147,8 +147,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>360</posy>
+					<left>10</left>
+					<top>360</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Album]</label>
@@ -160,8 +160,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>420</posy>
+					<left>10</left>
+					<top>420</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Title]</label>
@@ -175,8 +175,8 @@
 					<visible>!Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>420</posy>
+					<left>10</left>
+					<top>420</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Genre]</label>
@@ -191,8 +191,8 @@
 				</control>
 				<control type="label">
 					<description>Trackno txt</description>
-					<posx>10</posx>
-					<posy>480</posy>
+					<left>10</left>
+					<top>480</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[listitem.TrackNumber,[COLOR=blue]$LOCALIZE[31310]: [/COLOR]]</label>
@@ -204,8 +204,8 @@
 				</control>
 				<control type="label">
 					<description>Year txt</description>
-					<posx>10</posx>
-					<posy>505</posy>
+					<left>10</left>
+					<top>505</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[listitem.Year,[COLOR=blue]$LOCALIZE[345]: [/COLOR]]</label>
@@ -216,8 +216,8 @@
 				</control>
 				<control type="image">
 					<description>Rating value</description>
-					<posx>80</posx>
-					<posy>535</posy>
+					<left>80</left>
+					<top>535</top>
 					<width>150</width>
 					<height>30</height>
 					<aspectratio>keep</aspectratio>
@@ -228,20 +228,20 @@
 	</include>
 	<include name="AlbumWrapView2_Fanart">
 		<control type="group">
-			<posx>0</posx>
-			<posy>350</posy>
+			<left>0</left>
+			<top>350</top>
 			<visible>Control.IsVisible(509) + Skin.HasSetting(View509HideInfo)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>270</height>
 				<texture>HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="label">
-				<posx>40</posx>
-				<posy>70</posy>
+				<left>40</left>
+				<top>70</top>
 				<width>1200</width>
 				<height>20</height>
 				<font>font24_title</font>
@@ -257,12 +257,12 @@
 		<control type="group">
 			<visible>Control.IsVisible(509)</visible>
 			<include>VisibleFadeEffect</include>
-			<posx>0</posx>
-			<posy>450</posy>
+			<left>0</left>
+			<top>450</top>
 			<control type="fixedlist" id="509">
 				<visible>Container.Content(Albums)</visible>
-				<posx>-80</posx>
-				<posy>0</posy>
+				<left>-80</left>
+				<top>0</top>
 				<width>1360</width>
 				<height>250</height>
 				<onleft>509</onleft>
@@ -278,8 +278,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout height="200" width="160">
 					<control type="image">
-						<posx>2</posx>
-						<posy>20</posy>
+						<left>2</left>
+						<top>20</top>
 						<width>160</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -289,8 +289,8 @@
 						<texture background="true">$INFO[ListItem.Icon]</texture>
 					</control>
 					<control type="image">
-						<posx>6</posx>
-						<posy>24</posy>
+						<left>6</left>
+						<top>24</top>
 						<width>152</width>
 						<height>152</height>
 						<aspectratio>stretch</aspectratio>
@@ -298,8 +298,8 @@
 						<colordiffuse>AAFFFFFF</colordiffuse>
 					</control>
 					<control type="image">
-						<posx>2</posx>
-						<posy>180</posy>
+						<left>2</left>
+						<top>180</top>
 						<width>160</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -311,8 +311,8 @@
 				</itemlayout>
 				<focusedlayout height="200" width="160">
 					<control type="image">
-						<posx>-2</posx>
-						<posy>16</posy>
+						<left>-2</left>
+						<top>16</top>
 						<width>168</width>
 						<height>168</height>
 						<aspectratio>stretch</aspectratio>
@@ -324,8 +324,8 @@
 						<animation reversible="false" effect="zoom" end="-2,16,168,168" start="-12,-4,198,198" time="200">unfocus</animation>
 					</control>
 					<control type="image">
-						<posx>180</posx>
-						<posy>325</posy>
+						<left>180</left>
+						<top>325</top>
 						<width>35</width>
 						<height>35</height>
 						<aspectratio>keep</aspectratio>
@@ -342,8 +342,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>310</posx>
-				<posy>195</posy>
+				<left>310</left>
+				<top>195</top>
 				<width>660</width>
 				<height>25</height>
 				<texturesliderbackground border="14,0,14,0">ScrollBarH.png</texturesliderbackground>
@@ -359,20 +359,20 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>180</posx>
-			<posy>40</posy>
+			<left>180</left>
+			<top>40</top>
 			<visible>Control.IsVisible(509) + !Skin.HasSetting(View509HideInfo)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>920</width>
 				<height>410</height>
 				<texture border="20">ContentPanel.png</texture>
 			</control>
 			<control type="label">
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>840</width>
 				<height>20</height>
 				<font>font13</font>
@@ -384,8 +384,8 @@
 				<label>$INFO[ListItem.Property(Album_Artist)]</label>
 			</control>
 			<control type="label">
-				<posx>40</posx>
-				<posy>50</posy>
+				<left>40</left>
+				<top>50</top>
 				<width>840</width>
 				<height>20</height>
 				<font>font24_title</font>
@@ -397,11 +397,11 @@
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="group">
-				<posx>40</posx>
-				<posy>80</posy>
+				<left>40</left>
+				<top>80</top>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -413,8 +413,8 @@
 					<label>31331</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>35</posy>
+					<left>0</left>
+					<top>35</top>
 					<width>850</width>
 					<height>30</height>
 					<font>font13</font>
@@ -427,8 +427,8 @@
 					<scroll>false</scroll>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>65</posy>
+					<left>0</left>
+					<top>65</top>
 					<width>850</width>
 					<height>30</height>
 					<font>font13</font>
@@ -441,8 +441,8 @@
 					<scroll>false</scroll>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>95</posy>
+					<left>0</left>
+					<top>95</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -457,8 +457,8 @@
 				</control>
 				<control type="image">
 					<description>Rating value</description>
-					<posx>100</posx>
-					<posy>95</posy>
+					<left>100</left>
+					<top>95</top>
 					<width>160</width>
 					<height>32</height>
 					<aspectratio>keep</aspectratio>
@@ -466,8 +466,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Album</description>
-					<posx>0</posx>
-					<posy>150</posy>
+					<left>0</left>
+					<top>150</top>
 					<width>850</width>
 					<height>140</height>
 					<font>font12</font>
@@ -485,8 +485,8 @@
 			<visible>Control.IsVisible(511)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="511">
-				<posx>70</posx>
-				<posy>75</posy>
+				<left>70</left>
+				<top>75</top>
 				<width>760</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -499,15 +499,15 @@
 				<visible>Container.Content(MusicVideos)</visible>
 				<itemlayout height="40" width="760">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>760</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<font>font13</font>
@@ -518,8 +518,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>730</posx>
-						<posy>0</posy>
+						<left>730</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -530,8 +530,8 @@
 						<label>$INFO[ListItem.Label2]</label>
 					</control>
 					<control type="image">
-						<posx>735</posx>
-						<posy>14</posy>
+						<left>735</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
@@ -539,8 +539,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="760">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>760</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -548,8 +548,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>760</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -557,16 +557,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>560</posx>
-						<posy>5</posy>
+						<left>560</left>
+						<top>5</top>
 						<width>200</width>
 						<height>31</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(511) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<font>font13</font>
@@ -577,8 +577,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>730</posx>
-						<posy>0</posy>
+						<left>730</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -589,8 +589,8 @@
 						<label>$INFO[ListItem.Label2]</label>
 					</control>
 					<control type="image">
-						<posx>735</posx>
-						<posy>14</posy>
+						<left>735</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
@@ -598,8 +598,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>850</posx>
-				<posy>78</posy>
+				<left>850</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -614,11 +614,11 @@
 				<visible>Control.IsVisible(511)</visible>
 			</control>
 			<control type="group">
-				<posx>910</posx>
-				<posy>80</posy>
+				<left>910</left>
+				<top>80</top>
 				<control type="image">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>290</width>
 					<height>230</height>
 					<aspectratio>keep</aspectratio>
@@ -629,8 +629,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>10</posx>
-					<posy>230</posy>
+					<left>10</left>
+					<top>230</top>
 					<width>290</width>
 					<align>center</align>
 					<itemgap>0</itemgap>
@@ -639,8 +639,8 @@
 					<include>AudioCodecFlaggingConditions</include>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>290</posy>
+					<left>10</left>
+					<top>290</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Artist]</label>
@@ -652,8 +652,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>350</posy>
+					<left>10</left>
+					<top>350</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Album]</label>
@@ -665,8 +665,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>410</posy>
+					<left>10</left>
+					<top>410</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Title]</label>
@@ -680,8 +680,8 @@
 					<visible>!Container.Content(Albums)</visible>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>470</posy>
+					<left>10</left>
+					<top>470</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Studio]</label>
@@ -695,8 +695,8 @@
 				</control>
 				<control type="label">
 					<description>Year txt</description>
-					<posx>10</posx>
-					<posy>530</posy>
+					<left>10</left>
+					<top>530</top>
 					<width>290</width>
 					<height>25</height>
 					<label>$INFO[listitem.Year,[COLOR=blue]$LOCALIZE[345]: [/COLOR]]</label>
@@ -713,8 +713,8 @@
 			<visible>Control.IsVisible(512)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="512">
-				<posx>70</posx>
-				<posy>78</posy>
+				<left>70</left>
+				<top>78</top>
 				<width>580</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -727,15 +727,15 @@
 				<visible>Container.Content(Artists)</visible>
 				<itemlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>560</width>
 						<height>40</height>
 						<font>font13</font>
@@ -748,8 +748,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -757,8 +757,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -766,8 +766,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>560</width>
 						<height>40</height>
 						<font>font13</font>
@@ -780,8 +780,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>650</posx>
-				<posy>78</posy>
+				<left>650</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -796,11 +796,11 @@
 				<visible>Control.IsVisible(512)</visible>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>70</posy>
+				<left>710</left>
+				<top>70</top>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>510</width>
 					<height>300</height>
 					<aspectratio>keep</aspectratio>
@@ -810,11 +810,11 @@
 					<bordersize>8</bordersize>
 				</control>
 				<control type="group">
-					<posy>310</posy>
+					<top>310</top>
 					<control type="label">
 						<description>Born txt</description>
-						<posx>140</posx>
-						<posy>0</posy>
+						<left>140</left>
+						<top>0</top>
 						<width>140</width>
 						<height>25</height>
 						<label>$LOCALIZE[21893]:</label>
@@ -826,8 +826,8 @@
 					</control>
 					<control type="label">
 						<description>Born Value</description>
-						<posx>150</posx>
-						<posy>0</posy>
+						<left>150</left>
+						<top>0</top>
 						<width>350</width>
 						<height>25</height>
 						<label>$INFO[ListItem.Property(Artist_Born)]</label>
@@ -839,8 +839,8 @@
 					</control>
 					<control type="label">
 						<description>Formed txt</description>
-						<posx>140</posx>
-						<posy>0</posy>
+						<left>140</left>
+						<top>0</top>
 						<width>140</width>
 						<height>25</height>
 						<label>$LOCALIZE[21894]:</label>
@@ -852,8 +852,8 @@
 					</control>
 					<control type="label">
 						<description>Formed Value</description>
-						<posx>150</posx>
-						<posy>0</posy>
+						<left>150</left>
+						<top>0</top>
 						<width>350</width>
 						<height>25</height>
 						<label>$INFO[ListItem.Property(Artist_Formed)]</label>
@@ -865,8 +865,8 @@
 					</control>
 					<control type="label">
 						<description>Genre txt</description>
-						<posx>140</posx>
-						<posy>30</posy>
+						<left>140</left>
+						<top>30</top>
 						<width>140</width>
 						<height>25</height>
 						<label>$LOCALIZE[515]:</label>
@@ -877,8 +877,8 @@
 					</control>
 					<control type="label">
 						<description>Genre Value</description>
-						<posx>150</posx>
-						<posy>30</posy>
+						<left>150</left>
+						<top>30</top>
 						<width>350</width>
 						<height>25</height>
 						<label fallback="416">$INFO[ListItem.Property(Artist_Genre)]</label>
@@ -888,16 +888,16 @@
 						<scroll>true</scroll>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>60</posy>
+						<left>0</left>
+						<top>60</top>
 						<width>510</width>
 						<height>4</height>
 						<texture>separator.png</texture>
 					</control>
 					<control type="textbox">
 						<description>Description Value for Artist</description>
-						<posx>10</posx>
-						<posy>65</posy>
+						<left>10</left>
+						<top>65</top>
 						<width>490</width>
 						<height>190</height>
 						<font>font12</font>
@@ -915,8 +915,8 @@
 			<visible>Control.IsVisible(513)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="513">
-				<posx>70</posx>
-				<posy>75</posy>
+				<left>70</left>
+				<top>75</top>
 				<width>780</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -929,15 +929,15 @@
 				<visible>Container.Content(Albums)</visible>
 				<itemlayout height="40" width="780">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>780</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>730</width>
 						<height>40</height>
 						<font>font13</font>
@@ -948,8 +948,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>760</posx>
-						<posy>0</posy>
+						<left>760</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -962,8 +962,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="780">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>780</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -971,8 +971,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>780</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -980,16 +980,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>580</posx>
-						<posy>5</posy>
+						<left>580</left>
+						<top>5</top>
 						<width>200</width>
 						<height>31</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(513) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>730</width>
 						<height>40</height>
 						<font>font13</font>
@@ -1000,8 +1000,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>760</posx>
-						<posy>0</posy>
+						<left>760</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font12</font>
@@ -1014,8 +1014,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="51360">
-				<posx>850</posx>
-				<posy>78</posy>
+				<left>850</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1030,11 +1030,11 @@
 				<visible>Control.IsVisible(513)</visible>
 			</control>
 			<control type="group">
-				<posx>910</posx>
-				<posy>70</posy>
+				<left>910</left>
+				<top>70</top>
 				<control type="image">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>290</width>
 					<height>240</height>
 					<aspectratio aligny="bottom">keep</aspectratio>
@@ -1045,8 +1045,8 @@
 				</control>
 				<control type="label">
 					<description>Description Header txt</description>
-					<posx>10</posx>
-					<posy>240</posy>
+					<left>10</left>
+					<top>240</top>
 					<width>290</width>
 					<height>25</height>
 					<label>21821</label>
@@ -1058,8 +1058,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Album</description>
-					<posx>10</posx>
-					<posy>270</posy>
+					<left>10</left>
+					<top>270</top>
 					<width>290</width>
 					<height>300</height>
 					<font>font12</font>

--- a/addons/skin.confluence.lite/720p/ViewsPictures.xml
+++ b/addons/skin.confluence.lite/720p/ViewsPictures.xml
@@ -3,11 +3,11 @@
 		<control type="group">
 			<visible>Control.IsVisible(510)</visible>
 			<include>VisibleFadeEffect</include>
-			<posx>0</posx>
-			<posy>440</posy>
+			<left>0</left>
+			<top>440</top>
 			<control type="wraplist" id="510">
-				<posx>-25</posx>
-				<posy>5</posy>
+				<left>-25</left>
+				<top>5</top>
 				<width>1330</width>
 				<height>250</height>
 				<onleft>510</onleft>
@@ -22,8 +22,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout height="200" width="190">
 					<control type="image">
-						<posx>15</posx>
-						<posy>40</posy>
+						<left>15</left>
+						<top>40</top>
 						<width>160</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -33,8 +33,8 @@
 						<texture border="2">ThumbBG.png</texture>
 					</control>
 					<control type="image">
-						<posx>25</posx>
-						<posy>50</posy>
+						<left>25</left>
+						<top>50</top>
 						<width>140</width>
 						<height>140</height>
 						<aspectratio>keep</aspectratio>
@@ -43,8 +43,8 @@
 				</itemlayout>
 				<focusedlayout height="200" width="190">
 					<control type="image">
-						<posx>15</posx>
-						<posy>40</posy>
+						<left>15</left>
+						<top>40</top>
 						<width>160</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -56,8 +56,8 @@
 						<animation reversible="false" effect="zoom" end="15,40,160,160" start="-10,-5,210,210" time="200">unfocus</animation>
 					</control>
 					<control type="image">
-						<posx>25</posx>
-						<posy>50</posy>
+						<left>25</left>
+						<top>50</top>
 						<width>140</width>
 						<height>140</height>
 						<aspectratio>keep</aspectratio>
@@ -68,8 +68,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>310</posx>
-				<posy>200</posy>
+				<left>310</left>
+				<top>200</top>
 				<width>660</width>
 				<height>25</height>
 				<texturesliderbackground border="14,0,14,0">ScrollBarH.png</texturesliderbackground>
@@ -89,8 +89,8 @@
 		<control type="group">
 			<visible>Control.IsVisible(514)</visible>
 			<control type="panel" id="514">
-				<posx>60</posx>
-				<posy>75</posy>
+				<left>60</left>
+				<top>75</top>
 				<width>432</width>
 				<height>576</height>
 				<onleft>2</onleft>
@@ -103,8 +103,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout height="144" width="144">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>144</width>
 						<height>144</height>
 						<aspectratio>stretch</aspectratio>
@@ -114,8 +114,8 @@
 						<texture border="2">ThumbBG.png</texture>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>10</posy>
+						<left>10</left>
+						<top>10</top>
 						<width>124</width>
 						<height>124</height>
 						<aspectratio>keep</aspectratio>
@@ -124,8 +124,8 @@
 				</itemlayout>
 				<focusedlayout height="144" width="144">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>144</width>
 						<height>144</height>
 						<aspectratio>stretch</aspectratio>
@@ -135,8 +135,8 @@
 						<texture border="2">ThumbBG.png</texture>
 					</control>
 					<control type="image">
-						<posx>10</posx>
-						<posy>10</posy>
+						<left>10</left>
+						<top>10</top>
 						<width>124</width>
 						<height>124</height>
 						<aspectratio>keep</aspectratio>
@@ -145,8 +145,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>500</posx>
-				<posy>70</posy>
+				<left>500</left>
+				<top>70</top>
 				<width>25</width>
 				<height>576</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -161,12 +161,12 @@
 				<visible>Control.IsVisible(514)</visible>
 			</control>
 			<control type="group">
-				<posx>570</posx>
-				<posy>80</posy>
+				<left>570</left>
+				<top>80</top>
 				<control type="label">
 					<description>Title txt</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>640</width>
 					<height>15</height>
 					<label>$INFO[ListItem.Label]</label>
@@ -177,8 +177,8 @@
 					<shadowcolor>black</shadowcolor>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>640</width>
 					<height>470</height>
 					<texture background="true">$INFO[ListItem.FilenameAndPath]</texture>
@@ -189,8 +189,8 @@
 				</control>
 				<control type="label">
 					<description>Date time txt</description>
-					<posx>0</posx>
-					<posy>510</posy>
+					<left>0</left>
+					<top>510</top>
 					<width>640</width>
 					<height>15</height>
 					<label>$INFO[ListItem.PictureDateTime,[COLOR=blue]$LOCALIZE[31326][/COLOR] - ]</label>
@@ -202,8 +202,8 @@
 				</control>
 				<control type="label">
 					<description>Resolution txt</description>
-					<posx>0</posx>
-					<posy>535</posy>
+					<left>0</left>
+					<top>535</top>
 					<width>640</width>
 					<height>15</height>
 					<label>$INFO[ListItem.PictureResolution,[COLOR=blue]$LOCALIZE[31327][/COLOR] - ]</label>

--- a/addons/skin.confluence.lite/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence.lite/720p/ViewsVideoLibrary.xml
@@ -831,7 +831,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>510</left>
+						<left>10</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -850,6 +850,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -866,6 +867,7 @@
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>ListItem.IsResumable</visible>
 					</control>
 				</itemlayout>
@@ -909,7 +911,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>510</left>
+						<left>10</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -928,6 +930,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -944,6 +947,7 @@
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>ListItem.IsResumable</visible>
 					</control>
 				</focusedlayout>
@@ -1272,7 +1276,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>510</left>
+						<left>10</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -1291,6 +1295,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -1299,6 +1304,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -1350,7 +1356,7 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<left>510</left>
+						<left>10</left>
 						<top>0</top>
 						<width>500</width>
 						<height>40</height>
@@ -1369,6 +1375,7 @@
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
@@ -1377,6 +1384,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -1673,6 +1681,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
@@ -1721,6 +1730,7 @@
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
+						<aspectratio>keep</aspectratio>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">

--- a/addons/skin.confluence.lite/720p/ViewsVideoLibrary.xml
+++ b/addons/skin.confluence.lite/720p/ViewsVideoLibrary.xml
@@ -2,8 +2,8 @@
 	<include name="PosterWrapView">
 		<control type="grouplist">
 			<visible>Control.IsVisible(501)</visible>
-			<posx>60</posx>
-			<posy>80</posy>
+			<left>60</left>
+			<top>80</top>
 			<width>1160</width>
 			<height>460</height>
 			<onup>9000</onup>
@@ -12,8 +12,8 @@
 			<include>VisibleFadeEffect</include>
 			<control type="fixedlist" id="501">
 				<visible>Container.Content(Movies) | Container.Content(Seasons) | Container.Content(TVShows) | Container.Content(Sets)</visible>
-				<posx>-183</posx>
-				<posy>0</posy>
+				<left>-183</left>
+				<top>0</top>
 				<width>1526</width>
 				<height>390</height>
 				<onleft>501</onleft>
@@ -28,8 +28,8 @@
 				<preloaditems>4</preloaditems>
 				<itemlayout height="310" width="218">
 					<control type="image">
-						<posx>2</posx>
-						<posy>40</posy>
+						<left>2</left>
+						<top>40</top>
 						<width>214</width>
 						<height>310</height>
 						<aspectratio>stretch</aspectratio>
@@ -39,8 +39,8 @@
 						<visible>IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>2</posx>
-						<posy>40</posy>
+						<left>2</left>
+						<top>40</top>
 						<width>214</width>
 						<height>310</height>
 						<aspectratio>stretch</aspectratio>
@@ -52,8 +52,8 @@
 				</itemlayout>
 				<focusedlayout height="310" width="218">
 					<control type="image">
-						<posx>-2</posx>
-						<posy>36</posy>
+						<left>-2</left>
+						<top>36</top>
 						<width>222</width>
 						<height>318</height>
 						<aspectratio>stretch</aspectratio>
@@ -65,8 +65,8 @@
 						<visible>!IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>-2</posx>
-						<posy>36</posy>
+						<left>-2</left>
+						<top>36</top>
 						<width>222</width>
 						<height>318</height>
 						<aspectratio>stretch</aspectratio>
@@ -78,8 +78,8 @@
 						<visible>IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>6</posx>
-						<posy>44</posy>
+						<left>6</left>
+						<top>44</top>
 						<width>170</width>
 						<height>180</height>
 						<aspectratio>stretch</aspectratio>
@@ -88,8 +88,8 @@
 						<animation reversible="false" effect="zoom" end="6,44,170,180" start="-24,4,240,250" time="200">unfocus</animation>
 					</control>
 					<control type="image">
-						<posx>185</posx>
-						<posy>310</posy>
+						<left>185</left>
+						<top>310</top>
 						<width>35</width>
 						<height>35</height>
 						<aspectratio>keep</aspectratio>
@@ -106,8 +106,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>140</posx>
-				<posy>0</posy>
+				<left>140</left>
+				<top>0</top>
 				<width>880</width>
 				<height>25</height>
 				<texturesliderbackground border="14,0,14,0">ScrollBarH.png</texturesliderbackground>
@@ -125,15 +125,15 @@
 		<control type="group">
 			<visible>Control.IsVisible(501)</visible>
 			<control type="image">
-				<posx>56</posx>
-				<posy>120</posy>
+				<left>56</left>
+				<top>120</top>
 				<width>128</width>
 				<height>310</height>
 				<texture>SideFade.png</texture>
 			</control>
 			<control type="image">
-				<posx>1094</posx>
-				<posy>120</posy>
+				<left>1094</left>
+				<top>120</top>
 				<width>128</width>
 				<height>310</height>
 				<texture flipx="true">SideFade.png</texture>
@@ -142,8 +142,8 @@
 		<control type="group">
 			<visible>Control.IsVisible(501) + [Container.Content(Movies) | Container.Content(Sets)]</visible>
 			<control type="label">
-				<posx>30</posx>
-				<posy>500</posy>
+				<left>30</left>
+				<top>500</top>
 				<width>1220</width>
 				<height>35</height>
 				<font>font28_title</font>
@@ -155,8 +155,8 @@
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>540</posy>
+				<left>0</left>
+				<top>540</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font30</font>
@@ -168,8 +168,8 @@
 				<label>$INFO[ListItem.Year]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>580</posy>
+				<left>0</left>
+				<top>580</top>
 				<width>1280</width>
 				<height>20</height>
 				<font>font13</font>
@@ -182,8 +182,8 @@
 			</control>
 			<control type="grouplist">
 				<description>Media Codec Flagging Images</description>
-				<posx>0</posx>
-				<posy>610</posy>
+				<left>0</left>
+				<top>610</top>
 				<width>1280</width>
 				<align>center</align>
 				<itemgap>2</itemgap>
@@ -198,8 +198,8 @@
 		<control type="group">
 			<visible>Control.IsVisible(501) + Container.Content(Seasons)</visible>
 			<control type="label">
-				<posx>30</posx>
-				<posy>500</posy>
+				<left>30</left>
+				<top>500</top>
 				<width>1220</width>
 				<height>35</height>
 				<font>font28_title</font>
@@ -210,8 +210,8 @@
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>540</posy>
+				<left>0</left>
+				<top>540</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font30</font>
@@ -222,8 +222,8 @@
 				<label>$INFO[ListItem.TVShowTitle]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>575</posy>
+				<left>0</left>
+				<top>575</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font13</font>
@@ -234,8 +234,8 @@
 				<label>$INFO[ListItem.Episode,, $LOCALIZE[20453]]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>605</posy>
+				<left>0</left>
+				<top>605</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font12</font>
@@ -249,8 +249,8 @@
 		<control type="group">
 			<visible>Control.IsVisible(501) + Container.Content(TVShows)</visible>
 			<control type="label">
-				<posx>30</posx>
-				<posy>500</posy>
+				<left>30</left>
+				<top>500</top>
 				<width>1220</width>
 				<height>35</height>
 				<font>font28_title</font>
@@ -261,8 +261,8 @@
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>540</posy>
+				<left>0</left>
+				<top>540</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font30</font>
@@ -273,8 +273,8 @@
 				<label>$INFO[ListItem.Genre]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>575</posy>
+				<left>0</left>
+				<top>575</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font13</font>
@@ -285,8 +285,8 @@
 				<label>$INFO[ListItem.Episode,, $LOCALIZE[20453]]</label>
 			</control>
 			<control type="label">
-				<posx>0</posx>
-				<posy>605</posy>
+				<left>0</left>
+				<top>605</top>
 				<width>1280</width>
 				<height>35</height>
 				<font>font12</font>
@@ -300,20 +300,20 @@
 	</include>
 	<include name="PosterWrapView2_Fanart">
 		<control type="group">
-			<posx>0</posx>
-			<posy>350</posy>
+			<left>0</left>
+			<top>350</top>
 			<visible>Control.IsVisible(508) + [[ListItem.IsFolder + Container.Content(Movies)] | Skin.HasSetting(View508HideInfo) | Container.Content(Sets)]</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>270</height>
 				<texture>HomeNowPlayingBack.png</texture>
 			</control>
 			<control type="label">
-				<posx>40</posx>
-				<posy>70</posy>
+				<left>40</left>
+				<top>70</top>
 				<width>1200</width>
 				<height>20</height>
 				<font>font24_title</font>
@@ -329,12 +329,12 @@
 		<control type="group">
 			<visible>Control.IsVisible(508)</visible>
 			<include>VisibleFadeEffect</include>
-			<posx>0</posx>
-			<posy>460</posy>
+			<left>0</left>
+			<top>460</top>
 			<control type="fixedlist" id="508">
 				<visible>Container.Content(Movies) | Container.Content(Sets) | Container.Content(TVShows)</visible>
-				<posx>-20</posx>
-				<posy>0</posy>
+				<left>-20</left>
+				<top>0</top>
 				<width>1320</width>
 				<height>250</height>
 				<onleft>508</onleft>
@@ -350,8 +350,8 @@
 				<preloaditems>2</preloaditems>
 				<itemlayout height="200" width="120">
 					<control type="image">
-						<posx>2</posx>
-						<posy>20</posy>
+						<left>2</left>
+						<top>20</top>
 						<width>120</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -362,8 +362,8 @@
 						<visible>IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>2</posx>
-						<posy>20</posy>
+						<left>2</left>
+						<top>20</top>
 						<width>120</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -374,8 +374,8 @@
 						<visible>!IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>6</posx>
-						<posy>24</posy>
+						<left>6</left>
+						<top>24</top>
 						<width>112</width>
 						<height>152</height>
 						<aspectratio>stretch</aspectratio>
@@ -383,8 +383,8 @@
 						<colordiffuse>AAFFFFFF</colordiffuse>
 					</control>
 					<control type="image">
-						<posx>2</posx>
-						<posy>180</posy>
+						<left>2</left>
+						<top>180</top>
 						<width>120</width>
 						<height>160</height>
 						<aspectratio>stretch</aspectratio>
@@ -396,8 +396,8 @@
 				</itemlayout>
 				<focusedlayout height="310" width="120">
 					<control type="image">
-						<posx>-2</posx>
-						<posy>16</posy>
+						<left>-2</left>
+						<top>16</top>
 						<width>128</width>
 						<height>168</height>
 						<aspectratio>stretch</aspectratio>
@@ -410,8 +410,8 @@
 						<visible>IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>-2</posx>
-						<posy>16</posy>
+						<left>-2</left>
+						<top>16</top>
 						<width>128</width>
 						<height>168</height>
 						<aspectratio>stretch</aspectratio>
@@ -424,8 +424,8 @@
 						<visible>!IsEmpty(ListItem.Art(poster))</visible>
 					</control>
 					<control type="image">
-						<posx>90</posx>
-						<posy>150</posy>
+						<left>90</left>
+						<top>150</top>
 						<width>35</width>
 						<height>35</height>
 						<aspectratio>keep</aspectratio>
@@ -442,8 +442,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>310</posx>
-				<posy>185</posy>
+				<left>310</left>
+				<top>185</top>
 				<width>660</width>
 				<height>25</height>
 				<texturesliderbackground border="14,0,14,0">ScrollBarH.png</texturesliderbackground>
@@ -459,20 +459,20 @@
 			</control>
 		</control>
 		<control type="group">
-			<posx>180</posx>
-			<posy>40</posy>
+			<left>180</left>
+			<top>40</top>
 			<visible>Control.IsVisible(508) + ![ListItem.IsFolder + Container.Content(Movies)] + !Skin.HasSetting(View508HideInfo) + !Container.Content(Sets)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>920</width>
 				<height>410</height>
 				<texture border="20">ContentPanel.png</texture>
 			</control>
 			<control type="label">
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>840</width>
 				<height>20</height>
 				<font>font24_title</font>
@@ -484,12 +484,12 @@
 				<label>$INFO[ListItem.Label]</label>
 			</control>
 			<control type="group">
-				<posx>40</posx>
-				<posy>50</posy>
+				<left>40</left>
+				<top>50</top>
 				<visible>Container.Content(Movies)</visible>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -501,8 +501,8 @@
 					<label>31308</label>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -516,8 +516,8 @@
 					<pauseatend>2000</pauseatend>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>55</posy>
+					<left>0</left>
+					<top>55</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -531,8 +531,8 @@
 					<pauseatend>2000</pauseatend>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>80</posy>
+					<left>0</left>
+					<top>80</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -546,8 +546,8 @@
 					<pauseatend>2000</pauseatend>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>105</posy>
+					<left>0</left>
+					<top>105</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -562,12 +562,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>480</posx>
-				<posy>50</posy>
+				<left>480</left>
+				<top>50</top>
 				<visible>Container.Content(Movies)</visible>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -579,8 +579,8 @@
 					<label>20339</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -592,8 +592,8 @@
 					<label>$INFO[ListItem.Director]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>75</posy>
+					<left>0</left>
+					<top>75</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -605,8 +605,8 @@
 					<label>20417</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>105</posy>
+					<left>0</left>
+					<top>105</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -619,12 +619,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>40</posx>
-				<posy>50</posy>
+				<left>40</left>
+				<top>50</top>
 				<visible>Container.Content(TVShows)</visible>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -636,8 +636,8 @@
 					<label>20351</label>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -651,8 +651,8 @@
 					<pauseatend>2000</pauseatend>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>55</posy>
+					<left>0</left>
+					<top>55</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -666,8 +666,8 @@
 					<pauseatend>2000</pauseatend>
 				</control>
 				<control type="fadelabel">
-					<posx>0</posx>
-					<posy>80</posy>
+					<left>0</left>
+					<top>80</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -682,12 +682,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>480</posx>
-				<posy>50</posy>
+				<left>480</left>
+				<top>50</top>
 				<visible>Container.Content(TVShows)</visible>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -699,8 +699,8 @@
 					<label>20360</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -712,8 +712,8 @@
 					<label>$LOCALIZE[20161] : $INFO[ListItem.Episode]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>55</posy>
+					<left>0</left>
+					<top>55</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -725,8 +725,8 @@
 					<label>$LOCALIZE[16102] : $INFO[ListItem.Property(WatchedEpisodes)]</label>
 				</control>
 				<control type="label">
-					<posx>0</posx>
-					<posy>80</posy>
+					<left>0</left>
+					<top>80</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13</font>
@@ -739,11 +739,11 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>40</posx>
-				<posy>200</posy>
+				<left>40</left>
+				<top>200</top>
 				<control type="label">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font13_title</font>
@@ -756,8 +756,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value The Movie</description>
-					<posx>0</posx>
-					<posy>30</posy>
+					<left>0</left>
+					<top>30</top>
 					<width>850</width>
 					<height>120</height>
 					<font>font12</font>
@@ -769,8 +769,8 @@
 			</control>
 			<control type="grouplist">
 				<description>Media Codec Flagging Images</description>
-				<posx>30</posx>
-				<posy>360</posy>
+				<left>30</left>
+				<top>360</top>
 				<width>800</width>
 				<align>left</align>
 				<itemgap>2</itemgap>
@@ -783,8 +783,8 @@
 			</control>
 			<control type="grouplist">
 				<description>MPAA Rating Flagging Images</description>
-				<posx>95</posx>
-				<posy>360</posy>
+				<left>95</left>
+				<top>360</top>
 				<width>800</width>
 				<align>right</align>
 				<itemgap>0</itemgap>
@@ -798,8 +798,8 @@
 			<visible>Control.IsVisible(503)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="503">
-				<posx>70</posx>
-				<posy>245</posy>
+				<left>70</left>
+				<top>245</top>
 				<width>580</width>
 				<height>401</height>
 				<onleft>2</onleft>
@@ -812,15 +812,15 @@
 				<visible>Container.Content(TVShows) | Container.Content(Seasons) | Container.Content(Episodes) | Container.Content(Movies)</visible>
 				<itemlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>520</width>
 						<height>40</height>
 						<font>font13</font>
@@ -831,8 +831,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>510</posx>
-						<posy>0</posy>
+						<left>510</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font12</font>
@@ -845,24 +845,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>515</posx>
-						<posy>8</posy>
+						<left>515</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -871,8 +871,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -880,8 +880,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -889,16 +889,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>380</posx>
-						<posy>4</posy>
+						<left>380</left>
+						<top>4</top>
 						<width>200</width>
 						<height>33</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(503) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>520</width>
 						<height>40</height>
 						<font>font13</font>
@@ -909,8 +909,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>510</posx>
-						<posy>0</posy>
+						<left>510</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font12</font>
@@ -923,24 +923,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>515</posx>
-						<posy>8</posy>
+						<left>515</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -949,8 +949,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>650</posx>
-				<posy>245</posy>
+				<left>650</left>
+				<top>245</top>
 				<width>25</width>
 				<height>400</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -965,12 +965,12 @@
 				<visible>Control.IsVisible(503)</visible>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>245</posy>
+				<left>710</left>
+				<top>245</top>
 				<visible>Container.Content(TVShows)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>530</width>
 					<height>110</height>
 					<aspectratio>keep</aspectratio>
@@ -981,8 +981,8 @@
 					<visible>IsEmpty(ListItem.Art(banner))</visible>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>530</width>
 					<height>110</height>
 					<aspectratio>keep</aspectratio>
@@ -994,8 +994,8 @@
 				</control>
 				<control type="label">
 					<description>Episodes txt</description>
-					<posx>150</posx>
-					<posy>120</posy>
+					<left>150</left>
+					<top>120</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[20360]:</label>
@@ -1006,8 +1006,8 @@
 				</control>
 				<control type="label">
 					<description>Episodes Value</description>
-					<posx>160</posx>
-					<posy>120</posy>
+					<left>160</left>
+					<top>120</top>
 					<width>360</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.episode] [COLOR=grey] ($INFO[ListItem.Property(WatchedEpisodes),, $LOCALIZE[16102]] - $INFO[ListItem.Property(UnWatchedEpisodes), , $LOCALIZE[16101]])[/COLOR]</label>
@@ -1018,8 +1018,8 @@
 				</control>
 				<control type="label">
 					<description>Aired txt</description>
-					<posx>150</posx>
-					<posy>145</posy>
+					<left>150</left>
+					<top>145</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[31322]:</label>
@@ -1030,8 +1030,8 @@
 				</control>
 				<control type="label">
 					<description>Aired Value</description>
-					<posx>160</posx>
-					<posy>145</posy>
+					<left>160</left>
+					<top>145</top>
 					<width>360</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.premiered]</label>
@@ -1042,8 +1042,8 @@
 				</control>
 				<control type="label">
 					<description>Genre txt</description>
-					<posx>150</posx>
-					<posy>170</posy>
+					<left>150</left>
+					<top>170</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[515]:</label>
@@ -1054,8 +1054,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Genre Value</description>
-					<posx>160</posx>
-					<posy>170</posy>
+					<left>160</left>
+					<top>170</top>
 					<width>360</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.Genre]</label>
@@ -1066,16 +1066,16 @@
 					<pauseatend>1000</pauseatend>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>200</posy>
+					<left>0</left>
+					<top>200</top>
 					<width>530</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="textbox">
 					<description>Description Value for TVShows</description>
-					<posx>10</posx>
-					<posy>210</posy>
+					<left>10</left>
+					<top>210</top>
 					<width>510</width>
 					<height>180</height>
 					<font>font12</font>
@@ -1086,12 +1086,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>245</posy>
+				<left>710</left>
+				<top>245</top>
 				<visible>Container.Content(Episodes)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>530</width>
 					<height>210</height>
 					<aspectratio>keep</aspectratio>
@@ -1102,8 +1102,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>210</posy>
+					<left>0</left>
+					<top>210</top>
 					<width>530</width>
 					<align>center</align>
 					<itemgap>2</itemgap>
@@ -1116,8 +1116,8 @@
 				</control>
 				<control type="label">
 					<description>INFO txt</description>
-					<posx>10</posx>
-					<posy>245</posy>
+					<left>10</left>
+					<top>245</top>
 					<width>510</width>
 					<height>25</height>
 					<label>$INFO[ListItem.Season,[COLOR=blue] $LOCALIZE[20373] :[/COLOR] ] $INFO[ListItem.episode,[COLOR=blue] $LOCALIZE[20359] :[/COLOR] ] $INFO[ListItem.premiered,[COLOR=blue] $LOCALIZE[31322] :[/COLOR] ]</label>
@@ -1129,16 +1129,16 @@
 					<wrapmultiline>true</wrapmultiline>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>275</posy>
+					<left>0</left>
+					<top>275</top>
 					<width>530</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="textbox">
 					<description>Description Value for TVShows</description>
-					<posx>10</posx>
-					<posy>280</posy>
+					<left>10</left>
+					<top>280</top>
 					<width>510</width>
 					<height>120</height>
 					<font>font12</font>
@@ -1149,12 +1149,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>245</posy>
+				<left>710</left>
+				<top>245</top>
 				<visible>Container.Content(Seasons)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>260</width>
 					<height>355</height>
 					<aspectratio>keep</aspectratio>
@@ -1165,8 +1165,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Seasons</description>
-					<posx>270</posx>
-					<posy>0</posy>
+					<left>270</left>
+					<top>0</top>
 					<width>250</width>
 					<height>355</height>
 					<font>font12</font>
@@ -1178,8 +1178,8 @@
 				</control>
 				<control type="label">
 					<description>Watched Count</description>
-					<posx>10</posx>
-					<posy>370</posy>
+					<left>10</left>
+					<top>370</top>
 					<width>510</width>
 					<height>25</height>
 					<label>[COLOR=white]$LOCALIZE[20360]:[/COLOR] $INFO[ListItem.Property(WatchedEpisodes),([COLOR=blue],[/COLOR]) $LOCALIZE[16102]] $INFO[ListItem.Property(UnWatchedEpisodes),([COLOR=blue],[/COLOR]) $LOCALIZE[16101]]</label>
@@ -1191,12 +1191,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>245</posy>
+				<left>710</left>
+				<top>245</top>
 				<visible>Container.Content(Movies)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>260</width>
 					<height>355</height>
 					<aspectratio>keep</aspectratio>
@@ -1207,8 +1207,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>365</posy>
+					<left>0</left>
+					<top>365</top>
 					<width>530</width>
 					<align>center</align>
 					<itemgap>2</itemgap>
@@ -1221,8 +1221,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Movie</description>
-					<posx>270</posx>
-					<posy>0</posy>
+					<left>270</left>
+					<top>0</top>
 					<width>250</width>
 					<height>355</height>
 					<font>font12</font>
@@ -1239,8 +1239,8 @@
 			<visible>Control.IsVisible(504)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="504">
-				<posx>70</posx>
-				<posy>78</posy>
+				<left>70</left>
+				<top>78</top>
 				<width>580</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -1253,15 +1253,15 @@
 				<visible>Container.Content(TVShows) | Container.Content(Movies) | Container.Content(Episodes)</visible>
 				<itemlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>520</width>
 						<height>40</height>
 						<font>font13</font>
@@ -1272,8 +1272,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>510</posx>
-						<posy>0</posy>
+						<left>510</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font12</font>
@@ -1286,24 +1286,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>515</posx>
-						<posy>8</posy>
+						<left>515</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -1312,8 +1312,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="580">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -1321,8 +1321,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>580</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -1330,16 +1330,16 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>380</posx>
-						<posy>4</posy>
+						<left>380</left>
+						<top>4</top>
 						<width>200</width>
 						<height>33</height>
 						<texture border="0,0,14,0">MediaItemDetailBG.png</texture>
 						<visible>Control.HasFocus(504) + !IsEmpty(ListItem.Label2)</visible>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>520</width>
 						<height>40</height>
 						<font>font13</font>
@@ -1350,8 +1350,8 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="label">
-						<posx>510</posx>
-						<posy>0</posy>
+						<left>510</left>
+						<top>0</top>
 						<width>500</width>
 						<height>40</height>
 						<font>font12</font>
@@ -1364,24 +1364,24 @@
 						<animation effect="slide" start="0,0" end="40,0" delay="0" time="0" condition="![Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]">conditional</animation>
 					</control>
 					<control type="image">
-						<posx>515</posx>
-						<posy>8</posy>
+						<left>515</left>
+						<top>8</top>
 						<width>40</width>
 						<height>26</height>
 						<texture>$INFO[ListItem.VideoResolution,flagging/lists/,.png]</texture>
 						<visible>Window.IsVisible(Videos) + [Container.Content(Movies) | Container.Content(Episodes) | Container.Content(MusicVideos)]</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>555</posx>
-						<posy>14</posy>
+						<left>555</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -1390,8 +1390,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>650</posx>
-				<posy>78</posy>
+				<left>650</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="10,14,10,14">ScrollBarV.png</texturesliderbackground>
@@ -1406,12 +1406,12 @@
 				<visible>Control.IsVisible(504)</visible>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>70</posy>
+				<left>710</left>
+				<top>70</top>
 				<visible>Control.IsVisible(504) + [Container.Content(Movies) | Container.Content(TVShows)]</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>510</width>
 					<height>286</height>
 					<aspectratio>scale</aspectratio>
@@ -1422,8 +1422,8 @@
 					<bordersize>8</bordersize>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>510</width>
 					<height>325</height>
 					<aspectratio>scale</aspectratio>
@@ -1435,8 +1435,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>290</posy>
+					<left>0</left>
+					<top>290</top>
 					<width>510</width>
 					<align>center</align>
 					<itemgap>2</itemgap>
@@ -1448,16 +1448,16 @@
 					<include>VideoTypeHackFlaggingConditions</include>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>330</posy>
+					<left>0</left>
+					<top>330</top>
 					<width>510</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="label">
 					<description>Year txt</description>
-					<posx>150</posx>
-					<posy>335</posy>
+					<left>150</left>
+					<top>335</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[345]:</label>
@@ -1468,8 +1468,8 @@
 				</control>
 				<control type="label">
 					<description>Year Value</description>
-					<posx>160</posx>
-					<posy>335</posy>
+					<left>160</left>
+					<top>335</top>
 					<width>340</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.Year]</label>
@@ -1480,8 +1480,8 @@
 				</control>
 				<control type="label">
 					<description>Genre txt</description>
-					<posx>150</posx>
-					<posy>360</posy>
+					<left>150</left>
+					<top>360</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[515]:</label>
@@ -1492,8 +1492,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Genre Value</description>
-					<posx>160</posx>
-					<posy>360</posy>
+					<left>160</left>
+					<top>360</top>
 					<width>340</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.Genre]</label>
@@ -1504,16 +1504,16 @@
 					<pauseatend>1000</pauseatend>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>390</posy>
+					<left>0</left>
+					<top>390</top>
 					<width>510</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>490</width>
 					<height>170</height>
 					<font>font12</font>
@@ -1524,12 +1524,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>710</posx>
-				<posy>70</posy>
+				<left>710</left>
+				<top>70</top>
 				<visible>Control.IsVisible(504) + Container.Content(Episodes)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>510</width>
 					<height>286</height>
 					<aspectratio>scale</aspectratio>
@@ -1540,8 +1540,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>290</posy>
+					<left>0</left>
+					<top>290</top>
 					<width>510</width>
 					<align>center</align>
 					<itemgap>2</itemgap>
@@ -1553,16 +1553,16 @@
 					<include>VideoTypeHackFlaggingConditions</include>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>330</posy>
+					<left>0</left>
+					<top>330</top>
 					<width>510</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="label">
 					<description>Aired txt</description>
-					<posx>150</posx>
-					<posy>335</posy>
+					<left>150</left>
+					<top>335</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[31322]:</label>
@@ -1573,8 +1573,8 @@
 				</control>
 				<control type="label">
 					<description>Aired Value</description>
-					<posx>160</posx>
-					<posy>335</posy>
+					<left>160</left>
+					<top>335</top>
 					<width>340</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.Premiered]</label>
@@ -1585,8 +1585,8 @@
 				</control>
 				<control type="label">
 					<description>Episode txt</description>
-					<posx>150</posx>
-					<posy>360</posy>
+					<left>150</left>
+					<top>360</top>
 					<width>140</width>
 					<height>25</height>
 					<label>$LOCALIZE[20359]:</label>
@@ -1597,8 +1597,8 @@
 				</control>
 				<control type="fadelabel">
 					<description>Episode Value</description>
-					<posx>160</posx>
-					<posy>360</posy>
+					<left>160</left>
+					<top>360</top>
 					<width>340</width>
 					<height>25</height>
 					<label fallback="416">$INFO[listitem.Season,,x]$INFO[listitem.Episode]</label>
@@ -1609,16 +1609,16 @@
 					<pauseatend>1000</pauseatend>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>390</posy>
+					<left>0</left>
+					<top>390</top>
 					<width>510</width>
 					<height>4</height>
 					<texture>separator.png</texture>
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>490</width>
 					<height>170</height>
 					<font>font12</font>
@@ -1635,8 +1635,8 @@
 			<visible>Control.IsVisible(515)</visible>
 			<include>VisibleFadeEffect</include>
 			<control type="list" id="515">
-				<posx>70</posx>
-				<posy>78</posy>
+				<left>70</left>
+				<top>78</top>
 				<width>340</width>
 				<height>561</height>
 				<onleft>2</onleft>
@@ -1649,15 +1649,15 @@
 				<visible>Container.Content(TVShows) | Container.Content(Movies) | Container.Content(Episodes) | Container.Content(Seasons)</visible>
 				<itemlayout height="40" width="345">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>345</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>310</width>
 						<height>40</height>
 						<font>font13</font>
@@ -1668,16 +1668,16 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="image">
-						<posx>320</posx>
-						<posy>14</posy>
+						<left>320</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>320</posx>
-						<posy>14</posy>
+						<left>320</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -1686,8 +1686,8 @@
 				</itemlayout>
 				<focusedlayout height="40" width="345">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>345</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemNF.png</texture>
@@ -1695,8 +1695,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>345</width>
 						<height>41</height>
 						<texture border="0,2,0,2">MenuItemFO.png</texture>
@@ -1704,8 +1704,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>310</width>
 						<height>40</height>
 						<font>font13</font>
@@ -1716,16 +1716,16 @@
 						<label>$INFO[ListItem.Label]</label>
 					</control>
 					<control type="image">
-						<posx>320</posx>
-						<posy>14</posy>
+						<left>320</left>
+						<top>14</top>
 						<width>20</width>
 						<height>16</height>
 						<texture>$INFO[ListItem.Overlay]</texture>
 						<visible>!ListItem.IsResumable</visible>
 					</control>
 					<control type="image">
-						<posx>320</posx>
-						<posy>14</posy>
+						<left>320</left>
+						<top>14</top>
 						<width>16</width>
 						<height>16</height>
 						<texture>OverlayWatching.png</texture>
@@ -1734,8 +1734,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>415</posx>
-				<posy>78</posy>
+				<left>415</left>
+				<top>78</top>
 				<width>25</width>
 				<height>560</height>
 				<texturesliderbackground border="10,14,10,14">ScrollBarV.png</texturesliderbackground>
@@ -1750,12 +1750,12 @@
 				<visible>Control.IsVisible(515)</visible>
 			</control>
 			<control type="group">
-				<posx>470</posx>
-				<posy>70</posy>
+				<left>470</left>
+				<top>70</top>
 				<visible>Control.IsVisible(515) + Container.Content(Movies)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>750</width>
 					<height>420</height>
 					<aspectratio scalediffuse="false">scale</aspectratio>
@@ -1763,8 +1763,8 @@
 					<texture diffuse="Fanart_Diffuse.png" background="true" fallback="special://skin/backgrounds/Fanart_Fallback_Small.jpg" >$INFO[ListItem.Art(fanart)]</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>540</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -1776,8 +1776,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>425</posy>
+					<left>10</left>
+					<top>425</top>
 					<width>540</width>
 					<height>105</height>
 					<font>font12</font>
@@ -1788,8 +1788,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>540</posy>
+					<left>0</left>
+					<top>540</top>
 					<width>540</width>
 					<align>left</align>
 					<itemgap>2</itemgap>
@@ -1801,8 +1801,8 @@
 					<include>VideoTypeHackFlaggingConditions</include>
 				</control>
 				<control type="image">
-					<posx>560</posx>
-					<posy>140</posy>
+					<left>560</left>
+					<top>140</top>
 					<width>180</width>
 					<height>440</height>
 					<aspectratio align="left" aligny="bottom">keep</aspectratio>
@@ -1813,12 +1813,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>470</posx>
-				<posy>70</posy>
+				<left>470</left>
+				<top>70</top>
 				<visible>Control.IsVisible(515) + Container.Content(TVShows)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>750</width>
 					<height>420</height>
 					<aspectratio scalediffuse="false">scale</aspectratio>
@@ -1826,8 +1826,8 @@
 					<texture diffuse="Fanart_Diffuse.png" background="true" fallback="special://skin/backgrounds/Fanart_Fallback_Small.jpg" >$INFO[ListItem.Art(fanart)]</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>540</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -1839,8 +1839,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>425</posy>
+					<left>10</left>
+					<top>425</top>
 					<width>540</width>
 					<height>145</height>
 					<font>font12</font>
@@ -1850,8 +1850,8 @@
 					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
 				</control>
 				<control type="image">
-					<posx>560</posx>
-					<posy>140</posy>
+					<left>560</left>
+					<top>140</top>
 					<width>180</width>
 					<height>440</height>
 					<aspectratio align="left" aligny="bottom">keep</aspectratio>
@@ -1862,12 +1862,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>470</posx>
-				<posy>70</posy>
+				<left>470</left>
+				<top>70</top>
 				<visible>Control.IsVisible(515) + Container.Content(Seasons)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>750</width>
 					<height>420</height>
 					<aspectratio scalediffuse="false">scale</aspectratio>
@@ -1875,8 +1875,8 @@
 					<texture diffuse="Fanart_Diffuse.png" background="true" fallback="special://skin/backgrounds/Fanart_Fallback_Small.jpg" >$INFO[ListItem.Art(fanart)]</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>730</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -1888,8 +1888,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>425</posy>
+					<left>10</left>
+					<top>425</top>
 					<width>540</width>
 					<height>145</height>
 					<font>font12</font>
@@ -1899,8 +1899,8 @@
 					<autoscroll time="2000" delay="3000" repeat="5000">Skin.HasSetting(AutoScroll)</autoscroll>
 				</control>
 				<control type="image">
-					<posx>560</posx>
-					<posy>140</posy>
+					<left>560</left>
+					<top>140</top>
 					<width>180</width>
 					<height>440</height>
 					<aspectratio align="left" aligny="bottom">keep</aspectratio>
@@ -1911,12 +1911,12 @@
 				</control>
 			</control>
 			<control type="group">
-				<posx>470</posx>
-				<posy>70</posy>
+				<left>470</left>
+				<top>70</top>
 				<visible>Control.IsVisible(515) + Container.Content(Episodes)</visible>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>750</width>
 					<height>420</height>
 					<aspectratio scalediffuse="false">scale</aspectratio>
@@ -1924,8 +1924,8 @@
 					<texture diffuse="Fanart_Diffuse.png" background="true" fallback="special://skin/backgrounds/Fanart_Fallback_Small.jpg" >$INFO[ListItem.Art(fanart)]</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>395</posy>
+					<left>10</left>
+					<top>395</top>
 					<width>400</width>
 					<height>30</height>
 					<font>font24_title</font>
@@ -1937,8 +1937,8 @@
 				</control>
 				<control type="textbox">
 					<description>Description Value for Video</description>
-					<posx>10</posx>
-					<posy>425</posy>
+					<left>10</left>
+					<top>425</top>
 					<width>400</width>
 					<height>105</height>
 					<font>font12</font>
@@ -1949,8 +1949,8 @@
 				</control>
 				<control type="grouplist">
 					<description>Media Codec Flagging Images</description>
-					<posx>0</posx>
-					<posy>540</posy>
+					<left>0</left>
+					<top>540</top>
 					<width>410</width>
 					<align>left</align>
 					<itemgap>2</itemgap>
@@ -1962,8 +1962,8 @@
 					<include>VideoTypeHackFlaggingConditions</include>
 				</control>
 				<control type="image">
-					<posx>420</posx>
-					<posy>140</posy>
+					<left>420</left>
+					<top>140</top>
 					<width>330</width>
 					<height>440</height>
 					<aspectratio align="left" aligny="bottom">keep</aspectratio>

--- a/addons/skin.confluence.lite/720p/VisualisationPresetList.xml
+++ b/addons/skin.confluence.lite/720p/VisualisationPresetList.xml
@@ -2,32 +2,32 @@
 	<defaultcontrol>2</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>60</posy>
+		<left>240</left>
+		<top>60</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="group">
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>800</width>
 				<height>600</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
 				<description>Dialog Header image</description>
-				<posx>40</posx>
-				<posy>16</posy>
+				<left>40</left>
+				<top>16</top>
 				<width>720</width>
 				<height>40</height>
 				<texture>dialogheader.png</texture>
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>40</posx>
-				<posy>20</posy>
+				<left>40</left>
+				<top>20</top>
 				<width>720</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -39,16 +39,16 @@
 			</control>
 			<control type="label" id="4">
 				<description>No Settings Label</description>
-				<posx>20</posx>
-				<posy>180</posy>
+				<left>20</left>
+				<top>180</top>
 				<width>760</width>
 				<align>center</align>
 				<label>13389</label>
 				<font>font13</font>
 			</control>
 			<control type="list" id="2">
-				<posx>40</posx>
-				<posy>60</posy>
+				<left>40</left>
+				<top>60</top>
 				<width>720</width>
 				<height>495</height>
 				<onleft>60</onleft>
@@ -59,15 +59,15 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="45" width="720">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font13</font>
@@ -80,8 +80,8 @@
 				</itemlayout>
 				<focusedlayout height="45" width="720">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<texture border="5">button-nofocus.png</texture>
@@ -89,8 +89,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>720</width>
 						<height>40</height>
 						<texture border="5">button-focus2.png</texture>
@@ -98,8 +98,8 @@
 						<include>VisibleFadeEffect</include>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>700</width>
 						<height>40</height>
 						<font>font13</font>
@@ -112,8 +112,8 @@
 				</focusedlayout>
 			</control>
 			<control type="scrollbar" id="60">
-				<posx>760</posx>
-				<posy>60</posy>
+				<left>760</left>
+				<top>60</top>
 				<width>25</width>
 				<height>495</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -130,8 +130,8 @@
 			</control>
 			<control type="label">
 				<description>number of files/pages in list text label</description>
-				<posx>760</posx>
-				<posy>548</posy>
+				<left>760</left>
+				<top>548</top>
 				<width>300</width>
 				<height>35</height>
 				<font>font12</font>

--- a/addons/skin.confluence.lite/720p/custom_DiscDialog_1113.xml
+++ b/addons/skin.confluence.lite/720p/custom_DiscDialog_1113.xml
@@ -3,13 +3,13 @@
 	<include>dialogeffect</include>
 	<coordinates>
 		<system>1</system>
-		<posx>55</posx>
-		<posy>570</posy>
+		<left>55</left>
+		<top>570</top>
 	</coordinates>
 	<controls>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>200</width>
 			<height>150</height>
 			<texture border="20">OverlayDialogBackground.png</texture>
@@ -17,8 +17,8 @@
 		<control type="group" id="9000">
 			<control type="button" id="1">
 				<description>Play Button</description>
-				<posx>10</posx>
-				<posy>10</posy>
+				<left>10</left>
+				<top>10</top>
 				<width>180</width>
 				<height>40</height>
 				<label>208</label>
@@ -38,8 +38,8 @@
 			</control>
 			<control type="button" id="2">
 				<description>Eject Button</description>
-				<posx>10</posx>
-				<posy>50</posy>
+				<left>10</left>
+				<top>50</top>
 				<width>180</width>
 				<height>40</height>
 				<label>13391</label>
@@ -57,8 +57,8 @@
 			</control>
 			<control type="button" id="3">
 				<description>Cancel Button</description>
-				<posx>10</posx>
-				<posy>90</posy>
+				<left>10</left>
+				<top>90</top>
 				<width>180</width>
 				<height>40</height>
 				<label>222</label>

--- a/addons/skin.confluence.lite/720p/defaults.xml
+++ b/addons/skin.confluence.lite/720p/defaults.xml
@@ -1,28 +1,28 @@
 <includes>
 	<default type="image">
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 		<texture>-</texture>
 		<colorkey>0</colorkey>
 	</default>
 	<default type="label">
-		<posx>80</posx>
-		<posy>60</posy>
+		<left>80</left>
+		<top>60</top>
 		<label>-</label>
 		<font>font13</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>grey3</disabledcolor>
 	</default>
 	<default type="fadelabel">
-		<posx>80</posx>
-		<posy>60</posy>
+		<left>80</left>
+		<top>60</top>
 		<font>font13</font>
 		<textcolor>white</textcolor>
 		<disabledcolor>grey3</disabledcolor>
 	</default>
 	<default type="button">
-		<posx>300</posx>
-		<posy>200</posy>
+		<left>300</left>
+		<top>200</top>
 		<width>300</width>
 		<height>42</height>
 		<texturefocus border="5">button-focus.png</texturefocus>
@@ -35,8 +35,8 @@
 		<pulseonselect>no</pulseonselect>
 	</default>
 	<default type="togglebutton">
-		<posx>140</posx>
-		<posy>167</posy>
+		<left>140</left>
+		<top>167</top>
 		<width>20</width>
 		<height>20</height>
 		<texturefocus>scroll-up-focus.png</texturefocus>
@@ -50,8 +50,8 @@
 		<pulseonselect>no</pulseonselect>
 	</default>
 	<default type="textbox">
-		<posx>220</posx>
-		<posy>220</posy>
+		<left>220</left>
+		<top>220</top>
 		<width>410</width>
 		<height>215</height>
 		<align>left</align>
@@ -59,8 +59,8 @@
 		<font>font13</font>
 	</default>
 	<default type="progress">
-		<posx>100</posx>
-		<posy>325</posy>
+		<left>100</left>
+		<top>325</top>
 		<texturebg border="6,0,6,0">OSDProgressBack.png</texturebg>
 		<lefttexture>-</lefttexture>
 		<midtexture border="6,0,6,0">OSDProgressMid.png</midtexture>
@@ -68,8 +68,8 @@
 		<overlaytexture>-</overlaytexture>
 	</default>
 	<default type="spincontrol">
-		<posx>330</posx>
-		<posy>126</posy>
+		<left>330</left>
+		<top>126</top>
 		<textureup>scroll-up-2.png</textureup>
 		<texturedown>scroll-down-2.png</texturedown>
 		<textureupfocus>scroll-up-focus-2.png</textureupfocus>
@@ -88,8 +88,8 @@
 		<pulseonselect>no</pulseonselect>
 	</default>
 	<default type="spincontrolex">
-		<posx>530</posx>
-		<posy>160</posy>
+		<left>530</left>
+		<top>160</top>
 		<width>300</width>
 		<height>42</height>
 		<spinwidth>33</spinwidth>
@@ -109,8 +109,8 @@
 		<pulseonselect>no</pulseonselect>
 	</default>
 	<default type="radiobutton">
-		<posx>300</posx>
-		<posy>200</posy>
+		<left>300</left>
+		<top>200</top>
 		<width>300</width>
 		<height>42</height>
 		<radiowidth>24</radiowidth>
@@ -147,20 +147,20 @@
 		<disabledcolor>grey3</disabledcolor>
 	</default>
 	<default type="mover">
-		<posx>60</posx>
-		<posy>192</posy>
+		<left>60</left>
+		<top>192</top>
 		<texturefocus border="5">button-focus.png</texturefocus>
 		<texturenofocus border="5">button-nofocus.png</texturenofocus>
 	</default>
 	<default type="resize">
-		<posx>60</posx>
-		<posy>192</posy>
+		<left>60</left>
+		<top>192</top>
 		<texturefocus border="5">button-focus.png</texturefocus>
 		<texturenofocus border="5">button-nofocus.png</texturenofocus>
 	</default>
 	<default type="edit">
-		<posx>300</posx>
-		<posy>200</posy>
+		<left>300</left>
+		<top>200</top>
 		<width>300</width>
 		<height>42</height>
 		<texturefocus border="5">button-focus.png</texturefocus>

--- a/addons/skin.confluence.lite/720p/includes.xml
+++ b/addons/skin.confluence.lite/720p/includes.xml
@@ -57,8 +57,8 @@
 	</include>
 	<include name="BehindDialogFadeOut">
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
@@ -68,8 +68,8 @@
 		</control>
 	</include>
 	<include name="WindowTitleCommons">
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 		<width min="0" max="800">auto</width>
 		<height>30</height>
 		<font>font14</font>
@@ -115,8 +115,8 @@
 		<pulseonselect>false</pulseonselect>
 	</include>
 	<include name="HomeSubMenuCommonValues">
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 		<width>1280</width>
 		<height>35</height>
 		<align>center</align>
@@ -144,8 +144,8 @@
 		<animation effect="slide" start="0,0" end="-50,0" time="300" tween="quadratic" easing="out" condition="![ControlGroup(9000).HasFocus | Control.HasFocus(9001)]">WindowClose</animation>
 		<animation effect="slide" start="-50,0" end="0,0" time="300" tween="quadratic" easing="out">WindowOpen</animation>
 		<control type="button" id="9001">
-			<posx>250</posx>
-			<posy>260</posy>
+			<left>250</left>
+			<top>260</top>
 			<width>42</width>
 			<height>128</height>
 			<font>-</font>
@@ -153,16 +153,16 @@
 			<texturenofocus>HasSub.png</texturenofocus>
 		</control>
 		<control type="image">
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>260</width>
 			<height>720</height>
 			<texture border="0,0,10,0">MediaBladeSub.png</texture>
 		</control>
 		<control type="image">
 			<description>LOGO</description>
-			<posx>15</posx>
-			<posy>0</posy>
+			<left>15</left>
+			<top>0</top>
 			<width>220</width>
 			<height>80</height>
 			<aspectratio>keep</aspectratio>
@@ -178,8 +178,8 @@
 			<animation effect="fade" time="250" condition="Window.Next(Home)">WindowClose</animation>
 			<control type="image">
 				<description>Player Icon background</description>
-				<posx>30</posx>
-				<posy>55r</posy>
+				<left>30</left>
+				<top>55r</top>
 				<width>45</width>
 				<height>45</height>
 				<aspectratio>keep</aspectratio>
@@ -187,16 +187,16 @@
 			</control>
 			<control type="image">
 				<description>Player Icon</description>
-				<posx>35</posx>
-				<posy>50r</posy>
+				<left>35</left>
+				<top>50r</top>
 				<width>35</width>
 				<height>35</height>
 				<aspectratio>keep</aspectratio>
 				<texture>icon_player.png</texture>
 			</control>
 			<control type="label">
-				<posx>85</posx>
-				<posy>53r</posy>
+				<left>85</left>
+				<top>53r</top>
 				<width>700</width>
 				<height>20</height>
 				<label>$INFO[MusicPlayer.Title]$INFO[VideoPlayer.Title] - ([COLOR=blue]$INFO[Player.Time] / $INFO[Player.Duration,][/COLOR])</label>
@@ -207,8 +207,8 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="label">
-				<posx>85</posx>
-				<posy>32r</posy>
+				<left>85</left>
+				<top>32r</top>
 				<width>700</width>
 				<height>20</height>
 				<label>$INFO[MusicPlayer.Artist]$INFO[MusicPlayer.Album, - ]</label>
@@ -220,8 +220,8 @@
 				<visible>Player.HasAudio</visible>
 			</control>
 			<control type="label">
-				<posx>85</posx>
-				<posy>30r</posy>
+				<left>85</left>
+				<top>30r</top>
 				<width>700</width>
 				<height>20</height>
 				<label>$INFO[VideoPlayer.Studio]</label>
@@ -233,8 +233,8 @@
 				<visible>Player.HasVideo + VideoPlayer.Content(Movies)</visible>
 			</control>
 			<control type="label">
-				<posx>85</posx>
-				<posy>30r</posy>
+				<left>85</left>
+				<top>30r</top>
 				<width>700</width>
 				<height>20</height>
 				<label>$INFO[VideoPlayer.TVShowTitle]</label>
@@ -246,8 +246,8 @@
 				<visible>Player.HasVideo + VideoPlayer.Content(Episodes)</visible>
 			</control>
 			<control type="label">
-				<posx>85</posx>
-				<posy>30r</posy>
+				<left>85</left>
+				<top>30r</top>
 				<width>700</width>
 				<height>20</height>
 				<label>$INFO[VideoPlayer.Artist]</label>
@@ -264,8 +264,8 @@
 		<control type="group">
 			<control type="label">
 				<description>Page Count Label</description>
-				<posx>40r</posx>
-				<posy>53r</posy>
+				<left>40r</left>
+				<top>53r</top>
 				<width>500</width>
 				<height>20</height>
 				<font>font12</font>
@@ -278,8 +278,8 @@
 			</control>
 			<control type="label">
 				<description>Container Duration Label</description>
-				<posx>40r</posx>
-				<posy>32r</posy>
+				<left>40r</left>
+				<top>32r</top>
 				<width>500</width>
 				<height>20</height>
 				<font>font12</font>
@@ -295,8 +295,8 @@
 	<include name="SmallMusicInfo">
 		<control type="image">
 			<description>gradient</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>500</width>
 			<height>165</height>
 			<colordiffuse>DDFFFFFF</colordiffuse>
@@ -304,16 +304,16 @@
 		</control>
 		<control type="image">
 			<description>Cover image</description>
-			<posx>20</posx>
-			<posy>17</posy>
+			<left>20</left>
+			<top>17</top>
 			<width>130</width>
 			<height>130</height>
 			<texture>$INFO[MusicPlayer.Cover]</texture>
 		</control>
 		<control type="label">
 			<description>Artist label</description>
-			<posx>160</posx>
-			<posy>20</posy>
+			<left>160</left>
+			<top>20</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[MusicPlayer.Artist]</label>
@@ -325,8 +325,8 @@
 		</control>
 		<control type="fadelabel">
 			<description>Title label</description>
-			<posx>160</posx>
-			<posy>43</posy>
+			<left>160</left>
+			<top>43</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[MusicPlayer.Title]</label>
@@ -340,8 +340,8 @@
 		</control>
 		<control type="label">
 			<description>Album Label</description>
-			<posx>160</posx>
-			<posy>70</posy>
+			<left>160</left>
+			<top>70</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[MusicPlayer.Album]$INFO[musicplayer.discnumber, - $LOCALIZE[427]:]</label>
@@ -353,8 +353,8 @@
 		</control>
 		<control type="label">
 			<description>Time Label</description>
-			<posx>160</posx>
-			<posy>95</posy>
+			<left>160</left>
+			<top>95</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[MusicPlayer.Time]$INFO[MusicPlayer.Duration, / ]</label>
@@ -366,8 +366,8 @@
 		</control>
 		<control type="label">
 			<description>Next Label</description>
-			<posx>485</posx>
-			<posy>120</posy>
+			<left>485</left>
+			<top>120</top>
 			<height>30</height>
 			<width>325</width>
 			<label>[COLOR=blue]$LOCALIZE[209] :[/COLOR] $INFO[MusicPlayer.offset(1).Title]</label>
@@ -381,8 +381,8 @@
 	<include name="SmallVideoInfo">
 		<control type="image">
 			<description>gradient</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>500</width>
 			<height>165</height>
 			<colordiffuse>DDFFFFFF</colordiffuse>
@@ -390,8 +390,8 @@
 		</control>
 		<control type="image">
 			<description>Cover image</description>
-			<posx>20</posx>
-			<posy>17</posy>
+			<left>20</left>
+			<top>17</top>
 			<width>130</width>
 			<height>130</height>
 			<aspectratio>keep</aspectratio>
@@ -399,8 +399,8 @@
 		</control>
 		<control type="label">
 			<description>Studio label</description>
-			<posx>160</posx>
-			<posy>20</posy>
+			<left>160</left>
+			<top>20</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Studio]</label>
@@ -413,8 +413,8 @@
 		</control>
 		<control type="label">
 			<description>TV Show Title label</description>
-			<posx>160</posx>
-			<posy>20</posy>
+			<left>160</left>
+			<top>20</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.tvshowtitle]</label>
@@ -427,8 +427,8 @@
 		</control>
 		<control type="fadelabel">
 			<description>Music Video Artist label</description>
-			<posx>160</posx>
-			<posy>20</posy>
+			<left>160</left>
+			<top>20</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Artist]</label>
@@ -443,8 +443,8 @@
 		</control>
 		<control type="fadelabel">
 			<description>Title label</description>
-			<posx>160</posx>
-			<posy>43</posy>
+			<left>160</left>
+			<top>43</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Title]</label>
@@ -458,8 +458,8 @@
 		</control>
 		<control type="label">
 			<description>Genre label</description>
-			<posx>160</posx>
-			<posy>70</posy>
+			<left>160</left>
+			<top>70</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Genre]</label>
@@ -471,8 +471,8 @@
 			<visible>!videoplayer.content(episodes) + !videoplayer.content(musicvideos)</visible>
 		</control>
 		<control type="label">
-			<posx>160</posx>
-			<posy>70</posy>
+			<left>160</left>
+			<top>70</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Album]</label>
@@ -485,8 +485,8 @@
 		</control>
 		<control type="label">
 			<description>Season and Episode label</description>
-			<posx>160</posx>
-			<posy>70</posy>
+			<left>160</left>
+			<top>70</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$LOCALIZE[20373] $INFO[VideoPlayer.Season] - $LOCALIZE[20359] $INFO[VideoPlayer.episode]</label>
@@ -499,8 +499,8 @@
 		</control>
 		<control type="label">
 			<description>Time Label</description>
-			<posx>160</posx>
-			<posy>95</posy>
+			<left>160</left>
+			<top>95</top>
 			<height>30</height>
 			<width>325</width>
 			<label>$INFO[VideoPlayer.Time]$INFO[VideoPlayer.Duration, / ]</label>
@@ -534,8 +534,8 @@
 			<height>45</height>
 			<defaultcontrol always="true">603</defaultcontrol>
 			<control type="button" id="600">
-				<posx>5</posx>
-				<posy>2</posy>
+				<left>5</left>
+				<top>2</top>
 				<width>39</width>
 				<height>39</height>
 				<label>-</label>
@@ -549,8 +549,8 @@
 				<onclick>XBMC.PlayerControl(Previous)</onclick>
 			</control>
 			<control type="button" id="606">
-				<posx>45</posx>
-				<posy>2</posy>
+				<left>45</left>
+				<top>2</top>
 				<width>39</width>
 				<height>39</height>
 				<label>-</label>
@@ -567,8 +567,8 @@
 			<control type="group">
 				<animation effect="slide" start="0,0" end="40,0" time="0" condition="Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo">Conditional</animation>
 				<control type="togglebutton" id="603">
-					<posx>45</posx>
-					<posy>2</posy>
+					<left>45</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -585,8 +585,8 @@
 					<onclick>XBMC.PlayerControl(Play)</onclick>
 				</control>
 				<control type="button" id="601">
-					<posx>85</posx>
-					<posy>2</posy>
+					<left>85</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -601,8 +601,8 @@
 					<onclick>XBMC.PlayerControl(Stop)</onclick>
 				</control>
 				<control type="button" id="607">
-					<posx>125</posx>
-					<posy>2</posy>
+					<left>125</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -617,8 +617,8 @@
 					<visible>Window.IsVisible(MusicPlaylist) | Window.IsVisible(VideoPlaylist) | Player.HasVideo</visible>
 				</control>
 				<control type="button" id="602">
-					<posx>125</posx>
-					<posy>2</posy>
+					<left>125</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -636,8 +636,8 @@
 			<control type="group">
 				<visible>!Window.IsVisible(MusicPlaylist) + !Window.IsVisible(VideoPlaylist) + !Player.HasVideo</visible>
 				<control type="button" id="604">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -651,8 +651,8 @@
 					<onback>50</onback>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatNF.png</texture>
@@ -660,8 +660,8 @@
 					<visible>!Control.HasFocus(604)</visible>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatFO.png</texture>
@@ -669,8 +669,8 @@
 					<visible>Control.HasFocus(604)</visible>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatOneNF.png</texture>
@@ -678,8 +678,8 @@
 					<visible>!Control.HasFocus(604)</visible>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatOneFO.png</texture>
@@ -687,8 +687,8 @@
 					<visible>Control.HasFocus(604)</visible>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatAllNF.png</texture>
@@ -696,8 +696,8 @@
 					<visible>!Control.HasFocus(604)</visible>
 				</control>
 				<control type="image">
-					<posx>165</posx>
-					<posy>2</posy>
+					<left>165</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<texture>OSDRepeatAllFO.png</texture>
@@ -705,8 +705,8 @@
 					<visible>Control.HasFocus(604)</visible>
 				</control>
 				<control type="togglebutton" id="605">
-					<posx>205</posx>
-					<posy>2</posy>
+					<left>205</left>
+					<top>2</top>
 					<width>39</width>
 					<height>39</height>
 					<label>-</label>
@@ -748,18 +748,18 @@
 			<visible>Container.Scrolling + [StringCompare(Container.SortMethod,$LOCALIZE[551]) | StringCompare(Container.SortMethod,$LOCALIZE[561]) | StringCompare(Container.SortMethod,$LOCALIZE[558]) | StringCompare(Container.SortMethod,$LOCALIZE[557]) | StringCompare(Container.SortMethod,$LOCALIZE[556])]</visible>
 			<animation effect="slide" start="0,0" end="0,-60" time="100">Visible</animation>
 			<animation effect="slide" start="0,-60" end="0,0" delay="400" time="100">Hidden</animation>
-			<posx>300r</posx>
-			<posy>720</posy>
+			<left>300r</left>
+			<top>720</top>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>70</width>
 				<height>65</height>
 				<texture border="20,20,20,2">InfoMessagePanel.png</texture>
 			</control>
 			<control type="label">
-				<posx>5</posx>
-				<posy>0</posy>
+				<left>5</left>
+				<top>0</top>
 				<width>65</width>
 				<height>60</height>
 				<align>center</align>
@@ -773,8 +773,8 @@
 	<include name="Clock">
 		<control type="label">
 			<description>Low free memory label</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>1280</width>
 			<height>30</height>
 			<align>center</align>
@@ -787,8 +787,8 @@
 		</control>
 		<control type="label">
 			<description>time label</description>
-			<posx>20r</posx>
-			<posy>5</posy>
+			<left>20r</left>
+			<top>5</top>
 			<width>200</width>
 			<height>30</height>
 			<align>right</align>
@@ -810,8 +810,8 @@
 			<effect type="zoom" start="100" end="70" center="auto" easing="in" tween="quadratic" time="300" />
 			<effect type="fade" start="100" end="0" time="300" />
 		</animation>
-		<posx>0</posx>
-		<posy>190r</posy>
+		<left>0</left>
+		<top>190r</top>
 		<width>1280</width>
 		<height>200</height>
 		<pagecontrol>-</pagecontrol>
@@ -821,8 +821,8 @@
 		<orientation>Horizontal</orientation>
 		<itemlayout height="200" width="182">
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>180</width>
 				<height>120</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
@@ -831,16 +831,16 @@
 				<texture background="true">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>120</posy>
+				<left>5</left>
+				<top>120</top>
 				<width>170</width>
 				<height>110</height>
 				<aspectratio aligny="top">keep</aspectratio>
 				<texture diffuse="diffuse_mirror2.png" flipy="true" background="true">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="label">
-				<posx>91</posx>
-				<posy>125</posy>
+				<left>91</left>
+				<top>125</top>
 				<width>180</width>
 				<height>20</height>
 				<font>font12</font>
@@ -852,8 +852,8 @@
 		</itemlayout>
 		<focusedlayout height="200" width="182">
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>180</width>
 				<height>120</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
@@ -863,8 +863,8 @@
 				<visible>!ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>180</width>
 				<height>120</height>
 				<aspectratio aligny="bottom">keep</aspectratio>
@@ -874,16 +874,16 @@
 				<visible>ControlGroup(9002).HasFocus</visible>
 			</control>
 			<control type="image">
-				<posx>5</posx>
-				<posy>120</posy>
+				<left>5</left>
+				<top>120</top>
 				<width>170</width>
 				<height>110</height>
 				<aspectratio aligny="top">keep</aspectratio>
 				<texture diffuse="diffuse_mirror2.png" flipy="true" background="true">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="label">
-				<posx>91</posx>
-				<posy>125</posy>
+				<left>91</left>
+				<top>125</top>
 				<width>180</width>
 				<height>20</height>
 				<font>font12</font>
@@ -894,8 +894,8 @@
 				<visible>Control.HasFocus(9002)</visible>
 			</control>
 			<control type="label">
-				<posx>91</posx>
-				<posy>125</posy>
+				<left>91</left>
+				<top>125</top>
 				<width>180</width>
 				<height>20</height>
 				<font>font12</font>

--- a/addons/skin.confluence.lite/720p/includes.xml
+++ b/addons/skin.confluence.lite/720p/includes.xml
@@ -839,7 +839,7 @@
 				<texture diffuse="diffuse_mirror2.png" flipy="true" background="true">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="label">
-				<left>91</left>
+				<left>1</left>
 				<top>125</top>
 				<width>180</width>
 				<height>20</height>
@@ -882,7 +882,7 @@
 				<texture diffuse="diffuse_mirror2.png" flipy="true" background="true">$INFO[ListItem.Icon]</texture>
 			</control>
 			<control type="label">
-				<left>91</left>
+				<left>1</left>
 				<top>125</top>
 				<width>180</width>
 				<height>20</height>
@@ -894,7 +894,7 @@
 				<visible>Control.HasFocus(9002)</visible>
 			</control>
 			<control type="label">
-				<left>91</left>
+				<left>1</left>
 				<top>125</top>
 				<width>180</width>
 				<height>20</height>

--- a/addons/skin.confluence.lite/720p/script-Content_Search-main.xml
+++ b/addons/skin.confluence.lite/720p/script-Content_Search-main.xml
@@ -3,15 +3,15 @@
 	<defaultcontrol>9000</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>0</posx>
-		<posy>0</posy>
+		<left>0</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="group" id="100">
 			<include>VisibleFadeEffect</include>
 			<control type="image" id="99">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>720</height>
 				<texture background="true"></texture>
@@ -21,8 +21,8 @@
 				<animation effect="fade" time="200">Hidden</animation>
 			</control>
 			<control type="image">
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>1280</width>
 				<height>720</height>
 				<texture>black-back.png</texture>
@@ -30,8 +30,8 @@
 				<animation effect="fade" time="200">WindowClose</animation>
 			</control>
 			<control type="group">
-				<posx>90</posx>
-				<posy>30</posy>
+				<left>90</left>
+				<top>30</top>
 				<animation type="WindowOpen" reversible="false">
 					<effect type="zoom" start="80" end="100" center="640,360" easing="out" tween="back" time="300" />
 					<effect type="fade" start="0" end="100" time="300" />
@@ -41,31 +41,31 @@
 					<effect type="fade" start="100" end="0" time="300" />
 				</animation>
 				<control type="image">
-					<posx>5</posx>
-					<posy>5</posy>
+					<left>5</left>
+					<top>5</top>
 					<width>1090</width>
 					<height>630</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
-					<posx>5</posx>
-					<posy>5</posy>
+					<left>5</left>
+					<top>5</top>
 					<width>1090</width>
 					<height>630</height>
 					<texture border="15">ContentPanel.png</texture>
 				</control>
 				<control type="image">
 					<description>LOGO</description>
-					<posx>30</posx>
-					<posy>10</posy>
+					<left>30</left>
+					<top>10</top>
 					<width>220</width>
 					<height>80</height>
 					<aspectratio>keep</aspectratio>
 					<texture>Confluence_Logo.png</texture>
 				</control>
 				<control type="list" id="9000">
-					<posx>10</posx>
-					<posy>80</posy>
+					<left>10</left>
+					<top>80</top>
 					<width>260</width>
 					<height>540</height>
 					<onleft>9010</onleft>
@@ -76,15 +76,15 @@
 					<scrolltime>300</scrolltime>
 					<itemlayout height="60" width="260">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>260</width>
 							<height>61</height>
 							<texture border="5">MenuItemNF.png</texture>
 						</control>
 						<control type="label">
-							<posx>250</posx>
-							<posy>4</posy>
+							<left>250</left>
+							<top>4</top>
 							<width>380</width>
 							<height>25</height>
 							<font>font24_title</font>
@@ -94,8 +94,8 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>250</posx>
-							<posy>32</posy>
+							<left>250</left>
+							<top>32</top>
 							<width>870</width>
 							<height>20</height>
 							<font>font13</font>
@@ -107,16 +107,16 @@
 					</itemlayout>
 					<focusedlayout height="60" width="260">
 						<control type="image">
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>260</width>
 							<height>61</height>
 							<texture border="5">MenuItemFO.png</texture>
 							<animation effect="fade" start="100" end="50" time="100" condition="!Control.HasFocus(9000)">Conditional</animation>
 						</control>
 						<control type="label">
-							<posx>250</posx>
-							<posy>4</posy>
+							<left>250</left>
+							<top>4</top>
 							<width>380</width>
 							<height>25</height>
 							<font>font24_title</font>
@@ -126,8 +126,8 @@
 							<label>$INFO[ListItem.Label]</label>
 						</control>
 						<control type="label">
-							<posx>250</posx>
-							<posy>32</posy>
+							<left>250</left>
+							<top>32</top>
 							<width>870</width>
 							<height>20</height>
 							<font>font13</font>
@@ -202,15 +202,15 @@
 					</content>
 				</control>
 				<control type="image">
-					<posx>268</posx>
-					<posy>10</posy>
+					<left>268</left>
+					<top>10</top>
 					<width>790</width>
 					<height>618</height>
 					<texture border="5">black-back2.png</texture>
 				</control>
 				<control type="image">
-					<posx>268</posx>
-					<posy>10</posy>
+					<left>268</left>
+					<top>10</top>
 					<width>804</width>
 					<height>100</height>
 					<aspectratio>stretch</aspectratio>
@@ -218,8 +218,8 @@
 				</control>
 				<control type="label">
 					<description>header label Finished Searching</description>
-					<posx>300</posx>
-					<posy>20</posy>
+					<left>300</left>
+					<top>20</top>
 					<width>740</width>
 					<height>30</height>
 					<font>font16</font>
@@ -232,8 +232,8 @@
 				</control>
 				<control type="label">
 					<description>header Label Still Searching</description>
-					<posx>300</posx>
-					<posy>20</posy>
+					<left>300</left>
+					<top>20</top>
 					<width>740</width>
 					<height>30</height>
 					<font>font16</font>
@@ -246,8 +246,8 @@
 				</control>
 				<control type="label" id="190">
 					<!-- Hide this Control off the screen because we use the label above instead -->
-					<posx>2000</posx>
-					<posy>2000</posy>
+					<left>2000</left>
+					<top>2000</top>
 					<width>100</width>
 					<height>0</height>
 					<label>-</label>
@@ -256,16 +256,16 @@
 				</control>
 				<control type="label" id="191">
 					<!-- Hide this Control off the screen because we use the label above instead -->
-					<posx>2000</posx>
-					<posy>2000</posy>
+					<left>2000</left>
+					<top>2000</top>
 					<width>100</width>
 					<height>0</height>
 					<label>-</label>
 					<font>-</font>
 				</control>
 				<control type="label" id="199">
-					<posx>40</posx>
-					<posy>358</posy>
+					<left>40</left>
+					<top>358</top>
 					<width>1200</width>
 					<height>20</height>
 					<label>[B]$LOCALIZE[284][/B]</label>
@@ -284,12 +284,12 @@
 					<effect type="zoom" start="100" end="80" center="640,360" easing="in" tween="back" time="300" />
 					<effect type="fade" start="100" end="0" time="300" />
 				</animation>
-				<posx>380</posx>
-				<posy>90</posy>
+				<left>380</left>
+				<top>90</top>
 				<control type="button" id="198">
 					<!-- Hide this button  off the screen because we use the list above to pass to it instead -->
-					<posx>2000</posx>
-					<posy>2000</posy>
+					<left>2000</left>
+					<top>2000</top>
 					<width>10</width>
 					<height>10</height>
 					<label>-</label>
@@ -306,14 +306,14 @@
 				</control>
 				<control type="group" id="101">
 					<control type="group" id="119">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="110">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -323,8 +323,8 @@
 						<control type="panel" id="111">
 							<visible>Container(9000).HasFocus(1)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -336,30 +336,30 @@
 							<pagecontrol>118</pagecontrol>
 							<itemlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>50</posx>
-									<posy>70</posy>
+									<left>50</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>265</width>
 									<height>12</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -368,8 +368,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>265</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year),, - ]$INFO[ListItem.Property(Duration),, $LOCALIZE[12391]]</label>
@@ -379,8 +379,8 @@
 									<visible>!SubString(ListItem.Property(Duration),min)</visible>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>265</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year),, - ]$INFO[ListItem.Property(Duration)]</label>
@@ -390,8 +390,8 @@
 									<visible>SubString(ListItem.Property(Duration),min)</visible>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(Tagline)]</label>
@@ -399,8 +399,8 @@
 									<textcolor>white</textcolor>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(PlotOutline)]</label>
@@ -409,8 +409,8 @@
 									<visible>IsEmpty(ListItem.Property(TagLine))</visible>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -421,30 +421,30 @@
 							</itemlayout>
 							<focusedlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>50</posx>
-									<posy>70</posy>
+									<left>50</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>265</width>
 									<height>12</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -453,8 +453,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>265</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year),, - ]$INFO[ListItem.Property(Duration),, $LOCALIZE[12391]]</label>
@@ -464,8 +464,8 @@
 									<visible>!SubString(ListItem.Property(Duration),min)</visible>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>265</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year),, - ]$INFO[ListItem.Property(Duration)]</label>
@@ -475,8 +475,8 @@
 									<visible>SubString(ListItem.Property(Duration),min)</visible>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(Tagline)]</label>
@@ -484,8 +484,8 @@
 									<textcolor>white</textcolor>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(PlotOutline)]</label>
@@ -494,8 +494,8 @@
 									<visible>IsEmpty(ListItem.Property(TagLine))</visible>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>45</posy>
+									<left>100</left>
+									<top>45</top>
 									<width>265</width>
 									<height>75</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -506,8 +506,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="118">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -523,8 +523,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -538,14 +538,14 @@
 
 					</control>
 					<control type="group" id="129">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="120">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -555,8 +555,8 @@
 						<control type="panel" id="121">
 							<visible>Container(9000).HasFocus(2)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -568,30 +568,30 @@
 							<pagecontrol>128</pagecontrol>
 							<itemlayout width="375" height="175">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>170</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>360</width>
 									<height>65</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>330</posx>
-									<posy>70</posy>
+									<left>330</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>187</posx>
-									<posy>75</posy>
+									<left>187</left>
+									<top>75</top>
 									<width>360</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -601,8 +601,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>187</posx>
-									<posy>95</posy>
+									<left>187</left>
+									<top>95</top>
 									<width>360</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Premiered)]</label>
@@ -612,8 +612,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>5</posx>
-									<posy>110</posy>
+									<left>5</left>
+									<top>110</top>
 									<width>360</width>
 									<height>55</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -624,30 +624,30 @@
 							</itemlayout>
 							<focusedlayout width="375" height="175">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>170</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>360</width>
 									<height>65</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>330</posx>
-									<posy>70</posy>
+									<left>330</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>187</posx>
-									<posy>75</posy>
+									<left>187</left>
+									<top>75</top>
 									<width>360</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -657,8 +657,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>187</posx>
-									<posy>95</posy>
+									<left>187</left>
+									<top>95</top>
 									<width>360</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Premiered)]</label>
@@ -668,8 +668,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>5</posx>
-									<posy>110</posy>
+									<left>5</left>
+									<top>110</top>
 									<width>360</width>
 									<height>55</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -680,8 +680,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="128">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -697,8 +697,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -711,14 +711,14 @@
 						</control>
 					</control>
 					<control type="group" id="139">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="130">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -728,8 +728,8 @@
 						<control type="panel" id="131">
 							<visible>Container(9000).HasFocus(3)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -741,22 +741,22 @@
 							<pagecontrol>138</pagecontrol>
 							<itemlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>260</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Label]</label>
@@ -765,8 +765,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>260</width>
 									<height>120</height>
 									<label>$INFO[ListItem.Property(TvShowTitle)]</label>
@@ -776,22 +776,22 @@
 							</itemlayout>
 							<focusedlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>260</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Label]</label>
@@ -800,8 +800,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>100</posx>
-									<posy>30</posy>
+									<left>100</left>
+									<top>30</top>
 									<width>260</width>
 									<height>120</height>
 									<label>$INFO[ListItem.Property(TvShowTitle)]</label>
@@ -811,8 +811,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="138">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -828,8 +828,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -842,14 +842,14 @@
 						</control>
 					</control>
 					<control type="group" id="149">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="140">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -858,8 +858,8 @@
 						</control>
 						<control type="panel" id="141">
 							<visible>Container(9000).HasFocus(4)</visible>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -871,31 +871,31 @@
 							<pagecontrol>148</pagecontrol>
 							<itemlayout width="750" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>150</width>
 									<height>90</height>
 									<aspectratio>scale</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>120</posx>
-									<posy>70</posy>
+									<left>120</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>10</posy>
+									<left>160</left>
+									<top>10</top>
 									<width>585</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -904,8 +904,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>30</posy>
+									<left>160</left>
+									<top>30</top>
 									<width>585</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(TvShowTitle)]</label>
@@ -914,8 +914,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>160</posx>
-									<posy>50</posy>
+									<left>160</left>
+									<top>50</top>
 									<width>585</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -925,31 +925,31 @@
 							</itemlayout>
 							<focusedlayout width="750" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>150</width>
 									<height>90</height>
 									<aspectratio>scale</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>120</posx>
-									<posy>70</posy>
+									<left>120</left>
+									<top>70</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>10</posy>
+									<left>160</left>
+									<top>10</top>
 									<width>585</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -958,8 +958,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>30</posy>
+									<left>160</left>
+									<top>30</top>
 									<width>585</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(TvShowTitle)]</label>
@@ -968,8 +968,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>160</posx>
-									<posy>50</posy>
+									<left>160</left>
+									<top>50</top>
 									<width>585</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Plot)]</label>
@@ -979,8 +979,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="148">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -996,8 +996,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -1010,14 +1010,14 @@
 						</control>
 					</control>
 					<control type="group" id="159">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="150">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -1027,8 +1027,8 @@
 						<control type="panel" id="151">
 							<visible>Container(9000).HasFocus(5)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -1040,30 +1040,30 @@
 							<pagecontrol>158</pagecontrol>
 							<itemlayout width="375" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>101</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>120</width>
 									<height>90</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>100</posx>
-									<posy>65</posy>
+									<left>100</left>
+									<top>65</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>10</posy>
+									<left>135</left>
+									<top>10</top>
 									<width>230</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1072,8 +1072,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>30</posy>
+									<left>135</left>
+									<top>30</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist)]</label>
@@ -1082,8 +1082,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>55</posy>
+									<left>135</left>
+									<top>55</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year)]</label>
@@ -1092,8 +1092,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>75</posy>
+									<left>135</left>
+									<top>75</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Duration)]</label>
@@ -1104,30 +1104,30 @@
 							</itemlayout>
 							<focusedlayout width="375" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>101</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>120</width>
 									<height>90</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="image">
-									<posx>100</posx>
-									<posy>65</posy>
+									<left>100</left>
+									<top>65</top>
 									<width>30</width>
 									<height>30</height>
 									<texture>OverlayWatched.png</texture>
 									<visible>IntegerGreaterThan(ListItem.Property(PlayCount),0)</visible>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>10</posy>
+									<left>135</left>
+									<top>10</top>
 									<width>230</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1136,8 +1136,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>30</posy>
+									<left>135</left>
+									<top>30</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist)]</label>
@@ -1146,8 +1146,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>55</posy>
+									<left>135</left>
+									<top>55</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Year)]</label>
@@ -1156,8 +1156,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>135</posx>
-									<posy>75</posy>
+									<left>135</left>
+									<top>75</top>
 									<width>230</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Duration)]</label>
@@ -1168,8 +1168,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="158">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1185,8 +1185,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -1199,14 +1199,14 @@
 						</control>
 					</control>
 					<control type="group" id="169">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="160">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -1216,8 +1216,8 @@
 						<control type="panel" id="161">
 							<visible>Container(9000).HasFocus(6)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -1229,23 +1229,23 @@
 							<pagecontrol>168</pagecontrol>
 							<itemlayout width="750" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>150</width>
 									<height>90</height>
 									<aspectratio>keep</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>10</posy>
+									<left>160</left>
+									<top>10</top>
 									<width>580</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1254,8 +1254,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>30</posy>
+									<left>160</left>
+									<top>30</top>
 									<width>585</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist_Genre)]</label>
@@ -1264,8 +1264,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>160</posx>
-									<posy>50</posy>
+									<left>160</left>
+									<top>50</top>
 									<width>585</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Artist_Description)]</label>
@@ -1275,23 +1275,23 @@
 							</itemlayout>
 							<focusedlayout width="400" height="110">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>150</width>
 									<height>90</height>
 									<aspectratio>keep</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>10</posy>
+									<left>160</left>
+									<top>10</top>
 									<width>580</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1300,8 +1300,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>160</posx>
-									<posy>30</posy>
+									<left>160</left>
+									<top>30</top>
 									<width>585</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist_Genre)]</label>
@@ -1310,8 +1310,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>160</posx>
-									<posy>50</posy>
+									<left>160</left>
+									<top>50</top>
 									<width>585</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Artist_Description)]</label>
@@ -1321,8 +1321,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="168">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1338,8 +1338,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -1352,14 +1352,14 @@
 						</control>
 					</control>
 					<control type="group" id="179">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="170">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -1369,8 +1369,8 @@
 						<control type="panel" id="171">
 							<visible>Container(9000).HasFocus(7)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -1382,23 +1382,23 @@
 							<pagecontrol>178</pagecontrol>
 							<itemlayout width="750" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>100</width>
 									<height>90</height>
 									<aspectratio>keep</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>10</posy>
+									<left>110</left>
+									<top>10</top>
 									<width>630</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1407,8 +1407,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>30</posy>
+									<left>110</left>
+									<top>30</top>
 									<width>630</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist]</label>
@@ -1417,8 +1417,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>110</posx>
-									<posy>50</posy>
+									<left>110</left>
+									<top>50</top>
 									<width>630</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Album_Description)]</label>
@@ -1428,23 +1428,23 @@
 							</itemlayout>
 							<focusedlayout width="400" height="110">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>750</width>
 									<height>101</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>100</width>
 									<height>90</height>
 									<aspectratio>keep</aspectratio>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>10</posy>
+									<left>110</left>
+									<top>10</top>
 									<width>630</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1453,8 +1453,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>30</posy>
+									<left>110</left>
+									<top>30</top>
 									<width>630</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist)]</label>
@@ -1463,8 +1463,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="textbox">
-									<posx>110</posx>
-									<posy>50</posy>
+									<left>110</left>
+									<top>50</top>
 									<width>630</width>
 									<height>45</height>
 									<label>$INFO[ListItem.Property(Album_Description)]</label>
@@ -1474,8 +1474,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="178">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1491,8 +1491,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -1505,14 +1505,14 @@
 						</control>
 					</control>
 					<control type="group" id="189">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="180">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -1522,8 +1522,8 @@
 						<control type="panel" id="181">
 							<visible>Container(9000).HasFocus(8)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -1535,22 +1535,22 @@
 							<pagecontrol>188</pagecontrol>
 							<itemlayout width="375" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>101</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>90</width>
 									<height>90</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>10</posy>
+									<left>110</left>
+									<top>10</top>
 									<width>255</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1559,8 +1559,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>30</posy>
+									<left>110</left>
+									<top>30</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist)]</label>
@@ -1569,8 +1569,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>50</posy>
+									<left>110</left>
+									<top>50</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Genre)]</label>
@@ -1579,8 +1579,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>75</posy>
+									<left>110</left>
+									<top>75</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Duration)]</label>
@@ -1591,22 +1591,22 @@
 							</itemlayout>
 							<focusedlayout width="375" height="106">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>101</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>90</width>
 									<height>90</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>10</posy>
+									<left>110</left>
+									<top>10</top>
 									<width>255</width>
 									<height>15</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1615,8 +1615,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>30</posy>
+									<left>110</left>
+									<top>30</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Artist)]</label>
@@ -1625,8 +1625,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>50</posy>
+									<left>110</left>
+									<top>50</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Genre)]</label>
@@ -1635,8 +1635,8 @@
 									<aligny>center</aligny>
 								</control>
 								<control type="label">
-									<posx>110</posx>
-									<posy>75</posy>
+									<left>110</left>
+									<top>75</top>
 									<width>255</width>
 									<height>15</height>
 									<label>$INFO[ListItem.Property(Duration)]</label>
@@ -1647,8 +1647,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="188">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1664,8 +1664,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>
@@ -1678,14 +1678,14 @@
 						</control>
 					</control>
 					<control type="group" id="209">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>750</width>
 						<height>530</height>
 						<control type="label" id="200">
 							<!-- Hide this Control off the screen because we use the list above to pass to it instead -->
-							<posx>2000</posx>
-							<posy>2000</posy>
+							<left>2000</left>
+							<top>2000</top>
 							<width>100</width>
 							<height>0</height>
 							<label>-</label>
@@ -1695,8 +1695,8 @@
 						<control type="panel" id="201">
 							<visible>Container(9000).HasFocus(9)</visible>
 							<include>VisibleFadeEffect</include>
-							<posx>0</posx>
-							<posy>0</posy>
+							<left>0</left>
+							<top>0</top>
 							<width>750</width>
 							<height>530</height>
 							<onleft>9000</onleft>
@@ -1708,22 +1708,22 @@
 							<pagecontrol>118</pagecontrol>
 							<itemlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-nofocus.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>265</width>
 									<height>12</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1734,22 +1734,22 @@
 							</itemlayout>
 							<focusedlayout width="375" height="130">
 								<control type="image">
-									<posx>0</posx>
-									<posy>0</posy>
+									<left>0</left>
+									<top>0</top>
 									<width>370</width>
 									<height>125</height>
 									<texture border="5">button-focus2.png</texture>
 								</control>
 								<control type="image">
-									<posx>5</posx>
-									<posy>5</posy>
+									<left>5</left>
+									<top>5</top>
 									<width>80</width>
 									<height>115</height>
 									<texture background="true">$INFO[ListItem.Icon]</texture>
 								</control>
 								<control type="label">
-									<posx>100</posx>
-									<posy>10</posy>
+									<left>100</left>
+									<top>10</top>
 									<width>265</width>
 									<height>12</height>
 									<label>[B]$INFO[ListItem.Label][/B]</label>
@@ -1760,8 +1760,8 @@
 							</focusedlayout>
 						</control>
 						<control type="scrollbar" id="208">
-							<posx>770</posx>
-							<posy>0</posy>
+							<left>770</left>
+							<top>0</top>
 							<width>25</width>
 							<height>530</height>
 							<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -1777,8 +1777,8 @@
 						</control>
 						<control type="label">
 							<description>number of files/pages in list text label</description>
-							<posx>750</posx>
-							<posy>530</posy>
+							<left>750</left>
+							<top>530</top>
 							<width>500</width>
 							<height>35</height>
 							<font>font12</font>

--- a/addons/skin.confluence.lite/720p/script-RSS_Editor-rssEditor.xml
+++ b/addons/skin.confluence.lite/720p/script-RSS_Editor-rssEditor.xml
@@ -2,31 +2,31 @@
 	<defaultcontrol>10</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>140</posy>
+		<left>240</left>
+		<top>140</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>420</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label" id="2">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -37,8 +37,8 @@
 		</control>
 		<control type="label" id="3">
 			<description>List label</description>
-			<posx>20</posx>
-			<posy>65</posy>
+			<left>20</left>
+			<top>65</top>
 			<width>760</width>
 			<height>30</height>
 			<align>center</align>
@@ -48,8 +48,8 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="list" id="10">
-			<posx>30</posx>
-			<posy>105</posy>
+			<left>30</left>
+			<top>105</top>
 			<width>520</width>
 			<height>225</height>
 			<onup>9001</onup>
@@ -60,15 +60,15 @@
 			<scrolltime>200</scrolltime>
 			<itemlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>500</width>
 					<height>40</height>
 					<font>font13</font>
@@ -81,24 +81,24 @@
 			</itemlayout>
 			<focusedlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<visible>!Control.HasFocus(10)</visible>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<visible>Control.hasfocus(14) | Control.HasFocus(10)</visible>
 					<texture border="5">button-focus2.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>500</width>
 					<height>40</height>
 					<font>font13</font>
@@ -110,8 +110,8 @@
 			</focusedlayout>
 		</control>
 		<control type="scrollbar" id="60">
-			<posx>552</posx>
-			<posy>105</posy>
+			<left>552</left>
+			<top>105</top>
 			<width>25</width>
 			<height>225</height>
 			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -125,12 +125,12 @@
 			<orientation>vertical</orientation>
 		</control>
 		<control type="group" id="9000">
-			<posx>580</posx>
-			<posy>105</posy>
+			<left>580</left>
+			<top>105</top>
 			<control type="button" id="11">
 				<description>Change Set Button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -143,8 +143,8 @@
 			</control>
 			<control type="button" id="13">
 				<description>Add Button</description>
-				<posx>0</posx>
-				<posy>45</posy>
+				<left>0</left>
+				<top>45</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -158,8 +158,8 @@
 			</control>
 			<control type="button" id="14">
 				<description>Remove Button</description>
-				<posx>0</posx>
-				<posy>90</posy>
+				<left>0</left>
+				<top>90</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -175,8 +175,8 @@
 		<control type="group" id="9001">
 			<control type="button" id="18">
 				<description>Ok Button</description>
-				<posx>200</posx>
-				<posy>355</posy>
+				<left>200</left>
+				<top>355</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -190,8 +190,8 @@
 			</control>
 			<control type="button" id="19">
 				<description>Cancel Button</description>
-				<posx>410</posx>
-				<posy>355</posy>
+				<left>410</left>
+				<top>355</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/script-RSS_Editor-setEditor.xml
+++ b/addons/skin.confluence.lite/720p/script-RSS_Editor-setEditor.xml
@@ -2,31 +2,31 @@
 	<defaultcontrol>10</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>240</posx>
-		<posy>140</posy>
+		<left>240</left>
+		<top>140</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
 			<description>background image</description>
-			<posx>0</posx>
-			<posy>0</posy>
+			<left>0</left>
+			<top>0</top>
 			<width>800</width>
 			<height>420</height>
 			<texture border="40">DialogBack.png</texture>
 		</control>
 		<control type="image">
 			<description>Dialog Header image</description>
-			<posx>40</posx>
-			<posy>16</posy>
+			<left>40</left>
+			<top>16</top>
 			<width>720</width>
 			<height>40</height>
 			<texture>dialogheader.png</texture>
 		</control>
 		<control type="label" id="2">
 			<description>header label</description>
-			<posx>40</posx>
-			<posy>20</posy>
+			<left>40</left>
+			<top>20</top>
 			<width>720</width>
 			<height>30</height>
 			<font>font13_title</font>
@@ -37,8 +37,8 @@
 		</control>
 		<control type="label" id="3">
 			<description>List label</description>
-			<posx>20</posx>
-			<posy>65</posy>
+			<left>20</left>
+			<top>65</top>
 			<width>760</width>
 			<height>30</height>
 			<align>center</align>
@@ -48,8 +48,8 @@
 			<shadowcolor>black</shadowcolor>
 		</control>
 		<control type="list" id="10">
-			<posx>30</posx>
-			<posy>105</posy>
+			<left>30</left>
+			<top>105</top>
 			<width>520</width>
 			<height>225</height>
 			<onup>9001</onup>
@@ -60,15 +60,15 @@
 			<scrolltime>200</scrolltime>
 			<itemlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>500</width>
 					<height>40</height>
 					<font>font13</font>
@@ -81,24 +81,24 @@
 			</itemlayout>
 			<focusedlayout height="45">
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<visible>!Control.HasFocus(10)</visible>
 					<texture border="5">button-nofocus.png</texture>
 				</control>
 				<control type="image">
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>520</width>
 					<height>40</height>
 					<visible>Control.hasfocus(14) | Control.HasFocus(10)</visible>
 					<texture border="5">button-focus2.png</texture>
 				</control>
 				<control type="label">
-					<posx>10</posx>
-					<posy>0</posy>
+					<left>10</left>
+					<top>0</top>
 					<width>500</width>
 					<height>40</height>
 					<font>font13</font>
@@ -110,8 +110,8 @@
 			</focusedlayout>
 		</control>
 		<control type="scrollbar" id="60">
-			<posx>552</posx>
-			<posy>105</posy>
+			<left>552</left>
+			<top>105</top>
 			<width>25</width>
 			<height>225</height>
 			<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -125,12 +125,12 @@
 			<orientation>vertical</orientation>
 		</control>
 		<control type="group" id="9000">
-			<posx>580</posx>
-			<posy>105</posy>
+			<left>580</left>
+			<top>105</top>
 			<control type="button" id="11">
 				<description>Change Set Button</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -143,8 +143,8 @@
 			</control>
 			<control type="button" id="13">
 				<description>Add Button</description>
-				<posx>0</posx>
-				<posy>45</posy>
+				<left>0</left>
+				<top>45</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -158,8 +158,8 @@
 			</control>
 			<control type="button" id="14">
 				<description>Remove Button</description>
-				<posx>0</posx>
-				<posy>90</posy>
+				<left>0</left>
+				<top>90</top>
 				<width>200</width>
 				<height>40</height>
 				<font>font12_title</font>
@@ -175,8 +175,8 @@
 		<control type="group" id="9001">
 			<control type="button" id="18">
 				<description>Ok Button</description>
-				<posx>200</posx>
-				<posy>355</posy>
+				<left>200</left>
+				<top>355</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>
@@ -190,8 +190,8 @@
 			</control>
 			<control type="button" id="19">
 				<description>Cancel Button</description>
-				<posx>410</posx>
-				<posy>355</posy>
+				<left>410</left>
+				<top>355</top>
 				<width>200</width>
 				<height>40</height>
 				<align>center</align>

--- a/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-main.xml
+++ b/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-main.xml
@@ -3,8 +3,8 @@
 	<defaultcontrol always="false">101</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>680</posx>
-		<posy>0</posy>
+		<left>680</left>
+		<top>0</top>
 	</coordinates>
 	<controls>
 		<control type="group">
@@ -13,8 +13,8 @@
 			<animation effect="slide" start="0,0" end="600,0" time="200" tween="quadratic" easing="out">WindowClose</animation>
 			<control type="image">
 				<description>media info background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>600</width>
 				<height>720</height>
 				<colordiffuse>BBFFFFFF</colordiffuse>
@@ -22,8 +22,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>580</posx>
-				<posy>30</posy>
+				<left>580</left>
+				<top>30</top>
 				<width>550</width>
 				<height>30</height>
 				<font>font30_title</font>
@@ -35,8 +35,8 @@
 			</control>
 			<control type="label">
 				<description>Artist label</description>
-				<posx>580</posx>
-				<posy>60</posy>
+				<left>580</left>
+				<top>60</top>
 				<width>550</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -48,8 +48,8 @@
 			</control>
 			<control type="label">
 				<description>Song label</description>
-				<posx>580</posx>
-				<posy>85</posy>
+				<left>580</left>
+				<top>85</top>
 				<width>550</width>
 				<height>30</height>
 				<font>font13_title</font>
@@ -60,8 +60,8 @@
 				<shadowcolor>black</shadowcolor>
 			</control>
 			<control type="image">
-				<posx>30</posx>
-				<posy>120</posy>
+				<left>30</left>
+				<top>120</top>
 				<width>550</width>
 				<height>4</height>
 				<texture>separator.png</texture>
@@ -69,8 +69,8 @@
 			<!-- ** Required ** Do not change <id> or <type> (Text box for lyrics) -->
 			<control type="textbox" id="100">
 				<description>textarea</description>
-				<posx>30</posx>
-				<posy>130</posy>
+				<left>30</left>
+				<top>130</top>
 				<width>550</width>
 				<height>500</height>
 				<align>center</align>
@@ -85,8 +85,8 @@
 			</control>
 			<control type="spincontrol" id="101">
 				<description>Next page button</description>
-				<posx>520</posx>
-				<posy>650</posy>
+				<left>520</left>
+				<top>650</top>
 				<subtype>page</subtype>
 				<font>font12</font>
 				<onleft>101</onleft>
@@ -99,8 +99,8 @@
 			</control>
 			<!-- ** Required ** Do not change <id> or <type> (Smooth scrolling list for lyrics) -->
 			<control type="list" id="110">
-				<posx>30</posx>
-				<posy>130</posy>
+				<left>30</left>
+				<top>130</top>
 				<width>550</width>
 				<height>500</height>
 				<onleft>111</onleft>
@@ -111,8 +111,8 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="25">
 					<control type="label">
-						<posx>275</posx>
-						<posy>0</posy>
+						<left>275</left>
+						<top>0</top>
 						<width>550</width>
 						<height>25</height>
 						<font>font13</font>
@@ -125,8 +125,8 @@
 				</itemlayout>
 				<focusedlayout height="25">
 					<control type="label">
-						<posx>275</posx>
-						<posy>0</posy>
+						<left>275</left>
+						<top>0</top>
 						<width>550</width>
 						<height>25</height>
 						<font>font13</font>
@@ -140,8 +140,8 @@
 						<visible>!Control.HasFocus(110)</visible>
 					</control>
 					<control type="label">
-						<posx>275</posx>
-						<posy>0</posy>
+						<left>275</left>
+						<top>0</top>
 						<width>550</width>
 						<height>25</height>
 						<font>font13</font>
@@ -157,8 +157,8 @@
 			</control>
 			<control type="spincontrol" id="111">
 				<description>Next page button</description>
-				<posx>520</posx>
-				<posy>650</posy>
+				<left>520</left>
+				<top>650</top>
 				<subtype>page</subtype>
 				<font>font12</font>
 				<onleft>110</onleft>
@@ -171,8 +171,8 @@
 			</control>
 			<control type="label" id="2">
 				<description>Pick label</description>
-				<posx>30</posx>
-				<posy>130</posy>
+				<left>30</left>
+				<top>130</top>
 				<width>550</width>
 				<height>30</height>
 				<align>center</align>
@@ -184,8 +184,8 @@
 			</control>
 			<!-- ** Required ** Do not change <id> or <type> (Song Chooser if it gets it wrong) -->
 			<control type="list" id="120">
-				<posx>30</posx>
-				<posy>170</posy>
+				<left>30</left>
+				<top>170</top>
 				<width>550</width>
 				<height>440</height>
 				<onleft>121</onleft>
@@ -197,15 +197,15 @@
 				<animation effect="slide" start="0,0" end="20,0" time="0" condition="!Control.IsVisible(121)">Conditional</animation>
 				<itemlayout height="40">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>41</height>
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>530</width>
 						<height>40</height>
 						<font>font13</font>
@@ -217,24 +217,24 @@
 				</itemlayout>
 				<focusedlayout height="40">
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>41</height>
 						<visible>!Control.HasFocus(120)</visible>
 						<texture border="5">MenuItemNF.png</texture>
 					</control>
 					<control type="image">
-						<posx>0</posx>
-						<posy>0</posy>
+						<left>0</left>
+						<top>0</top>
 						<width>550</width>
 						<height>41</height>
 						<visible>Control.HasFocus(120)</visible>
 						<texture border="5">MenuItemFO.png</texture>
 					</control>
 					<control type="label">
-						<posx>10</posx>
-						<posy>0</posy>
+						<left>10</left>
+						<top>0</top>
 						<width>530</width>
 						<height>40</height>
 						<font>font13</font>
@@ -247,8 +247,8 @@
 			</control>
 			<control type="spincontrol" id="121">
 				<description>Next page button</description>
-				<posx>520</posx>
-				<posy>650</posy>
+				<left>520</left>
+				<top>650</top>
 				<subtype>page</subtype>
 				<font>font12</font>
 				<onleft>120</onleft>
@@ -260,16 +260,16 @@
 				<visible>Control.IsVisible(120)</visible>
 			</control>
 			<control type="image">
-				<posx>30</posx>
-				<posy>640</posy>
+				<left>30</left>
+				<top>640</top>
 				<width>550</width>
 				<height>4</height>
 				<texture>separator.png</texture>
 			</control>
 			<control type="label">
 				<description>Scraper label</description>
-				<posx>580</posx>
-				<posy>680</posy>
+				<left>580</left>
+				<top>680</top>
 				<width>550</width>
 				<height>30</height>
 				<label>$LOCALIZE[31205] - $INFO[Control.GetLabel(200)]</label>

--- a/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-main.xml
+++ b/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-main.xml
@@ -111,7 +111,7 @@
 				<scrolltime>200</scrolltime>
 				<itemlayout height="25">
 					<control type="label">
-						<left>275</left>
+						<left>0</left>
 						<top>0</top>
 						<width>550</width>
 						<height>25</height>
@@ -125,7 +125,7 @@
 				</itemlayout>
 				<focusedlayout height="25">
 					<control type="label">
-						<left>275</left>
+						<left>0</left>
 						<top>0</top>
 						<width>550</width>
 						<height>25</height>
@@ -140,7 +140,7 @@
 						<visible>!Control.HasFocus(110)</visible>
 					</control>
 					<control type="label">
-						<left>275</left>
+						<left>0</left>
 						<top>0</top>
 						<width>550</width>
 						<height>25</height>

--- a/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-settings.xml
+++ b/addons/skin.confluence.lite/720p/script-XBMC_Lyrics-settings.xml
@@ -2,14 +2,14 @@
 	<defaultcontrol>201</defaultcontrol>
 	<coordinates>
 		<system>1</system>
-		<posx>220</posx>
-		<posy>85</posy>
+		<left>220</left>
+		<top>85</top>
 	</coordinates>
 	<include>dialogeffect</include>
 	<controls>
 		<control type="image">
-			<posx>-220</posx>
-			<posy>-85</posy>
+			<left>-220</left>
+			<top>-85</top>
 			<width>1280</width>
 			<height>720</height>
 			<texture>black-back.png</texture>
@@ -21,22 +21,22 @@
 			<include>VisibleFadeEffect</include>
 			<control type="image">
 				<description>background image</description>
-				<posx>0</posx>
-				<posy>0</posy>
+				<left>0</left>
+				<top>0</top>
 				<width>840</width>
 				<height>550</height>
 				<texture border="40">DialogBack.png</texture>
 			</control>
 			<control type="image">
-				<posx>230</posx>
-				<posy>10</posy>
+				<left>230</left>
+				<top>10</top>
 				<width>570</width>
 				<height>528</height>
 				<texture border="5">black-back2.png</texture>
 			</control>
 			<control type="image">
-				<posx>230</posx>
-				<posy>10</posy>
+				<left>230</left>
+				<top>10</top>
 				<width>570</width>
 				<height>100</height>
 				<aspectratio>stretch</aspectratio>
@@ -44,8 +44,8 @@
 			</control>
 			<control type="label">
 				<description>header label</description>
-				<posx>240</posx>
-				<posy>20</posy>
+				<left>240</left>
+				<top>20</top>
 				<width>550</width>
 				<height>30</height>
 				<font>font24_title</font>
@@ -57,8 +57,8 @@
 			</control>
 			<control type="label" id="30">
 				<description>Version label</description>
-				<posx>790</posx>
-				<posy>23</posy>
+				<left>790</left>
+				<top>23</top>
 				<width>300</width>
 				<height>30</height>
 				<font>font10</font>
@@ -70,8 +70,8 @@
 			</control>
 			<!-- ** Required ** Do not change id's or type's -->
 			<control type="scrollbar" id="60">
-				<posx>803</posx>
-				<posy>70</posy>
+				<left>803</left>
+				<top>70</top>
 				<width>25</width>
 				<height>440</height>
 				<texturesliderbackground border="0,14,0,14">ScrollBarV.png</texturesliderbackground>
@@ -85,8 +85,8 @@
 				<orientation>vertical</orientation>
 			</control>
 			<control type="grouplist" id="9000">
-				<posx>230</posx>
-				<posy>70</posy>
+				<left>230</left>
+				<top>70</top>
 				<width>570</width>
 				<height>440</height>
 				<itemgap>-1</itemgap>
@@ -97,8 +97,8 @@
 				<ondown>9000</ondown>
 				<control type="button" id="201">
 					<description>Setting1 Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>570</width>
 					<height>40</height>
 					<font>font13</font>
@@ -128,8 +128,8 @@
 				</control>
 				<control type="button" id="203">
 					<description>Setting2 Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>570</width>
 					<height>40</height>
 					<label>$LOCALIZE[SCRIPT203]</label>
@@ -213,8 +213,8 @@
 				</control>
 				<control type="button" id="207">
 					<description>Setting7 Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>570</width>
 					<height>40</height>
 					<label>$LOCALIZE[SCRIPT207]</label>
@@ -232,8 +232,8 @@
 				</control>
 				<control type="button" id="208">
 					<description>Setting8 Button</description>
-					<posx>0</posx>
-					<posy>0</posy>
+					<left>0</left>
+					<top>0</top>
 					<width>570</width>
 					<height>40</height>
 					<label>$LOCALIZE[SCRIPT208]</label>
@@ -258,12 +258,12 @@
 			</control>
 			<!-- ** Required ** Do not change id's or type's -->
 			<control type="group" id="2000">
-				<posx>10</posx>
-				<posy>20</posy>
+				<left>10</left>
+				<top>20</top>
 				<control type="image">
 					<description>LOGO</description>
-					<posx>0</posx>
-					<posy>10</posy>
+					<left>0</left>
+					<top>10</top>
 					<width>220</width>
 					<height>80</height>
 					<aspectratio>keep</aspectratio>
@@ -271,8 +271,8 @@
 				</control>
 				<control type="button" id="250">
 					<description>OK button</description>
-					<posx>0</posx>
-					<posy>90</posy>
+					<left>0</left>
+					<top>90</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT250]</label>
@@ -287,8 +287,8 @@
 				</control>
 				<control type="button" id="251">
 					<description>Cancel button</description>
-					<posx>0</posx>
-					<posy>140</posy>
+					<left>0</left>
+					<top>140</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT251]</label>
@@ -303,8 +303,8 @@
 				</control>
 				<control type="button" id="252">
 					<description>Update button</description>
-					<posx>0</posx>
-					<posy>190</posy>
+					<left>0</left>
+					<top>190</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT252]</label>
@@ -319,8 +319,8 @@
 				</control>
 				<control type="button" id="254">
 					<description>Play button</description>
-					<posx>0</posx>
-					<posy>240</posy>
+					<left>0</left>
+					<top>240</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT254]</label>
@@ -335,8 +335,8 @@
 				</control>
 				<control type="button" id="255">
 					<description>Defaults button</description>
-					<posx>0</posx>
-					<posy>290</posy>
+					<left>0</left>
+					<top>290</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT255]</label>
@@ -351,8 +351,8 @@
 				</control>
 				<control type="button" id="253">
 					<description>Credits button</description>
-					<posx>0</posx>
-					<posy>340</posy>
+					<left>0</left>
+					<top>340</top>
 					<width>215</width>
 					<height>51</height>
 					<label>$LOCALIZE[SCRIPT253]</label>


### PR DESCRIPTION
- This is backport of [#4772](https://github.com/xbmc/xbmc/pull/4772)

This PR do follow things:
1. Replaced old legacy `<posx>`/`<posy>` with `<top>`/`<left>`
2. Adjustments to image scaling and label positioning after removing some legacy things in GUILIB