### PR TITLE
changed: use HTTP for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "addons/skin.estuary"]
 	path = addons/skin.estuary
-	url = git@github.com:antonic901/skin.estuary.git
+	url = https://github.com/antonic901/skin.estuary.git


### PR DESCRIPTION
Update .gitmodules so that is HTTPS which is easier for most users to clone repo and is typically what other major repo's do.