### PR TITLE
[Addons Framework] allow browsing new repositories from Kodi

### DIFF
--- a/xbmc/addons/AddonInstaller.cpp
+++ b/xbmc/addons/AddonInstaller.cpp
@@ -196,11 +196,10 @@ bool CAddonInstaller::InstallOrUpdate(const std::string &addonID, bool backgroun
 {
   AddonPtr addon;
   RepositoryPtr repo;
-  std::string hash;
-  if (!CAddonInstallJob::GetAddonWithHash(addonID, repo, addon, hash))
+  if (!CAddonInstallJob::GetAddon(addonID, repo, addon))
     return false;
 
-  return DoInstall(addon, repo, hash, background, modal);
+  return DoInstall(addon, repo, background, modal);
 }
 
 void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& version, const std::string& repoId)
@@ -218,22 +217,17 @@ void CAddonInstaller::Install(const std::string& addonId, const AddonVersion& ve
   if (!CServiceBroker::GetAddonMgr().GetAddon(repoId, repo, ADDON_REPOSITORY))
     return;
 
-  std::string hash;
-  if (!boost::static_pointer_cast<CRepository>(repo)->GetAddonHash(addon, hash))
-    return;
-  DoInstall(addon, boost::static_pointer_cast<CRepository>(repo), hash, true, false);
+  DoInstall(addon, boost::static_pointer_cast<CRepository>(repo), true, false);
 }
 
-bool CAddonInstaller::DoInstall(const AddonPtr &addon, const RepositoryPtr& repo,
-    const std::string &hash /* = "" */, bool background /* = true */, bool modal /* = false */,
-    bool autoUpdate /* = false*/)
+bool CAddonInstaller::DoInstall(const AddonPtr &addon, const RepositoryPtr& repo, bool background /* = true */, bool modal /* = false */, bool autoUpdate /* = false*/)
 {
   // check whether we already have the addon installing
   CSingleLock lock(m_critSection);
   if (m_downloadJobs.find(addon->ID()) != m_downloadJobs.end())
     return false;
 
-  CAddonInstallJob* installJob = new CAddonInstallJob(addon, repo, hash, autoUpdate);
+  CAddonInstallJob* installJob = new CAddonInstallJob(addon, repo, autoUpdate);
   if (background)
   {
     // Workaround: because CAddonInstallJob is blocking waiting for other jobs, it needs to be run
@@ -427,9 +421,8 @@ void CAddonInstaller::InstallUpdates()
     {
       AddonPtr toInstall;
       RepositoryPtr repo;
-      std::string hash;
-      if (CAddonInstallJob::GetAddonWithHash(addon->ID(), repo, toInstall, hash))
-        DoInstall(toInstall, repo, hash, true, false, true);
+      if (CAddonInstallJob::GetAddon(addon->ID(), repo, toInstall))
+        DoInstall(toInstall, repo, true, false, true);
     }
   }
 }
@@ -467,19 +460,17 @@ int64_t CAddonInstaller::EnumeratePackageFolder(std::map<std::string,CFileItemLi
   return size;
 }
 
-CAddonInstallJob::CAddonInstallJob(const AddonPtr &addon, const AddonPtr &repo,
-    const std::string &hash, bool isAutoUpdate)
+CAddonInstallJob::CAddonInstallJob(const AddonPtr &addon, const RepositoryPtr &repo, bool isAutoUpdate)
   : m_addon(addon),
     m_repo(repo),
-    m_hash(hash),
     m_isAutoUpdate(isAutoUpdate)
 {
   AddonPtr dummy;
   m_isUpdate = CServiceBroker::GetAddonMgr().GetAddon(addon->ID(), dummy, ADDON_UNKNOWN, false);
 }
 
-bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, RepositoryPtr& repo,
-    ADDON::AddonPtr& addon, std::string& hash)
+bool CAddonInstallJob::GetAddon(const std::string& addonID, RepositoryPtr& repo,
+    ADDON::AddonPtr& addon)
 {
   if (!CServiceBroker::GetAddonMgr().FindInstallableById(addonID, addon))
     return false;
@@ -489,7 +480,8 @@ bool CAddonInstallJob::GetAddonWithHash(const std::string& addonID, RepositoryPt
     return false;
 
   repo = boost::static_pointer_cast<CRepository>(tmp);
-  return repo->GetAddonHash(addon, hash);
+
+  return true;
 }
 
 bool CAddonInstallJob::DoWork()
@@ -517,12 +509,27 @@ bool CAddonInstallJob::DoWork()
     std::string dest = "special://home/addons/packages/";
     std::string package = URIUtils::AddFileToFolder("special://home/addons/packages/",
                                                     URIUtils::GetFileName(m_addon->Path()));
-    if (URIUtils::HasSlashAtEnd(m_addon->Path()))
+    if (!m_repo && URIUtils::HasSlashAtEnd(m_addon->Path()))
     { // passed in a folder - all we need do is copy it across
       installFrom = m_addon->Path();
     }
     else
     {
+      std::string path(m_addon->Path());
+      std::string hash;
+      if (m_repo)
+      {
+        CRepository::ResolveResult resolvedAddon = m_repo->ResolvePathAndHash(m_addon);
+        path = resolvedAddon.location;
+        hash = resolvedAddon.hash;
+        if (path.empty())
+        {
+          CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to resolve addon install source path", m_addon->ID().c_str());
+          ReportInstallError(m_addon->ID(), m_addon->ID());
+          return false;
+        }
+      }
+
       CAddonDatabase db;
       if (!db.Open())
       {
@@ -531,13 +538,16 @@ bool CAddonInstallJob::DoWork()
         return false;
       }
 
-      std::string md5;
       // check that we don't already have a valid copy
-      if (!m_hash.empty() && CFile::Exists(package))
+      if (!hash.empty())
       {
-        if (db.GetPackageHash(m_addon->ID(), package, md5) && m_hash != md5)
+        std::string hashExisting;
+        if (db.GetPackageHash(m_addon->ID(), package, hashExisting) && hash != hashExisting)
         {
           db.RemovePackage(package);
+        }
+        if (CFile::Exists(package))
+        {
           CFile::Delete(package);
         }
       }
@@ -545,7 +555,6 @@ bool CAddonInstallJob::DoWork()
       // zip passed in - download + extract
       if (!CFile::Exists(package))
       {
-        std::string path(m_addon->Path());
         if (!DownloadPackage(path, dest))
         {
           CFile::Delete(package);
@@ -558,15 +567,15 @@ bool CAddonInstallJob::DoWork()
 
       // at this point we have the package - check that it is valid
       SetText(g_localizeStrings.Get(24077));
-      if (!m_hash.empty())
+      if (!hash.empty())
       {
-        md5 = CUtil::GetFileMD5(package);
-        if (!StringUtils::EqualsNoCase(md5, m_hash))
+        std::string md5 = CUtil::GetFileMD5(package);
+        if (!StringUtils::EqualsNoCase(md5, hash))
         {
           CFile::Delete(package);
 
           CLog::Log(LOGERROR, "CAddonInstallJob[%s]: MD5 mismatch after download. Expected %s, was %s",
-              m_addon->ID().c_str(), m_hash.c_str(), md5.c_str());
+              m_addon->ID().c_str(), hash.c_str(), md5.c_str());
           ReportInstallError(m_addon->ID(), URIUtils::GetFileName(package));
           return false;
         }
@@ -684,7 +693,7 @@ bool CAddonInstallJob::DoFileOperation(FileAction action, CFileItemList &items, 
   return result;
 }
 
-bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& repo)
+bool CAddonInstallJob::Install(const std::string &installFrom, const RepositoryPtr& repo)
 {
   SetText(g_localizeStrings.Get(24079));
   ADDONDEPS deps = m_addon->GetDeps();
@@ -727,15 +736,14 @@ bool CAddonInstallJob::Install(const std::string &installFrom, const AddonPtr& r
         {
           RepositoryPtr repoForDep;
           AddonPtr addon;
-          std::string hash;
-          if (!CAddonInstallJob::GetAddonWithHash(addonID, repoForDep, addon, hash))
+          if (!CAddonInstallJob::GetAddon(addonID, repoForDep, addon))
           {
             CLog::Log(LOGERROR, "CAddonInstallJob[%s]: failed to find dependency %s", m_addon->ID().c_str(), addonID.c_str());
             ReportInstallError(m_addon->ID(), m_addon->ID(), g_localizeStrings.Get(24085));
             return false;
           }
 
-          CAddonInstallJob dependencyJob(addon, repoForDep, hash, false);
+          CAddonInstallJob dependencyJob(addon, repoForDep, false);
 
           // pass our progress indicators to the temporary job and don't allow it to
           // show progress or information updates (no progress, title or text changes)

--- a/xbmc/addons/AddonInstaller.h
+++ b/xbmc/addons/AddonInstaller.h
@@ -125,12 +125,11 @@ private:
   /*! \brief Install an addon from a repository or zip
    \param addon the AddonPtr describing the addon
    \param repo the repository to install addon from
-   \param hash the hash to verify the install. Defaults to "".
    \param background whether to install in the background or not. Defaults to true.
    \return true on successful install, false on failure.
    */
   bool DoInstall(const ADDON::AddonPtr &addon, const ADDON::RepositoryPtr &repo,
-      const std::string &hash = "", bool background = true, bool modal = false, bool autoUpdate = false);
+      bool background = true, bool modal = false, bool autoUpdate = false);
 
   /*! \brief Check whether dependencies of an addon exist or are installable.
    Iterates through the addon's dependencies, checking they're installed or installable.
@@ -154,8 +153,7 @@ private:
 class CAddonInstallJob : public CFileOperationJob
 {
 public:
-  CAddonInstallJob(const ADDON::AddonPtr& addon, const ADDON::AddonPtr& repo,
-      const std::string& hash, bool isAutoUpdate);
+  CAddonInstallJob(const ADDON::AddonPtr& addon, const ADDON::RepositoryPtr& repo, bool isAutoUpdate);
 
   virtual bool DoWork();
 
@@ -166,13 +164,12 @@ public:
    *  \param hash Hash of the add-on
    *  \return True if the add-on and its hash were found, false otherwise.
    */
-  static bool GetAddonWithHash(const std::string& addonID, ADDON::RepositoryPtr& repo,
-      ADDON::AddonPtr& addon, std::string& hash);
+  static bool GetAddon(const std::string& addonID, ADDON::RepositoryPtr& repo, ADDON::AddonPtr& addon);
 
 private:
   void OnPreInstall();
   void OnPostInstall();
-  bool Install(const std::string &installFrom, const ADDON::AddonPtr& repo = ADDON::AddonPtr());
+  bool Install(const std::string &installFrom, const ADDON::RepositoryPtr& repo = ADDON::RepositoryPtr());
   bool DownloadPackage(const std::string &path, const std::string &dest);
 
   bool DoFileOperation(FileAction action, CFileItemList &items, const std::string &file, bool useSameJob = true);
@@ -185,8 +182,7 @@ private:
   void ReportInstallError(const std::string& addonID, const std::string& fileName, const std::string& message = "");
 
   ADDON::AddonPtr m_addon;
-  ADDON::AddonPtr m_repo;
-  std::string m_hash;
+  ADDON::RepositoryPtr m_repo;
   bool m_isUpdate;
   bool m_isAutoUpdate;
 };

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -97,7 +97,7 @@ AddonPtr CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type)
   return boost::shared_ptr<IAddon>();
 }
 
-bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions/* = false*/, std::string assetBasePath)
+bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions/* = false*/, const CRepository::DirInfo& repo)
 {
   if (!plugin || !plugin->identifier)
     return false;
@@ -124,17 +124,10 @@ bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder
     }
   }
 
