### PR TITLE
[CPlayerController] backport of video player controller from Kodi Krypton

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -3916,6 +3916,12 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					RelativePath=".\xbmc\video\GUIViewStateVideo.h">
 				</File>
 				<File
+					RelativePath=".\xbmc\video\PlayerController.cpp">
+				</File>
+				<File
+					RelativePath=".\xbmc\video\PlayerController.h">
+				</File>
+				<File
 					RelativePath=".\xbmc\video\VideoDatabase.cpp">
 				</File>
 				<File

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -136,6 +136,7 @@
 #include "windows/GUIWindowScreensaver.h"
 #include "video/windows/GUIWindowFullScreen.h"
 #include "video/dialogs/GUIDialogVideoOSD.h"
+#include "video/PlayerController.h"
 
 // Dialog includes
 #include "video/dialogs/GUIDialogVideoBookmarks.h"
@@ -1317,6 +1318,7 @@ HRESULT CApplication::Initialize()
 
   // register action listeners
   RegisterActionListener(&CSeekHandler::Get());
+  RegisterActionListener(&CPlayerController::GetInstance());
 
   CRepositoryUpdater::GetInstance().Start();
 
@@ -3650,6 +3652,7 @@ void CApplication::Stop(bool bLCDStop)
 
     // unregister action listeners
     UnregisterActionListener(&CSeekHandler::Get());
