### PR TITLE
[UPnP] fix broken UPnP by reverting 84f0f63441fd549d6ce58429b35af709ba15f124

### DIFF
--- a/xbmc/network/upnp/UPnPInternal.cpp
+++ b/xbmc/network/upnp/UPnPInternal.cpp
@@ -33,12 +33,8 @@
 #include "filesystem/StackDirectory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
-#include "video/VideoDatabase.h"
 #include "video/VideoInfoTag.h"
-#include "music/MusicDatabase.h"
 #include "music/tags/MusicInfoTag.h"
-#include "TextureDatabase.h"
-#include "ThumbLoader.h"
 
 using namespace MUSIC_INFO;
 using namespace XFILE;
@@ -304,17 +300,14 @@ PopulateObjectFromTag(CVideoInfoTag&         tag,
 |   BuildObject
 +---------------------------------------------------------------------*/
 PLT_MediaObject*
-BuildObject(CFileItem&                    item,
+BuildObject(const CFileItem&              item,
             NPT_String&                   file_path,
             bool                          with_count,
-            NPT_Reference<CThumbLoader>&  thumb_loader,
             const PLT_HttpRequestContext* context /* = NULL */,
             CUPnPServer*                  upnp_server /* = NULL */)
 {
     PLT_MediaItemResource resource;
     PLT_MediaObject*      object = NULL;
-    std::string thumb, fanart;
-    bool fetched_art(false);
 
     CLog::Log(LOGDEBUG, "Building didl for object '%s'", (const char*)item.GetPath().c_str());
 
@@ -535,26 +528,24 @@ BuildObject(CFileItem&                    item,
             object->m_Title = title;
         }
     }
-    // determine the correct artwork for this item
-    if (!thumb_loader.IsNull())
-        fetched_art = thumb_loader->FillLibraryArt(item);
-
-    // finally apply the found artwork
-    if (fetched_art && upnp_server) {
+    // set a thumbnail if we have one
+    if (item.HasArt("thumb") && upnp_server) {
         object->m_ExtraInfo.album_art_uri = upnp_server->BuildSafeResourceUri(
             (*ips.GetFirstItem()).ToString(),
-            CTextureUtils::GetWrappedImageURL(item.GetArt("thumb")).c_str());
-
+            item.GetArt("thumb").c_str());
         // Set DLNA profileID by extension, defaulting to JPEG.
-        if (URIUtils::HasExtension(thumb, ".png")) {
+        NPT_String ext = URIUtils::GetExtension(item.GetArt("thumb")).c_str();
+        if (strcmp(ext, ".png") == 0) {
             object->m_ExtraInfo.album_art_uri_dlna_profile = "PNG_TN";
         } else {
             object->m_ExtraInfo.album_art_uri_dlna_profile = "JPEG_TN";
         }
+    }
 
-        std::string fanart = item.GetArt("fanart");
-        if (!fanart.empty())
-            upnp_server->AddSafeResourceUri(object, ips, CTextureUtils::GetWrappedImageURL(fanart).c_str(), "xbmc.org:*:fanart:*");
+    if (upnp_server) {
+        if (item.HasArt("fanart")) {
+            upnp_server->AddSafeResourceUri(object, ips, item.GetArt("fanart").c_str(), "xbmc.org:*:fanart:*");
+        }
     }
 
     return object;

--- a/xbmc/network/upnp/UPnPInternal.h
+++ b/xbmc/network/upnp/UPnPInternal.h
@@ -22,12 +22,10 @@
 #include "system.h"
 #include "utils/StdString.h"
 #include "NptTypes.h"
-#include "NptReferences.h"
 #include "PltDidl.h"
 
 class CUPnPServer;
 class CFileItem;
-class CThumbLoader;
 class PLT_HttpRequestContext;
 class PLT_MediaItemResource;
 class PLT_MediaObject;
@@ -82,10 +80,9 @@ namespace UPNP
                                           PLT_MediaItemResource* resource,
                                           EClientQuirks          quirks);
 
-  PLT_MediaObject* BuildObject(CFileItem&              item,
+  PLT_MediaObject* BuildObject(const CFileItem&              item,
                                       NPT_String&                   file_path,
                                       bool                          with_count,
-                                      NPT_Reference<CThumbLoader>&  thumb_loader,
                                       const PLT_HttpRequestContext* context = NULL,
                                       CUPnPServer*                  upnp_server = NULL);
 

--- a/xbmc/network/upnp/UPnPRenderer.h
+++ b/xbmc/network/upnp/UPnPRenderer.h
@@ -41,9 +41,9 @@ public:
     void UpdateState();
 
     // Http server handler
-    virtual NPT_Result ProcessHttpGetRequest(NPT_HttpRequest&              request,
-                                             const NPT_HttpRequestContext& context,
-                                             NPT_HttpResponse&             response);
+    virtual NPT_Result ProcessHttpRequest(NPT_HttpRequest&              request,
+                                          const NPT_HttpRequestContext& context,
+                                          NPT_HttpResponse&             response);
 
     // AVTransport methods
     virtual NPT_Result OnNext(PLT_ActionReference& action);

--- a/xbmc/network/upnp/UPnPServer.cpp
+++ b/xbmc/network/upnp/UPnPServer.cpp
@@ -1,8 +1,7 @@
 #include "UPnPServer.h"
 #include "UPnPInternal.h"
 #include "Platinum.h"
-#include "video/VideoThumbLoader.h"
-#include "music/MusicThumbLoader.h"
+#include "ThumbLoader.h"
 #include "filesystem/Directory.h"
 #include "filesystem/MusicDatabaseDirectory.h"
 #include "filesystem/VideoDatabaseDirectory.h"
@@ -54,9 +53,9 @@ PLT_MediaObject*
 CUPnPServer::Build(CFileItemPtr                  item,
                    bool                          with_count,
                    const PLT_HttpRequestContext& context,
-                   NPT_Reference<CThumbLoader>&  thumb_loader,
                    const char*                   parent_id /* = NULL */)
 {
+    CThumbLoader thumb_loader;
     PLT_MediaObject* object = NULL;
     NPT_String       path = item->GetPath().c_str();
 
@@ -122,6 +121,9 @@ CUPnPServer::Build(CFileItemPtr                  item,
                     }
                 }
 
+                if (!item->HasArt("thumb") )
+                    item->SetArt("thumb", thumb_loader.GetCachedImage(*item, "thumb"));
+
                 if (item->GetLabel().empty()) {
                     /* if no label try to grab it from node type */
                     CStdString label;
@@ -165,11 +167,14 @@ CUPnPServer::Build(CFileItemPtr                  item,
                         item->SetLabelPreformated(true);
                     }
                 }
+
+                if (!item->HasArt("thumb") )
+                    item->SetArt("thumb", thumb_loader.GetCachedImage(*item, "thumb"));
             }
         }
 
         // not a virtual path directory, new system
-        object = BuildObject(*item.get(), file_path, with_count, thumb_loader, &context, this);
+        object = BuildObject(*item.get(), file_path, with_count, &context, this);
 
         // set parent id if passed, otherwise it should have been determined
         if (object && parent_id) {
@@ -240,7 +245,6 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
     NPT_String                     id = TranslateWMPObjectId(object_id);
     vector<CStdString>             paths;
     CFileItemPtr                   item;
-    NPT_Reference<CThumbLoader>    thumb_loader;
 
     CLog::Log(LOGINFO, "Received UPnP Browse Metadata request for object '%s'", (const char*)object_id);
 
@@ -251,7 +255,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
             item.reset(new CFileItem((const char*)id, true));
             item->SetLabel("Root");
             item->SetLabelPreformated(true);
-            object = Build(item, true, context, thumb_loader);
+            object = Build(item, true, context);
         } else {
             return NPT_FAILURE;
         }
@@ -270,16 +274,7 @@ CUPnPServer::OnBrowseMetadata(PLT_ActionReference&          action,
 //        }
 //#endif
 
-        if (item->IsVideoDb()) {
-            thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-        }
-        else if (item->IsMusicDb()) {
-            thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
-        }
-        if (!thumb_loader.IsNull()) {
-            thumb_loader->OnLoaderStart();
-        }
-        object = Build(item, true, context, thumb_loader, parent.empty()?NULL:parent.c_str());
+        object = Build(item, true, context, parent.empty()?NULL:parent.c_str());
     }
 
     if (object.IsNull()) {
@@ -391,21 +386,6 @@ CUPnPServer::BuildResponse(PLT_ActionReference&          action,
         starting_index,
         requested_count);
 
-    // we will reuse this ThumbLoader for all items
-    NPT_Reference<CThumbLoader> thumb_loader;
-
-    // this isn't ideal, just grabbing first item to identify the content type
-    // of this FileItemList, but there's no other option
-    if (!items.IsEmpty() && items.Get(0)->HasVideoInfoTag()) {
-        thumb_loader = NPT_Reference<CThumbLoader>(new CVideoThumbLoader());
-    }
-    else if (!items.IsEmpty() && items.Get(0)->HasMusicInfoTag()) {
-        thumb_loader = NPT_Reference<CThumbLoader>(new CMusicThumbLoader());
-    }
-    if (!thumb_loader.IsNull()) {
-        thumb_loader->OnLoaderStart();
-    }
-
     // won't return more than UPNP_MAX_RETURNED_ITEMS items at a time to keep things smooth
     // 0 requested means as many as possible
     NPT_UInt32 max_count  = (requested_count == 0)?m_MaxReturnedItems:min((unsigned long)requested_count, (unsigned long)m_MaxReturnedItems);
@@ -415,7 +395,7 @@ CUPnPServer::BuildResponse(PLT_ActionReference&          action,
     NPT_String didl = didl_header;
     PLT_MediaObjectReference object;
     for (unsigned long i=starting_index; i<stop_index; ++i) {
-        object = Build(items[i], true, context, thumb_loader, parent_id);
+        object = Build(items[i], true, context, parent_id);
         if (object.IsNull()) {
             continue;
         }

--- a/xbmc/network/upnp/UPnPServer.h
+++ b/xbmc/network/upnp/UPnPServer.h
@@ -22,7 +22,6 @@
 #include "PltMediaConnect.h"
 #include "FileItem.h"
 
-class CThumbLoader;
 class PLT_MediaObject;
 class PLT_HttpRequestContext;
 
@@ -87,7 +86,6 @@ private:
     PLT_MediaObject* Build(CFileItemPtr                  item,
                            bool                          with_count,
                            const PLT_HttpRequestContext& context,
-                           NPT_Reference<CThumbLoader>&  thumbLoader,
                            const char*                   parent_id = NULL);
     NPT_Result       BuildResponse(PLT_ActionReference&          action,
                                    CFileItemList&                items,


### PR DESCRIPTION
This PR reverts https://github.com/antonic901/xbmc4xbox-redux/commit/84f0f63441fd549d6ce58429b35af709ba15f124 which broke UPnP. I wasn't able to identify error, but for some reason applying this commit results in stack overflow exception when converting ip address of UPnP server to string.

This code fails for IP address of UPnP sever (ex. 192.168.0.41):
```
/*----------------------------------------------------------------------
|   NPT_IpAddress::ToString
+---------------------------------------------------------------------*/
NPT_String
NPT_IpAddress::ToString() const
{
    NPT_String address;
    address.Reserve(16);
    address += NPT_String::FromInteger(m_Address[0]);
    address += '.';
    address += NPT_String::FromInteger(m_Address[1]);
    address += '.';
    address += NPT_String::FromInteger(m_Address[2]);
    address += '.';
    address += NPT_String::FromInteger(m_Address[3]);

    return address;
}
```

More speficially, `address += NPT_String::FromInteger(m_Address[0]);` (192.) fails at this line:
```
static Buffer* Allocate(NPT_Size allocated, NPT_Size length) {
    void* mem = ::operator new(sizeof(Buffer)+allocated+1);
    return new(mem) Buffer(allocated, length);
}
```

Line `void* mem = ::operator new(sizeof(Buffer)+allocated+1);` results in exception.


Since I was't able to fully backport [#1569](https://github.com/xbmc/xbmc/pull/1569) because of our old UPnP library, I'm reverting this commit to get our UPnP working again.