-  if (assetBasePath.empty() && plugin->plugin_path)
-  {
-    // Default for add-on information not loaded from repository
-    assetBasePath = plugin->plugin_path;
-  }
-
-  FillCpluffMetadata(plugin, builder, assetBasePath);
-  return true;
+  FillCpluffMetadata(plugin, builder, repo);  return true;
 }
 
-void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, std::string const& assetBasePath)
+void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, const CRepository::DirInfo& repo)
 {
   builder.SetId(plugin->identifier);
 
@@ -149,9 +142,6 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
 
   if (plugin->provider_name)
     builder.SetAuthor(plugin->provider_name);
-
-  if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0)
-    builder.SetPath(plugin->plugin_path);
 
   {
     ADDONDEPS dependencies;
@@ -170,6 +160,35 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
   const cp_extension_t *metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "xbmc.addon.metadata");
   if (!metadata)
     metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "kodi.addon.metadata");
+
+  std::string path;
+  if (metadata)
+    path = CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "path");
+
+  if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0 && strcmp(plugin->plugin_path, "memory") != 0)
+    builder.SetPath(plugin->plugin_path);
+  else
+  {
+    if (path.empty())
+      builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, plugin->identifier,
+        StringUtils::Format("%s-%s.zip", plugin->identifier, builder.GetVersion().asString().c_str())));
+    else
+      builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, path));
+  }
+
+  std::string assetBasePath = repo.artdir;
+  if (repo.artdir.empty() && plugin->plugin_path)
+  {
+    // Default for add-on information not loaded from repository
+    assetBasePath = plugin->plugin_path;
+  }
+  else
+  {
+    if (path.empty())
+      assetBasePath = URIUtils::AddFileToFolder(assetBasePath, plugin->identifier);
+    else
+      assetBasePath = URIUtils::AddFileToFolder(assetBasePath, StringUtils::Split(path, '/')[0]);
+  }
 
   if (!assetBasePath.empty())
   {
@@ -1135,14 +1154,8 @@ bool CAddonMgr::AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::s
     {
       CAddonBuilder builder;
       std::string basePath = URIUtils::AddFileToFolder(repo.datadir, info->identifier);
-      info->plugin_path = static_cast<char*>(malloc(basePath.length() + 1));
-      strncpy(info->plugin_path, basePath.c_str(), basePath.length());
-      info->plugin_path[basePath.length()] = '\0';
-
-      if (Factory(info, ADDON_UNKNOWN, builder, false, URIUtils::AddFileToFolder(repo.artdir, info->identifier)))
+      if (Factory(info, ADDON_UNKNOWN, builder, false, repo))
       {
-        builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, info->identifier,
-          StringUtils::Format("{}-{}.zip", info->identifier, builder.GetVersion().asString())));
         ADDON::AddonPtr addon = builder.Build();
         if (addon)
           addons.push_back(boost::move(addon));

--- a/xbmc/addons/AddonManager.cpp
+++ b/xbmc/addons/AddonManager.cpp
@@ -97,7 +97,7 @@ AddonPtr CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type)
   return boost::shared_ptr<IAddon>();
 }
 
-bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions/* = false*/)
+bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions/* = false*/, std::string assetBasePath)
 {
   if (!plugin || !plugin->identifier)
     return false;
@@ -124,11 +124,17 @@ bool CAddonMgr::Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder
     }
   }
 
-  FillCpluffMetadata(plugin, builder);
+  if (assetBasePath.empty() && plugin->plugin_path)
+  {
+    // Default for add-on information not loaded from repository
+    assetBasePath = plugin->plugin_path;
+  }
+
+  FillCpluffMetadata(plugin, builder, assetBasePath);
   return true;
 }
 
-void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder)
+void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, std::string const& assetBasePath)
 {
   builder.SetId(plugin->identifier);
 
@@ -165,15 +171,15 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
   if (!metadata)
     metadata = CServiceBroker::GetAddonMgr().GetExtension(plugin, "kodi.addon.metadata");
 
-  if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0)
+  if (!assetBasePath.empty())
   {
     //backwards compatibility
     std::string icon = metadata && CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "noicon") == "true" ? "" : "icon.png";
     std::string fanart = metadata && CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "nofanart") == "true" ? "" : "fanart.jpg";
     if (!icon.empty())
-      builder.SetIcon(URIUtils::AddFileToFolder(plugin->plugin_path, icon));
+      builder.SetIcon(URIUtils::AddFileToFolder(assetBasePath, icon));
     if (!fanart.empty())
-      builder.SetArt("fanart", URIUtils::AddFileToFolder(plugin->plugin_path, fanart));
+      builder.SetArt("fanart", URIUtils::AddFileToFolder(assetBasePath, fanart));
   }
 
   if (metadata)
@@ -195,7 +201,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
 
     builder.SetBroken(CServiceBroker::GetAddonMgr().GetExtValue(metadata->configuration, "broken"));
 