+    UnregisterActionListener(&CPlayerController::GetInstance());
 
     // stop all remaining scripts; must be done after skin has been unloaded,
     // not before some windows still need it when deinitializing during skin

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -1,0 +1,462 @@
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "PlayerController.h"
+#include "dialogs/GUIDialogSlider.h"
+#include "settings/AdvancedSettings.h"
+#include "settings/MediaSettings.h"
+#include "settings/Settings.h"
+#include "cores/IPlayer.h"
+#include "guilib/Key.h"
+#include "guilib/LocalizeStrings.h"
+#include "guilib/GUISliderControl.h"
+#include "dialogs/GUIDialogKaiToast.h"
+#include "video/dialogs/GUIDialogAudioSubtitleSettings.h"
+#ifdef HAS_VIDEO_PLAYBACK
+#include "cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h"
+#endif
+#include "Application.h"
+#include "utils/LangCodeExpander.h"
+#include "utils/StringUtils.h"
+
+CPlayerController::CPlayerController()
+  : m_sliderAction(0)
+{
+}
+
+CPlayerController::~CPlayerController()
+{
+}
+
+CPlayerController& CPlayerController::GetInstance()
+{
+  static CPlayerController instance;
+  return instance;
+}
+
+bool CPlayerController::OnAction(const CAction &action)
+{
+  const unsigned int MsgTime = 300;
+  const unsigned int DisplTime = 2000;
+
+  if (g_application.m_pPlayer->IsPlayingVideo())
+  {
+    switch (action.GetID())
+    {
+      case ACTION_SHOW_SUBTITLES:
+      {
+        if (g_application.m_pPlayer->GetSubtitleCount() == 0)
+          return true;
+
+        bool subsOn = !g_application.m_pPlayer->GetSubtitleVisible();
+        g_application.m_pPlayer->SetSubtitleVisible(subsOn);
+        std::string sub, lang;
+        if (subsOn)
+        {
+          SPlayerSubtitleStreamInfo info;
+          g_application.m_pPlayer->GetSubtitleStreamInfo(g_application.m_pPlayer->GetSubtitle(), info);
+          if (!g_LangCodeExpander.Lookup(info.language, lang))
+            lang = g_localizeStrings.Get(13205); // Unknown
+
+          if (info.name.length() == 0)
+            sub = lang;
+          else
+            sub = StringUtils::Format("%s - %s", lang.c_str(), info.name.c_str());
+        }
+        else
+          sub = g_localizeStrings.Get(1223);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                              g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_NEXT_SUBTITLE:
+      case ACTION_CYCLE_SUBTITLE:
+      {
+        if (g_application.m_pPlayer->GetSubtitleCount() == 0)
+          return true;
+
+        int currentSub = g_application.m_pPlayer->GetSubtitle();
+        bool currentSubVisible = true;
+
+        if (g_application.m_pPlayer->GetSubtitleVisible())
+        {
+          if (++currentSub >= g_application.m_pPlayer->GetSubtitleCount())
+          {
+            currentSub = 0;
+            if (action.GetID() == ACTION_NEXT_SUBTITLE)
+            {
+              g_application.m_pPlayer->SetSubtitleVisible(false);
+              currentSubVisible = false;
+            }
+          }
+          g_application.m_pPlayer->SetSubtitle(currentSub);
+        }
+        else if (action.GetID() == ACTION_NEXT_SUBTITLE)
+        {
+          g_application.m_pPlayer->SetSubtitleVisible(true);
+        }
+
+        std::string sub, lang;
+        if (currentSubVisible)
+        {
+          SPlayerSubtitleStreamInfo info;
+          g_application.m_pPlayer->GetSubtitleStreamInfo(currentSub, info);
+          if (!g_LangCodeExpander.Lookup(info.language, lang))
+            lang = g_localizeStrings.Get(13205); // Unknown
+
+          if (info.name.length() == 0)
+            sub = lang;
+          else
+            sub = StringUtils::Format("%s - %s", lang.c_str(), info.name.c_str());
+        }
+        else
+          sub = g_localizeStrings.Get(1223);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(287), sub, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_DELAY_MIN:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+
+        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_DELAY_PLUS:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+
+        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_DELAY:
+      {
+        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+                                          -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
+                                           g_advancedSettings.m_videoSubsDelayRange, true);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY:
+      {
+        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange, true);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY_MIN:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+
+        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange);
+        return true;
+      }
+
+      case ACTION_AUDIO_DELAY_PLUS:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+
+        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+                                        -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
+                                         g_advancedSettings.m_videoAudioDelayRange);
+        return true;
+      }
+
+      case ACTION_AUDIO_NEXT_LANGUAGE:
+      {
+        if (g_application.m_pPlayer->GetAudioStreamCount() == 1)
+          return true;
+
+        int currentAudio = g_application.m_pPlayer->GetAudioStream();
+
+        if (++currentAudio >= g_application.m_pPlayer->GetAudioStreamCount())
+          currentAudio = 0;
+        g_application.m_pPlayer->SetAudioStream(currentAudio);    // Set the audio stream to the one selected
+        std::string aud;
+        std::string lan;
+        SPlayerAudioStreamInfo info;
+        g_application.m_pPlayer->GetAudioStreamInfo(currentAudio, info);
+        if (!g_LangCodeExpander.Lookup(info.language, lan))
+          lan = g_localizeStrings.Get(13205); // Unknown
+        if (info.name.empty())
+          aud = lan;
+        else
+          aud = StringUtils::Format("%s - %s", lan.c_str(), info.name.c_str());
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, g_localizeStrings.Get(460), aud, DisplTime, false, MsgTime);
+        return true;
+      }
+
+      case ACTION_ZOOM_IN:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount += 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount > 2.f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 216, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_ZOOM_OUT:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount -= 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 0.5f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 216, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_INCREASE_PAR:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 217, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_DECREASE_PAR:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 217, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_VSHIFT_UP:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift -= 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift < -2.0f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift = -2.0f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 225, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_VSHIFT_DOWN:
+      {
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift += 0.01f;
+        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift > 2.0f)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift = 2.0f;
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
+        ShowSlider(action.GetID(), 225, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_VSHIFT_UP:
+      {
+        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
+        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
+        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
+        {
+          res_info.iSubtitles ++;
+          if (res_info.iSubtitles >= res_info.iHeight)
+            res_info.iSubtitles = res_info.iHeight - 1;
+
+          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+        }
+        else
+        {
+          res_info.iSubtitles --;
+          if (res_info.iSubtitles < 0)
+            res_info.iSubtitles = 0;
+
+          if (subalign == SUBTITLE_ALIGN_MANUAL)
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+          else
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
+        }
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_VSHIFT_DOWN:
+      {
+        RESOLUTION_INFO res_info =  g_graphicsContext.GetResInfo();
+        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
+        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
+        {
+          res_info.iSubtitles--;
+          if (res_info.iSubtitles < 0)
+            res_info.iSubtitles = 0;
+
+          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+        }
+        else
+        {
+          res_info.iSubtitles++;
+          if (res_info.iSubtitles >= res_info.iHeight)
+            res_info.iSubtitles = res_info.iHeight - 1;
+
+          if (subalign == SUBTITLE_ALIGN_MANUAL)
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
+          else
+            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
+        }
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
+      }
+
+      case ACTION_SUBTITLE_ALIGN:
+      {
+        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
+        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
+
+        subalign++;
+        if (subalign > SUBTITLE_ALIGN_TOP_OUTSIDE)
+          subalign = SUBTITLE_ALIGN_MANUAL;
+
+        res_info.iSubtitles = res_info.iHeight - 1;
+
+        CSettings::GetInstance().SetInt(CSettings::SETTING_SUBTITLES_ALIGN, subalign);
+        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
+                                              g_localizeStrings.Get(21460),
+                                              g_localizeStrings.Get(21461 + subalign),
+                                              TOAST_DISPLAY_TIME, false);
+        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
+        return true;
+      }
+
+      case ACTION_VOLAMP_UP:
+      case ACTION_VOLAMP_DOWN:
+      {
+        // Don't allow change with passthrough audio
+        if (g_application.m_pPlayer->IsPassthrough())
+        {
+          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
+                                                g_localizeStrings.Get(660),
+                                                g_localizeStrings.Get(29802),
+                                                TOAST_DISPLAY_TIME, false);
+          return false;
+        }
+
+        float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
+        float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
+
+        if (action.GetID() == ACTION_VOLAMP_UP)
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification += 1.0f;
+        else
+          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification -= 1.0f;
+
+        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification =
+          std::max(std::min(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification, sliderMax), sliderMin);
+
+        g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+
+        ShowSlider(action.GetID(), 660, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification, sliderMin, 1.0f, sliderMax);
+        return true;
+      }
+
+      case ACTION_VOLAMP:
+      {
+        float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
+        float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
+        ShowSlider(action.GetID(), 660,
+                   CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification,
+                   sliderMin, 1.0f, sliderMax, true);
+        return true;
+      }
+
+      default:
+        break;
+    }
+  }
+  return false;
+}
+
+void CPlayerController::ShowSlider(int action, int label, float value, float min, float delta, float max, bool modal)
+{
+  m_sliderAction = action;
+  if (modal)
+    CGUIDialogSlider::ShowAndGetInput(g_localizeStrings.Get(label), value, min, delta, max, this);
+  else
+    CGUIDialogSlider::Display(label, value, min, delta, max, this);
+}
+
+void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
+{
+  if (!slider)
+    return;
+
+  if (m_sliderAction == ACTION_ZOOM_OUT || m_sliderAction == ACTION_ZOOM_IN ||
+      m_sliderAction == ACTION_INCREASE_PAR || m_sliderAction == ACTION_DECREASE_PAR ||
+      m_sliderAction == ACTION_VSHIFT_UP || m_sliderAction == ACTION_VSHIFT_DOWN ||
+      m_sliderAction == ACTION_SUBTITLE_VSHIFT_UP || m_sliderAction == ACTION_SUBTITLE_VSHIFT_DOWN)
+  {
+    std::string strValue = StringUtils::Format("%1.2f",slider->GetFloatValue());
+    slider->SetTextValue(strValue);
+  }
+  else if (m_sliderAction == ACTION_VOLAMP_UP ||
+          m_sliderAction == ACTION_VOLAMP_DOWN ||
+          m_sliderAction == ACTION_VOLAMP)
+    slider->SetTextValue(CGUIDialogAudioSubtitleSettings::FormatDecibel(slider->GetFloatValue()));
+  else
+    slider->SetTextValue(CGUIDialogAudioSubtitleSettings::FormatDelay(slider->GetFloatValue(), 0.025f));
+
+  if (g_application.m_pPlayer->HasPlayer())
+  {
+    if (m_sliderAction == ACTION_AUDIO_DELAY)
+    {
+      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = slider->GetFloatValue();
+      g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+    }
+    else if (m_sliderAction == ACTION_SUBTITLE_DELAY)
+    {
+      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = slider->GetFloatValue();
+      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+    }
+    else if (m_sliderAction == ACTION_VOLAMP)
+    {
+      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification = slider->GetFloatValue();
+      g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification * 100));
+    }
+  }
+}

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -29,9 +29,6 @@
 #include "guilib/GUISliderControl.h"
 #include "dialogs/GUIDialogKaiToast.h"
 #include "video/dialogs/GUIDialogAudioSubtitleSettings.h"