-    if (plugin->plugin_path && strcmp(plugin->plugin_path, "") != 0)
+    if (!assetBasePath.empty())
     {
       cp_cfg_element_t *assets = CServiceBroker::GetAddonMgr().GetExtElement(metadata->configuration, "assets");
       if (assets)
@@ -204,7 +210,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
         builder.SetArt("fanart", "");
         std::string icon = CServiceBroker::GetAddonMgr().GetExtValue(assets, "icon");
         if (!icon.empty())
-          icon = URIUtils::AddFileToFolder(plugin->plugin_path, icon);
+          icon = URIUtils::AddFileToFolder(assetBasePath, icon);
         builder.SetIcon(icon);
 
         std::map<std::string, std::string> art;
@@ -215,7 +221,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
           std::string value = CServiceBroker::GetAddonMgr().GetExtValue(assets, type.c_str());
           if (!value.empty())
           {
-            value = URIUtils::AddFileToFolder(plugin->plugin_path, value);
+            value = URIUtils::AddFileToFolder(assetBasePath, value);
             builder.SetArt(type, value);
           }
         }
@@ -228,7 +234,7 @@ void CAddonMgr::FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder
           {
             cp_cfg_element_t *const &elem = *it;
             if (elem->value && strcmp(elem->value, "") != 0)
-              screenshots.push_back(URIUtils::AddFileToFolder(plugin->plugin_path, elem->value));
+              screenshots.push_back(URIUtils::AddFileToFolder(assetBasePath, elem->value));
           }
         }
         builder.SetScreenshots(boost::move(screenshots));
@@ -1128,15 +1134,15 @@ bool CAddonMgr::AddonsFromRepoXML(const CRepository::DirInfo& repo, const std::s
     if (info)
     {
       CAddonBuilder builder;
-      std::string basePath = URIUtils::AddFileToFolder(repo.datadir, std::string(info->identifier));
+      std::string basePath = URIUtils::AddFileToFolder(repo.datadir, info->identifier);
       info->plugin_path = static_cast<char*>(malloc(basePath.length() + 1));
       strncpy(info->plugin_path, basePath.c_str(), basePath.length());
       info->plugin_path[basePath.length()] = '\0';
 
-      if (Factory(info, ADDON_UNKNOWN, builder))
+      if (Factory(info, ADDON_UNKNOWN, builder, false, URIUtils::AddFileToFolder(repo.artdir, info->identifier)))
       {
-        builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, StringUtils::Format("%s/%s-%s.zip",
-            info->identifier, info->identifier, builder.GetVersion().asString().c_str())));
+        builder.SetPath(URIUtils::AddFileToFolder(repo.datadir, info->identifier,
+          StringUtils::Format("{}-{}.zip", info->identifier, builder.GetVersion().asString())));
         ADDON::AddonPtr addon = builder.Build();
         if (addon)
           addons.push_back(boost::move(addon));

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -249,8 +249,8 @@ namespace ADDON
     bool IsCompatible(const IAddon& addon);
 
     static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type);
-    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false, std::string assetBasePath = "");
-    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, std::string const& assetBasePath);
+    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false, const CRepository::DirInfo& repo = CRepository::DirInfo());
+    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, const CRepository::DirInfo& repo);
 
   private:
     void OnEventSubmit(const std::string& id, const CDateTime& time);

--- a/xbmc/addons/AddonManager.h
+++ b/xbmc/addons/AddonManager.h
@@ -249,8 +249,8 @@ namespace ADDON
     bool IsCompatible(const IAddon& addon);
 
     static AddonPtr Factory(const cp_plugin_info_t* plugin, TYPE type);
-    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false);
-    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder);
+    static bool Factory(const cp_plugin_info_t* plugin, TYPE type, CAddonBuilder& builder, bool ignoreExtensions = false, std::string assetBasePath = "");
+    static void FillCpluffMetadata(const cp_plugin_info_t* plugin, CAddonBuilder& builder, std::string const& assetBasePath);
 
   private:
     void OnEventSubmit(const std::string& id, const CDateTime& time);

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -115,6 +115,18 @@ CRepository::ResolveResult CRepository::ResolvePathAndHash(const AddonPtr& addon
   return resolveResult;
 }
 
+CRepository::DirInfo CRepository::ParseDirConfiguration(cp_cfg_element_t* configuration)
+{
+  const ADDON::CAddonMgr &mgr = CServiceBroker::GetAddonMgr();
+  DirInfo dir;
+  dir.checksum = mgr.GetExtValue(configuration, "checksum");
+  dir.info = mgr.GetExtValue(configuration, "info");
+  dir.datadir = mgr.GetExtValue(configuration, "datadir");
+  dir.hashes = mgr.GetExtValue(configuration, "hashes") == "true";
+  dir.version = AddonVersion(mgr.GetExtValue(configuration, "@minversion"));
+  return dir;
+}
+
 boost::movelib::unique_ptr<CRepository> CRepository::FromExtension(AddonProps props, const cp_extension_t* ext)
 {
   DirList dirs;
@@ -124,30 +136,19 @@ boost::movelib::unique_ptr<CRepository> CRepository::FromExtension(AddonProps pr
     version = addonver->Version();
   for (size_t i = 0; i < ext->configuration->num_children; ++i)
   {
-    if(ext->configuration->children[i].name &&
-       strcmp(ext->configuration->children[i].name, "dir") == 0)
+    cp_cfg_element_t* element = &ext->configuration->children[i];
+    if(element->name && strcmp(element->name, "dir") == 0)
     {
-      AddonVersion min_version(CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "@minversion"));
-      if (min_version <= version)
+      DirInfo dir = ParseDirConfiguration(element);
+      if (dir.version <= version)
       {
-        DirInfo dir;
-        dir.version = min_version;
-        dir.checksum = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "checksum");
-        dir.info = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "info");
-        dir.datadir = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "datadir");
-        dir.hashes = CServiceBroker::GetAddonMgr().GetExtValue(&ext->configuration->children[i], "hashes") == "true";
         dirs.push_back(boost::move(dir));
       }
     }
   }
   if (!CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "info").empty())
   {
-    DirInfo info;
-    info.checksum = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "checksum");
-    info.info = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "info");
-    info.datadir = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "datadir");
-    info.hashes = CServiceBroker::GetAddonMgr().GetExtValue(ext->configuration, "hashes") == "true";
-    dirs.push_back(boost::move(info));
+    dirs.push_back(ParseDirConfiguration(ext->configuration));
   }
   return boost::movelib::unique_ptr<CRepository>(new CRepository(boost::move(props), boost::move(dirs)));
 }

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -22,6 +22,7 @@
 
 #include <iterator>
 #include <utility>
+#include <boost/bind.hpp>
 
 #include "ServiceBroker.h"
 #include "addons/AddonDatabase.h"
@@ -39,6 +40,7 @@
 #include "settings/Settings.h"
 #include "TextureDatabase.h"
 #include "URL.h"
+#include "utils/Base64.h"
 #include "utils/JobManager.h"
 #include "utils/log.h"
 #include "utils/Mime.h"
@@ -52,6 +54,66 @@ using namespace ADDON;
 using namespace KODI::MESSAGING;
 
 using KODI::MESSAGING::HELPERS::DialogResponse;