-#ifdef HAS_VIDEO_PLAYBACK
-#include "cores/VideoPlayer/VideoRenderers/OverlayRendererGUI.h"
-#endif
 #include "Application.h"
 #include "utils/LangCodeExpander.h"
 #include "utils/StringUtils.h"
@@ -88,7 +85,6 @@ bool CPlayerController::OnAction(const CAction &action)
       }
 
       case ACTION_NEXT_SUBTITLE:
-      case ACTION_CYCLE_SUBTITLE:
       {
         if (g_application.m_pPlayer->GetSubtitleCount() == 0)
           return true;
@@ -269,142 +265,6 @@ bool CPlayerController::OnAction(const CAction &action)
         return true;
       }
 
-      case ACTION_VSHIFT_UP:
-      {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift -= 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift < -2.0f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift = -2.0f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 225, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
-        return true;
-      }
-
-      case ACTION_VSHIFT_DOWN:
-      {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift += 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift > 2.0f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift = 2.0f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
-        g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 225, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomVerticalShift, -2.0f, 0.1f, 2.0f);
-        return true;
-      }
-
-      case ACTION_SUBTITLE_VSHIFT_UP:
-      {
-        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
-        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
-        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
-        {
-          res_info.iSubtitles ++;
-          if (res_info.iSubtitles >= res_info.iHeight)
-            res_info.iSubtitles = res_info.iHeight - 1;
-
-          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
-        }
-        else
-        {
-          res_info.iSubtitles --;
-          if (res_info.iSubtitles < 0)
-            res_info.iSubtitles = 0;
-
-          if (subalign == SUBTITLE_ALIGN_MANUAL)
-            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
-          else
-            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
-        }
-        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-        return true;
-      }
-
-      case ACTION_SUBTITLE_VSHIFT_DOWN:
-      {
-        RESOLUTION_INFO res_info =  g_graphicsContext.GetResInfo();
-        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
-        if ((subalign == SUBTITLE_ALIGN_BOTTOM_OUTSIDE) || (subalign == SUBTITLE_ALIGN_TOP_INSIDE))
-        {
-          res_info.iSubtitles--;
-          if (res_info.iSubtitles < 0)
-            res_info.iSubtitles = 0;
-
-          ShowSlider(action.GetID(), 274, (float) res_info.iHeight - res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
-        }
-        else
-        {
-          res_info.iSubtitles++;
-          if (res_info.iSubtitles >= res_info.iHeight)
-            res_info.iSubtitles = res_info.iHeight - 1;
-
-          if (subalign == SUBTITLE_ALIGN_MANUAL)
-            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles, 0.0f, 1.0f, (float) res_info.iHeight);
-          else
-            ShowSlider(action.GetID(), 274, (float) res_info.iSubtitles - res_info.iHeight, (float) -res_info.iHeight, -1.0f, 0.0f);
-        }
-        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-        return true;
-      }
-
-      case ACTION_SUBTITLE_ALIGN:
-      {
-        RESOLUTION_INFO res_info = g_graphicsContext.GetResInfo();
-        int subalign = CSettings::GetInstance().GetInt(CSettings::SETTING_SUBTITLES_ALIGN);
-
-        subalign++;
-        if (subalign > SUBTITLE_ALIGN_TOP_OUTSIDE)
-          subalign = SUBTITLE_ALIGN_MANUAL;
-
-        res_info.iSubtitles = res_info.iHeight - 1;
-
-        CSettings::GetInstance().SetInt(CSettings::SETTING_SUBTITLES_ALIGN, subalign);
-        CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info,
-                                              g_localizeStrings.Get(21460),
-                                              g_localizeStrings.Get(21461 + subalign),
-                                              TOAST_DISPLAY_TIME, false);
-        g_graphicsContext.SetResInfo(g_graphicsContext.GetVideoResolution(), res_info);
-        return true;
-      }
-
-      case ACTION_VOLAMP_UP:
-      case ACTION_VOLAMP_DOWN:
-      {
-        // Don't allow change with passthrough audio
-        if (g_application.m_pPlayer->IsPassthrough())
-        {
-          CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Warning,
-                                                g_localizeStrings.Get(660),
-                                                g_localizeStrings.Get(29802),
-                                                TOAST_DISPLAY_TIME, false);
-          return false;
-        }
-
-        float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
-        float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
-
-        if (action.GetID() == ACTION_VOLAMP_UP)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification += 1.0f;
-        else
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification -= 1.0f;
-
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification =
-          std::max(std::min(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification, sliderMax), sliderMin);
-
-        g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification * 100));
-
-        ShowSlider(action.GetID(), 660, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification, sliderMin, 1.0f, sliderMax);
-        return true;
-      }
-
-      case ACTION_VOLAMP:
-      {
-        float sliderMax = VOLUME_DRC_MAXIMUM / 100.0f;
-        float sliderMin = VOLUME_DRC_MINIMUM / 100.0f;
-        ShowSlider(action.GetID(), 660,
-                   CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification,
-                   sliderMin, 1.0f, sliderMax, true);
-        return true;
-      }
-
       default:
         break;
     }