+
+bool dirHasParent(const ADDON::CRepository::DirInfo &dir, const std::string &path) { return URIUtils::PathHasParent(path, dir.datadir, true); }
+
+CRepository::ResolveResult CRepository::ResolvePathAndHash(const AddonPtr& addon) const
+{
+  std::string const& path = addon->Path();
+
+  ADDON::CRepository::DirList::const_iterator dirIt = std::find_if(m_dirs.begin(), m_dirs.end(), boost::bind(dirHasParent, _1, boost::cref(path)));
+  if (dirIt == m_dirs.end())
+  {
+    CLog::Log(LOGERROR, "Requested path {} not found in known repository directories", path);
+    ResolveResult resolveResult = {};
+    return resolveResult;
+  }
+
+  if (!dirIt->hashes)
+  {
+    // We have a path, but need no hash
+    ResolveResult resolveResult = {path, ""};
+    return resolveResult;
+  }
+
+  // Do not follow mirror redirect, we want the headers of the redirect response
+  CURL url(path);
+  url.SetProtocolOption("redirect-limit", "0");
+  CCurlFile file;
+  if (!file.Open(url))
+  {
+    CLog::Log(LOGERROR, "Could not fetch addon location and hash from {}", path);
+    ResolveResult resolveResult = {};
+    return resolveResult;
+  }
+
+  // Return the location from the header so we don't have to look it up again
+  // (saves one request per addon install)
+  std::string location = file.GetRedirectURL();
+  // content-* headers are base64, convert to base16
+  std::string hash = StringUtils::ToHexadecimal(Base64::Decode(file.GetHttpHeader().GetValue("content-md5")));
+
+  if (hash.empty())
+  {
+    // Expected hash, but none found -> fall back to old method
+    if (!FetchChecksum(path + ".md5", hash))
+    {
+      CLog::Log(LOGERROR, "Failed to find hash for {} from HTTP header and in separate file", path);
+      ResolveResult resolveResult = {};
+      return resolveResult;
+    }
+  }
+  if (location.empty())
+  {
+    // Fall back to original URL if we do not get a redirect
+    location = path;
+  }
+
+  CLog::Log(LOGDEBUG, "Resolved addon path {} to {} hash {}", path, location, hash);
+
+  ResolveResult resolveResult = {location, hash};
+  return resolveResult;
+}
 
 boost::movelib::unique_ptr<CRepository> CRepository::FromExtension(AddonProps props, const cp_extension_t* ext)
 {
@@ -93,34 +155,14 @@ boost::movelib::unique_ptr<CRepository> CRepository::FromExtension(AddonProps pr
 CRepository::CRepository(AddonProps props, DirList dirs)
     : CAddon(boost::move(props)), m_dirs(boost::move(dirs))
 {
-}
-
-
-bool CRepository::GetAddonHash(const AddonPtr& addon, std::string& checksum) const
-{
-  DirList::const_iterator it;
-  for (it = m_dirs.begin();it != m_dirs.end(); ++it)
-    if (URIUtils::PathHasParent(addon->Path(), it->datadir, true))
-      break;
-
-  if (it != m_dirs.end())
+  for (DirList::const_iterator it = m_dirs.begin(); it != m_dirs.end(); ++it)
   {
-    if (!it->hashes)
+    const ADDON::CRepository::DirInfo &dir = *it;
+    if (CURL(dir.datadir).IsProtocol("http"))
     {
-      checksum = "";
-      return true;
-    }
-    if (FetchChecksum(addon->Path() + ".md5", checksum))
-    {
-      size_t pos = checksum.find_first_of(" \n");
-      if (pos != std::string::npos)
-      {
-        checksum = checksum.substr(0, pos);
-        return true;
-      }
+      CLog::Log(LOGWARNING, "Repository {} uses plain HTTP for add-on downloads - this is insecure and will make your Kodi installation vulnerable to attacks if enabled!", Name());
     }
   }
-  return false;
 }
 
 bool CRepository::FetchChecksum(const std::string& url, std::string& checksum)
@@ -139,6 +181,11 @@ bool CRepository::FetchChecksum(const std::string& url, std::string& checksum)
   if (read <= -1)
     return false;
   checksum = ss.str();
+  std::size_t pos = checksum.find_first_of(" \n");
+  if (pos != std::string::npos)
+  {
+    checksum = checksum.substr(0, pos);
+  }
   return true;
 }
 

--- a/xbmc/addons/Repository.cpp
+++ b/xbmc/addons/Repository.cpp
@@ -122,6 +122,11 @@ CRepository::DirInfo CRepository::ParseDirConfiguration(cp_cfg_element_t* config
   dir.checksum = mgr.GetExtValue(configuration, "checksum");
   dir.info = mgr.GetExtValue(configuration, "info");
   dir.datadir = mgr.GetExtValue(configuration, "datadir");
+  dir.artdir = mgr.GetExtValue(configuration, "artdir");
+  if (dir.artdir.empty())
+  {
+    dir.artdir = dir.datadir;
+  }
   dir.hashes = mgr.GetExtValue(configuration, "hashes") == "true";
   dir.version = AddonVersion(mgr.GetExtValue(configuration, "@minversion"));
   return dir;

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -41,6 +41,7 @@ namespace ADDON
       std::string info;
       std::string checksum;
       std::string datadir;
+      std::string artdir;
       bool hashes;
     };
 

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -27,6 +27,8 @@
 #include "utils/Job.h"
 #include "utils/ProgressJob.h"
 
+struct cp_cfg_element_t;
+
 namespace ADDON
 {
   class CRepository : public CAddon
@@ -73,6 +75,8 @@ namespace ADDON
   private:
     static bool FetchChecksum(const std::string& url, std::string& checksum);
     static bool FetchIndex(const DirInfo& repo, VECADDONS& addons);
+
+    static DirInfo ParseDirConfiguration(cp_cfg_element_t* configuration);
 
     DirList m_dirs;
   };

--- a/xbmc/addons/Repository.h
+++ b/xbmc/addons/Repository.h
@@ -63,6 +63,13 @@ namespace ADDON
 
     FetchStatus FetchIfChanged(const std::string& oldChecksum, std::string& checksum, VECADDONS& addons) const;
 
+    struct ResolveResult
+    {
+      std::string location;
+      std::string hash;
+    };
+    ResolveResult ResolvePathAndHash(AddonPtr const& addon) const;
+
   private:
     static bool FetchChecksum(const std::string& url, std::string& checksum);
     static bool FetchIndex(const DirInfo& repo, VECADDONS& addons);

--- a/xbmc/filesystem/CurlFile.cpp
+++ b/xbmc/filesystem/CurlFile.cpp
@@ -1080,8 +1080,8 @@ bool CCurlFile::Open(const CURL& url)
     }
   }
 