@@ -427,17 +287,11 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
     return;
 
   if (m_sliderAction == ACTION_ZOOM_OUT || m_sliderAction == ACTION_ZOOM_IN ||
-      m_sliderAction == ACTION_INCREASE_PAR || m_sliderAction == ACTION_DECREASE_PAR ||
-      m_sliderAction == ACTION_VSHIFT_UP || m_sliderAction == ACTION_VSHIFT_DOWN ||
-      m_sliderAction == ACTION_SUBTITLE_VSHIFT_UP || m_sliderAction == ACTION_SUBTITLE_VSHIFT_DOWN)
+      m_sliderAction == ACTION_INCREASE_PAR || m_sliderAction == ACTION_DECREASE_PAR)
   {
     std::string strValue = StringUtils::Format("%1.2f",slider->GetFloatValue());
     slider->SetTextValue(strValue);
   }
-  else if (m_sliderAction == ACTION_VOLAMP_UP ||
-          m_sliderAction == ACTION_VOLAMP_DOWN ||
-          m_sliderAction == ACTION_VOLAMP)
-    slider->SetTextValue(CGUIDialogAudioSubtitleSettings::FormatDecibel(slider->GetFloatValue()));
   else
     slider->SetTextValue(CGUIDialogAudioSubtitleSettings::FormatDelay(slider->GetFloatValue(), 0.025f));
 