-  char* efurl;
-  if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
+  std::string efurl = GetInfoString(CURLINFO_EFFECTIVE_URL);
+  if (!efurl.empty())
   {
     if (m_url != efurl)
     {
@@ -1117,8 +1117,8 @@ bool CCurlFile::OpenForWrite(const CURL& url, bool bOverWrite)
   SetCommonOptions(m_state);
   SetRequestHeaders(m_state);
 
-  char* efurl;
-  if (CURLE_OK == g_curlInterface.easy_getinfo(m_state->m_easyHandle, CURLINFO_EFFECTIVE_URL,&efurl) && efurl)
+  std::string efurl = GetInfoString(CURLINFO_EFFECTIVE_URL);
+  if (!efurl.empty())
     m_url = efurl;
 
   m_opened = true;
@@ -1794,6 +1794,23 @@ std::string CCurlFile::GetServerReportedCharset(void)
 std::string CCurlFile::GetURL(void)
 {
   return m_url;
+}
+
+std::string CCurlFile::GetRedirectURL()
+{
+  return GetInfoString(CURLINFO_REDIRECT_URL);
+}
+
+std::string CCurlFile::GetInfoString(int infoType)
+{
+  char* info = nullptr;
+  CURLcode result = g_curlInterface.easy_getinfo(m_state->m_easyHandle, static_cast<XCURL::CURLINFO> (infoType), &info);
+  if (result != CURLE_OK)
+  {
+    CLog::Log(LOGERROR, "Info string request for type {} failed with result code {}", infoType, result);
+    return "";
+  }
+  return (info ? info : "");
 }
 
 /* STATIC FUNCTIONS */

--- a/xbmc/filesystem/CurlFile.h
+++ b/xbmc/filesystem/CurlFile.h
@@ -96,6 +96,7 @@ namespace XFILE
       const CHttpHeader& GetHttpHeader() const { return m_state->m_httpheader; }
       std::string GetServerReportedCharset(void);
       std::string GetURL(void);
+      std::string GetRedirectURL();
 
       /* static function that will get content type of a file */
       static bool GetHttpHeader(const CURL &url, CHttpHeader &headers);
@@ -159,6 +160,7 @@ namespace XFILE
       void SetRequestHeaders(CReadState* state);
       void SetCorrectHeaders(CReadState* state);
       bool Service(const std::string& strURL, std::string& strHTML);
+      std::string GetInfoString(int infoType);
 
     protected:
       CReadState*     m_state;

--- a/xbmc/filesystem/File.h
+++ b/xbmc/filesystem/File.h
@@ -24,9 +24,6 @@
 //
 //////////////////////////////////////////////////////////////////////
 
-#if !defined(AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_)
-#define AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_
-
 #pragma once
 
 #include <iostream>
@@ -234,4 +231,3 @@ private:
 };
 
 }
-#endif // !defined(AFX_FILE_H__A7ED6320_C362_49CB_8925_6C6C8CAE7B78__INCLUDED_)


### PR DESCRIPTION
After merging Addons Framework from Kodi Krypton we were not able to browser our own repository as well as any other repository which wasn't ment for Kodi Krypton. Reason for this was because Kodi Krypton was expecting "\n" at end of line in MD5 checkum files. This was removed by Kodi Leia so I have taken some commits from leia branch and bacport them:
- First five commits are taken from [#13647](https://github.com/xbmc/xbmc/pull/13647) - those commits slightly changed a way how checking checkum was done, so if MD file don't have "\n" at the end of line, it's not gonna fail
- Last commit is backport of [#13991](https://github.com/xbmc/xbmc/pull/13991)

I have tested repository browsing from latest version of [jurialmunkey repository](https://github.com/jurialmunkey/repository.jurialmunkey) and I was able to see and open info dialog for all addons within this repository.