@@ -452,11 +306,6 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
     {
       CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = slider->GetFloatValue();
       g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
-    }
-    else if (m_sliderAction == ACTION_VOLAMP)
-    {
-      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification = slider->GetFloatValue();
-      g_application.m_pPlayer->SetDynamicRangeCompression((long)(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_VolumeAmplification * 100));
     }
   }
 }

--- a/xbmc/video/PlayerController.cpp
+++ b/xbmc/video/PlayerController.cpp
@@ -131,12 +131,12 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_DELAY_MIN:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
-        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay -= 0.1f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay < -g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = -g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
 
-        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
                                           -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
                                            g_advancedSettings.m_videoSubsDelayRange);
         return true;
@@ -144,12 +144,12 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_DELAY_PLUS:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
-        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+        CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay += 0.1f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay > g_advancedSettings.m_videoSubsDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = g_advancedSettings.m_videoSubsDelayRange;
+        g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
 
-        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
                                           -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
                                            g_advancedSettings.m_videoSubsDelayRange);
         return true;
@@ -157,7 +157,7 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_SUBTITLE_DELAY:
       {
-        ShowSlider(action.GetID(), 22006, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay,
+        ShowSlider(action.GetID(), 22006, CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay,
                                           -g_advancedSettings.m_videoSubsDelayRange, 0.1f,
                                            g_advancedSettings.m_videoSubsDelayRange, true);
         return true;
@@ -165,7 +165,7 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_AUDIO_DELAY:
       {
-        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
                                         -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
                                          g_advancedSettings.m_videoAudioDelayRange, true);
         return true;
@@ -173,12 +173,12 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_AUDIO_DELAY_MIN:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
-        g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay -= 0.025f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay < -g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = -g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
 
-        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
                                         -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
                                          g_advancedSettings.m_videoAudioDelayRange);
         return true;
@@ -186,12 +186,12 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_AUDIO_DELAY_PLUS:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
-        g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+        CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay += 0.025f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay > g_advancedSettings.m_videoAudioDelayRange)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = g_advancedSettings.m_videoAudioDelayRange;
+        g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
 
-        ShowSlider(action.GetID(), 297, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay,
+        ShowSlider(action.GetID(), 297, CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay,
                                         -g_advancedSettings.m_videoAudioDelayRange, 0.025f,
                                          g_advancedSettings.m_videoAudioDelayRange);
         return true;
@@ -223,45 +223,45 @@ bool CPlayerController::OnAction(const CAction &action)
 
       case ACTION_ZOOM_IN:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount += 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount > 2.f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount += 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount > 2.f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 216, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
         return true;
       }
 
       case ACTION_ZOOM_OUT:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount -= 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 0.5f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount -= 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 0.5f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 216, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
+        ShowSlider(action.GetID(), 216, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount, 0.5f, 0.1f, 2.0f);
         return true;
       }
 
       case ACTION_INCREASE_PAR:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio += 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio > 2.f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount = 2.f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 217, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
         return true;
       }
 
       case ACTION_DECREASE_PAR:
       {
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
-        if (CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
-          CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
-        CMediaSettings::GetInstance().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio -= 0.01f;
+        if (CMediaSettings::Get().GetCurrentVideoSettings().m_CustomZoomAmount < 0.5f)
+          CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio = 0.5f;
+        CMediaSettings::Get().GetCurrentVideoSettings().m_ViewMode = ViewModeCustom;
         g_application.m_pPlayer->SetRenderViewMode(ViewModeCustom);
-        ShowSlider(action.GetID(), 217, CMediaSettings::GetInstance().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
+        ShowSlider(action.GetID(), 217, CMediaSettings::Get().GetCurrentVideoSettings().m_CustomPixelRatio, 0.5f, 0.1f, 2.0f);
         return true;
       }
 
@@ -299,13 +299,13 @@ void CPlayerController::OnSliderChange(void *data, CGUISliderControl *slider)
   {
     if (m_sliderAction == ACTION_AUDIO_DELAY)
     {
-      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay = slider->GetFloatValue();
-      g_application.m_pPlayer->SetAVDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_AudioDelay);
+      CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay = slider->GetFloatValue();
+      g_application.m_pPlayer->SetAVDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_AudioDelay);
     }
     else if (m_sliderAction == ACTION_SUBTITLE_DELAY)
     {
-      CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay = slider->GetFloatValue();
-      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::GetInstance().GetCurrentVideoSettings().m_SubtitleDelay);
+      CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay = slider->GetFloatValue();
+      g_application.m_pPlayer->SetSubTitleDelay(CMediaSettings::Get().GetCurrentVideoSettings().m_SubtitleDelay);
     }
   }
 }

--- a/xbmc/video/PlayerController.h
+++ b/xbmc/video/PlayerController.h
@@ -1,0 +1,68 @@
+#pragma once
+
+/*
+ *      Copyright (C) 2012-2013 Team XBMC
+ *      http://xbmc.org
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, see
+ *  <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "guilib/ISliderCallback.h"
+#include "guilib/Key.h"
+#include "interfaces/IActionListener.h"
+
+/*! \brief Player controller class to handle user actions.
+
+ Handles actions that are normally suited to fullscreen playback, such as
+ altering subtitles and audio tracks, changing aspect ratio, subtitle placement,
+ and placement of the video on screen.
+ */
+class CPlayerController : public ISliderCallback, public IActionListener
+{
+public:
+  static CPlayerController& GetInstance();
+
+  /*! \brief Perform a player control action if appropriate.
+  \param action the action to perform.
+  \return true if the action is considered handled, false if it should be handled elsewhere.
+  */
+  virtual bool OnAction(const CAction &action);
+
+  /*! \brief Callback from the slider dialog.
+   \sa CGUIDialogSlider
+   */
+  virtual void OnSliderChange(void *data, CGUISliderControl *slider);
+
+protected:
+  CPlayerController();
+  CPlayerController(const CPlayerController&);
+  CPlayerController& operator=(CPlayerController const&);
+  virtual ~CPlayerController();
+
+private:
+  /*! \brief pop up a slider dialog for a particular action
+   \param action id of the action the slider responds to
+   \param label id of the label to display
+   \param value value to set on the slider
+   \param min minimum value the slider may take
+   \param delta change value to advance the slider by with each click
+   \param max maximal value the slider may take
+   \param modal true if we should wait for the slider to finish. Defaults to false
+   */
+  void ShowSlider(int action, int label, float value, float min, float delta, float max, bool modal = false);
+
+  int m_sliderAction; ///< \brief set to the action id for a slider being displayed \sa ShowSlider
+};


### PR DESCRIPTION
This PR is backport of CPlayerController from Kodi Krypton. This moves actions from CGUIWindowFullscreen to CPlayerController which is processed by all windows. This will allow custom dialogs from Estuary to control things like audio, subtitles etc.

This PR fixes broken subtitles and audio settings when using Estuary skin, becase estuary is not calling them from video fullscreen.

Things like subtitle position, volumeamp etc. are removed.