### PR TITLE
[Locales] cleanup: remove unused locales - part 1

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -84,12 +84,7 @@ msgctxt "#8"
 msgid "Weather"
 msgstr ""
 
-#: Unknown
-msgctxt "#9"
-msgid "XBMC media center"
-msgstr ""
-
-#empty string with id 10
+#empty strings from id 9 to 10
 
 #. Weather token
 msgctxt "#11"
@@ -727,10 +722,7 @@ msgctxt "#169"
 msgid "Resolution"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#170"
-msgid "Adjust display refresh rate"
-msgstr ""
+#empty string with id 170
 
 #: xbmc/playlists/SmartPlayList.cpp
 #: xbmc/utils/SortUtils.cpp
@@ -989,12 +981,7 @@ msgctxt "#224"
 msgid "Speed"
 msgstr ""
 
-#empty string with id 225
-
-#: system/settings/settings.xml
-msgctxt "#226"
-msgid "Test patterns..."
-msgstr ""
+#empty strings from id 225 to 226
 
 #: system/settings/settings.xml
 msgctxt "#227"
@@ -1091,9 +1078,7 @@ msgctxt "#252"
 msgid "Output stereo to all speakers"
 msgstr ""
 
-msgctxt "#253"
-msgid "Number of channels"
-msgstr ""
+#empty string with id 253
 
 #: system/settings/settings.xml
 msgctxt "#254"
@@ -2689,17 +2674,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#621"
 msgid "Encoder"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#622"
-msgid "Quality"
-msgstr ""
-
-#: system/settings/settings.xml
-#: addons/skin.estuary/1080i/MusicVisualisation.xml
-msgctxt "#623"
-msgid "Bitrate"
 msgstr ""
 
 msgctxt "#624"
@@ -5597,10 +5571,6 @@ msgctxt "#13303"
 msgid "Fonts"
 msgstr ""
 
-msgctxt "#13304"
-msgid "Enable flipping bi-directional strings"
-msgstr ""
-
 #: system/settings/settings.xml
 msgctxt "#13305"
 msgid "Show RSS news feeds"
@@ -5616,28 +5586,7 @@ msgctxt "#13307"
 msgid "Track naming template"
 msgstr ""
 
-#: unused
-msgctxt "#13308"
-msgid "Do you wish to reboot your system instead of just this application?"
-msgstr ""
-
 #empty string with id 13309
-
-msgctxt "#13310"
-msgid "Zoom effect"
-msgstr ""
-
-msgctxt "#13311"
-msgid "Float effect"
-msgstr ""
-
-msgctxt "#13312"
-msgid "Black bar reduction"
-msgstr ""
-
-msgctxt "#13313"
-msgid "Restart"
-msgstr ""
 
 #: system/settings/settings.xml
 msgctxt "#13314"
@@ -5646,10 +5595,6 @@ msgstr ""
 
 msgctxt "#13315"
 msgid "Regenerate thumbnails"
-msgstr ""
-
-msgctxt "#13316"
-msgid "Recursive thumbnails"
 msgstr ""
 
 #: addons/skin.estuary/1080i/MyPics.xml
@@ -5672,25 +5617,9 @@ msgctxt "#13320"
 msgid "Stereo"
 msgstr ""
 
-msgctxt "#13321"
-msgid "Left only"
-msgstr ""
-
-msgctxt "#13322"
-msgid "Right only"
-msgstr ""
-
 #: system/settings/settings.xml
 msgctxt "#13323"
 msgid "Enable karaoke support"
-msgstr ""
-
-msgctxt "#13324"
-msgid "Background transparency"
-msgstr ""
-
-msgctxt "#13325"
-msgid "Foreground transparency"
 msgstr ""
 
 msgctxt "#13326"
@@ -5776,10 +5705,6 @@ msgstr ""
 
 msgctxt "#13347"
 msgid "Queue item"
-msgstr ""
-
-msgctxt "#13348"
-msgid "Search IMDb..."
 msgstr ""
 
 msgctxt "#13349"
@@ -5991,17 +5916,9 @@ msgctxt "#13407"
 msgid "%s presets"
 msgstr ""
 
-msgctxt "#13408"
-msgid "(IMDb user rating)"
-msgstr ""
-
 #: xbmc/playlists/SmartPlaylist.cpp
 msgctxt "#13409"
 msgid "Top 250"
-msgstr ""
-
-msgctxt "#13410"
-msgid "Tune in on Last.fm"
 msgstr ""
 
 msgctxt "#13411"
@@ -6025,28 +5942,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#13415"
 msgid "Render method"
-msgstr ""
-
-#: system/settings/settings.xml
-#: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
-msgctxt "#13416"
-msgid "Auto detect"
-msgstr ""
-
-#: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
-msgctxt "#13417"
-msgid "Basic shaders (ARB)"
-msgstr ""
-
-#: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
-msgctxt "#13418"
-msgid "Advanced shaders (GLSL)"
-msgstr ""
-
-#: system/settings/settings.xml
-#: xbmc/cores/VideoPlayer/VideoRenderers/BaseRenderer.cpp
-msgctxt "#13419"
-msgid "Software"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogContextMenu.cpp
@@ -6162,91 +6057,11 @@ msgctxt "#13557"
 msgid "Skip delay"
 msgstr ""
 
-#empty strings from id 13558 to 13999
-
-msgctxt "#14000"
-msgid "Stack"
-msgstr ""
-
-msgctxt "#14001"
-msgid "Unstack"
-msgstr ""
-
-#empty string with id 14002
-
-msgctxt "#14003"
-msgid "Downloading playlist file..."
-msgstr ""
-
-msgctxt "#14004"
-msgid "Downloading streams list..."
-msgstr ""
-
-msgctxt "#14005"
-msgid "Parsing streams list..."
-msgstr ""
-
-msgctxt "#14006"
-msgid "Downloading streams list failed"
-msgstr ""
-
-msgctxt "#14007"
-msgid "Downloading playlist file failed"
-msgstr ""
-
-#empty string with id 14008
-
-msgctxt "#14009"
-msgid "Games directory"
-msgstr ""
-
-msgctxt "#14010"
-msgid "Auto switch to thumbs based on"
-msgstr ""
-
-msgctxt "#14011"
-msgid "Enable auto switching to thumbs view"
-msgstr ""
-
-msgctxt "#14012"
-msgid "- Use large icons"
-msgstr ""
-
-msgctxt "#14013"
-msgid "- Switch based on"
-msgstr ""
-
-msgctxt "#14014"
-msgid "- Percentage"
-msgstr ""
-
-msgctxt "#14015"
-msgid "No files and at least one thumb"
-msgstr ""
-
-msgctxt "#14016"
-msgid "At least one file and thumb"
-msgstr ""
-
-msgctxt "#14017"
-msgid "Percentage of thumbs"
-msgstr ""
+#empty strings from id 13558 to 14017
 
 #: addons/skin.estuary/1080i/Includes_MediaMenu.xml
 msgctxt "#14018"
 msgid "View options"
-msgstr ""
-
-msgctxt "#14019"
-msgid "Change area code 1"
-msgstr ""
-
-msgctxt "#14020"
-msgid "Change area code 2"
-msgstr ""
-
-msgctxt "#14021"
-msgid "Change area code 3"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6255,10 +6070,6 @@ msgstr ""
 #: xbmc/vide/windows/GUIWindowVideoBase.cpp
 msgctxt "#14022"
 msgid "Library"
-msgstr ""
-
-msgctxt "#14023"
-msgid "No TV"
 msgstr ""
 
 msgctxt "#14024"
@@ -6514,11 +6325,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#14080"
 msgid "Timezone"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#14081"
-msgid "File lists"
 msgstr ""
 
 #: system/settings/settings.xml
@@ -6928,34 +6734,7 @@ msgctxt "#14277"
 msgid "Allow remote control from applications on other systems"
 msgstr "
 
-#empty strings from id 14278 to 14299
-
-#: system/settings/settings.xml
-msgctxt "#14300"
-msgid "PVR Manager"
-msgstr "
-
-#: system/settings/settings.xml
-msgctxt "#14301"
-msgid "Channels"
-msgstr "
-
-#: system/settings/settings.xml
-msgctxt "#14302"
-msgid "Icons"
-msgstr "
-
-#: system/settings/settings.xml
-msgctxt "#14303"
-msgid "Updates"
-msgstr "
-
-#: system/settings/settings.xml
-msgctxt "#14304"
-msgid "RDS Radio"
-msgstr "
-
-#empty strings from id 14305 to 15010
+#empty strings from id 14278 to 15010
 
 #: xbmc/music/MusicDatabase.cpp
 #: xbmc/video/VideoDatabase.cpp
@@ -7609,168 +7388,10 @@ msgctxt "#19000"
 msgid "Switch to channel"
 msgstr ""
 
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
-msgctxt "#19001"
-msgid "Separate the search words by using AND, OR and / or NOT."
-msgstr ""
-
-#: addons/skin.estuary/1080i/DialogPVRGuideSearch.xml
-msgctxt "#19002"
-msgid "or use phrases to find an exact match, like \"The wizard of Oz\"."
-msgstr ""
-
-#. Label of a button / context menu entry to find similar programs (matching a given epg event)
-#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
-#: xbmc/pvr/windows/GUIWindowPVRGuide.cpp
-#: xbmc/pvr/windows/GUIWindowPVRRecordings.cpp
-msgctxt "#19003"
-msgid "Find similar"
-msgstr ""
-
-#: xbmc/epg/EpgContainer.cpp
-msgctxt "#19004"
-msgid "Importing guide from clients"
-msgstr ""
-
-#: addons/skin.estuary/1080i/VideoFullScreen.xml
-msgctxt "#19005"
-msgid "PVR stream information"
-msgstr ""
-
-msgctxt "#19006"
-msgid "Receiving device"
-msgstr ""
-
-msgctxt "#19007"
-msgid "Device status"
-msgstr ""
-
-#: addons/skin.estuary/1080i/VideoFullScreen.xml
-msgctxt "#19008"
-msgid "Signal quality"
-msgstr ""
-
-#: addons/skin.estuary/1080i/VideoFullScreen.xml
-msgctxt "#19009"
-msgid "SNR"
-msgstr ""
-
-msgctxt "#19010"
-msgid "BER"
-msgstr ""
-
-msgctxt "#19011"
-msgid "UNC"
-msgstr ""
-
-#: xbmc/windows/GUIWindowSystemInfo.cpp
-msgctxt "#19012"
-msgid "PVR backend"
-msgstr ""
-
-#: xbmc/pvr/channels/PVRChannel.cpp
-msgctxt "#19013"
-msgid "Free to air"
-msgstr ""
-
-#: xbmc/pvr/channels/PVRChannel.cpp
-msgctxt "#19014"
-msgid "Fixed"
-msgstr ""
-
-msgctxt "#19015"
-msgid "Encryption"
-msgstr ""
-
-#: unused
-msgctxt "#19016"
-msgid "PVR backend %i - %s"
-msgstr ""
-
-#: xbmc/dialogs/GUIDialogMediaSource.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-msgctxt "#19017"
-msgid "Recordings"
-msgstr ""
-
-#. Name of a setting, asking to enter the path to a folder that contains icons for TV channels
-#: system/settings/settings.xml
-msgctxt "#19018"
-msgid "Folder with channel icons"
-msgstr ""
-
-#: xbmc/windows/GUIWindowSystemInfo.cpp
-#: addons/skin.estuary/1080i/DialogPVRGuideOSD.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelsOSD.xml
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/Home.xml
-msgctxt "#19019"
-msgid "Channels"
-msgstr ""
-
-#: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
-#: xbmc/pvr/PVRManager.cpp
-#: addons/skin.estuary/1080i/Includes.xml
-#: addons/skin.estuary/1080i/Home.xml
-msgctxt "#19020"
-msgid "TV"
-msgstr ""
-
-#: xbmc/pvr/channels/PVRChannelGroupsContainer.cpp
-#: xbmc/pvr/PVRManager.cpp
-#: addons/skin.estuary/1080i/Home.xml
-msgctxt "#19021"
-msgid "Radio"
-msgstr ""
-
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: xbmc/pvr/windows/GUIWindowPVRChannels.cpp
-msgctxt "#19022"
-msgid "Hidden"
-msgstr ""
-
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: addons/skin.estuary/1080i/Variables.xml
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
-msgctxt "#19023"
-msgid "TV channels"
-msgstr ""
-
-#: xbmc/pvr/dialogs/GUIDialogPVRGroupManager.cpp
-#: addons/skin.estuary/1080i/DialogPVRChannelManager.xml
-#: addons/skin.estuary/1080i/Variables.xml
-msgctxt "#19024"
-msgid "Radio channels"
-msgstr ""
-
-#: xbmc/windows/GUIWindowSystemInfo.cpp
-msgctxt "#19025"
-msgid "Upcoming recordings"
-msgstr ""
-
-msgctxt "#19026"
-msgid "Add timer..."
-msgstr ""
-
-msgctxt "#19027"
-msgid "No search results"
-msgstr ""
-
-msgctxt "#19028"
-msgid "No guide entries"
-msgstr ""
-
 #: addons/skin.estuary/1080i/DialogFullScreenInfo.xml
 #: addons/skin.estuary/1080i/MyPVRGuide.xml
 msgctxt "#19029"
 msgid "Channel"
-msgstr ""
-
-#: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
-#: addons/skin.estuary/1080i/MyWeather.xml
-msgctxt "#19030"
-msgid "Now"
 msgstr ""
 
 #. Label prefix for the next playing tv-show (PVR) or media, like "Next: The Simpsons", "Next: AC/DC - Thunderstruck". It's also used as EPG display mode (EPG: timeline / now / next)
@@ -7778,11 +7399,6 @@ msgstr ""
 #: addons/skin.estuary/1080i/DialogPVRRadioRDSInfo.xml
 msgctxt "#19031"
 msgid "Next"
-msgstr ""
-
-#: addons/skin.estuary/1080i/MyPVRGuide.xml
-msgctxt "#19032"
-msgid "Timeline"
 msgstr ""
 
 #: xbmc/event/windows/GUIWindowEventLog.cpp
@@ -8594,12 +8210,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#20187"
 msgid "UPnP / DLNA"
-msgstr ""
-
-#: xbmc/network/upnp/UPnPServer.cpp
-#: system/settings/settings.xml
-msgctxt "#20188"
-msgid "Announce library updates"
 msgstr ""
 
 #: addons/skin.estuary/1080i/SkinSettings.xml
@@ -9993,13 +9603,6 @@ msgctxt "#21449"
 msgid "Remote control sends keyboard presses"
 msgstr ""
 
-#. Label for controls used to edit something (e.g. setting "Appearance -> Skin -> Edit" or a context menu entry to open timer settings dialog)
-#: system/settings/settings.xml
-#: xbmc/pvr/windows/GUIWindowPVRTimers.cpp
-msgctxt "#21450"
-msgid "Edit"
-msgstr ""
-
 msgctxt "#21451"
 msgid "Internet connection required."
 msgstr ""
@@ -10627,11 +10230,6 @@ msgid "Size"
 msgstr ""
 
 #: system/settings/settings.xml
-msgctxt "#22032"
-msgid "Colours"
-msgstr ""
-
-#: system/settings/settings.xml
 msgctxt "#22033"
 msgid "Charset"
 msgstr ""
@@ -10864,11 +10462,6 @@ msgctxt "#24031"
 msgid "Error loading settings"
 msgstr ""
 
-#: xbmc/pvr/addons/PVRClients.cpp
-msgctxt "#24032"
-msgid "All add-ons"
-msgstr ""
-
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
 #: xbmc/filesystem/AddonsDirectory.cpp
 msgctxt "#24033"
@@ -10959,11 +10552,6 @@ msgctxt "#24049"
 msgid "Incompatible"
 msgstr ""
 
-#: unknown
-msgctxt "#24050"
-msgid "Available add-ons"
-msgstr ""
-
 #: xbmc/peripherals/bus/PeripheralBus.cpp
 #: xbmc/addons/AddonVersion.cpp
 msgctxt "#24051"
@@ -10974,11 +10562,6 @@ msgstr ""
 #: skin.estouchy
 msgctxt "#24052"
 msgid "Disclaimer"
-msgstr ""
-
-#: unknown
-msgctxt "#24053"
-msgid "License:"
 msgstr ""
 
 #: xbmc/addons/GUIDialogAddonInfo.cpp
@@ -11021,29 +10604,6 @@ msgstr ""
 #: xbmc/addons/RepositoryUpdater.cpp
 msgctxt "#24061"
 msgid "Add-on updates available"
-msgstr ""
-
-#: xbmc/addons/GUIViewStateAddonBrowser.cpp
-#: xbmc/filesystem/AddonsDirectory.cpp
-#: xbmc/filesystem/AndroidAppDirectory.cpp
-msgctxt "#24062"
-msgid "Enabled add-ons"
-msgstr ""
-
-msgctxt "#24063"
-msgid "Auto update"
-msgstr ""
-
-#. Used as an event log description for add-ons that have been installed/enabled
-#: xbmc/addons/AddonInstaller.cpp
-#: xbmc/addons/AddonManager.cpp
-msgctxt "#24064"
-msgid "Add-on enabled"
-msgstr ""
-
-#: xbmc/addons/AddonInstaller.cpp
-msgctxt "#24065"
-msgid "Add-on updated"
 msgstr ""
 
 #: xbmc/addons/GUIViewStateAddonBrowser.cpp
@@ -11357,28 +10917,6 @@ msgctxt "#24127"
 msgid "Automatically download first subtitle from the search result list"
 msgstr ""
 
-#. Info dialog after migrating userdata from xbmc to kodi
-#: xbmc/Application.cpp
-msgctxt "#24128"
-msgid "Configuration has been moved"
-msgstr ""
-
-#. Info dialog after migrating userdata from xbmc to kodi
-#: xbmc/Application.cpp
-msgctxt "#24129"
-msgid "The configuration of XBMC has been moved to the new location for Kodi. Please refer to http://kodi.wiki/view/Migration - this message will not be shown again!"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#24130"
-msgid "Enable parsing for closed captions"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#24131"
-msgid "Enable to parse for CC in video stream. Puts slightly more load on the CPU"
-msgstr ""
-
 #: xbmc/addons/LanguageResource.cpp
 msgctxt "#24132"
 msgid "Would you like to switch to this language?"
@@ -11394,24 +10932,12 @@ msgctxt "#24134"
 msgid "We were unable to load your configured language. Please check your language settings."
 msgstr ""
 
-#empty strings from id 24135 to 24138
-
-#. Label for the action provided by addon management events to jump to a specific Add-on
-#: xbmc/events/AddonManagementEvent.cpp
-msgctxt "#24139"
-msgid "View Add-on"
-msgstr ""
+#empty strings from id 24135 to 24139
 
 #. Label for the action provided by media library events to jump to a specific path/file
 #: xbmc/events/MediaLibraryEvent.cpp
 msgctxt "#24140"
 msgid "View"
-msgstr ""
-
-#. Used as an event log description for add-ons that have been disabled
-#: xbmc/addons/AddonManager.cpp
-msgctxt "#24141"
-msgid "Add-on disabled"
 msgstr ""
 
 #. The dependency on <addon id> version <addon version> coult not be satisfied.
@@ -11862,86 +11388,7 @@ msgctxt "#33063"
 msgid "Options"
 msgstr ""
 
-#empty string with id 33064
-
-#: Unknown
-msgctxt "#33065"
-msgid "Editor"
-msgstr ""
-
-#: Unknown
-msgctxt "#33066"
-msgid "About your"
-msgstr ""
-
-#: Unknown
-msgctxt "#33067"
-msgid "Star rating"
-msgstr ""
-
-#: Unknown
-msgctxt "#33068"
-msgid "Background"
-msgstr ""
-
-#: Unknown
-msgctxt "#33069"
-msgid "Backgrounds"
-msgstr ""
-
-#: Unknown
-msgctxt "#33070"
-msgid "Custom background"
-msgstr ""
-
-#: Unknown
-msgctxt "#33071"
-msgid "Custom backgrounds"
-msgstr ""
-
-#: Unknown
-msgctxt "#33072"
-msgid "View readme"
-msgstr ""
-
-#: Unknown
-msgctxt "#33073"
-msgid "View changelog"
-msgstr ""
-
-#empty strings from id 33074 to 33076
-
-#: Unknown
-msgctxt "#33077"
-msgid "No data found!"
-msgstr ""
-
-#: Unknown
-msgctxt "#33078"
-msgid "Next page"
-msgstr ""
-
-#: Unknown
-msgctxt "#33079"
-msgid "Love"
-msgstr ""
-
-#: Unknown
-msgctxt "#33080"
-msgid "Hate"
-msgstr ""
-
-#empty string with id 33081
-
-#: Unknown
-msgctxt "#33082"
-msgid "Path to script"
-msgstr ""
-
-#: Unknown
-msgctxt "#33083"
-msgid "Enable custom script button"
-msgstr ""
+#empty strings from id 33064 to 33083
 
 msgctxt "#33084"
 msgid "Auto login"
@@ -11968,20 +11415,7 @@ msgctxt "#33102"
 msgid "Event server"
 msgstr ""
 
-#: xbmc/network/network.cpp
-#: xbmc/network/NetworkServices.cpp
-msgctxt "#33103"
-msgid "Remote communication server"
-msgstr ""
-
-#empty strings from id 33104 to 33199
-
-#: xbmc/network/eventclient.cpp
-msgctxt "#33200"
-msgid "Detected new connection"
-msgstr ""
-
-#empty strings from id 33201 to 33999
+#empty strings from id 33103 to 33999
 #translators: no need to add these to your language files
 
 #: system/settings/settings.xml
@@ -12006,90 +11440,7 @@ msgctxt "#34005"
 msgid "FLAC"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#34006"
-msgid "MPEG-4 audio (FFmpeg M4A AAC)"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#34007"
-msgid "Windows media audio 2 (FFmpeg wmav2)"
-msgstr ""
-
-#empty strings from id 34008 to 34099
-
-#: system/settings/settings.xml
-msgctxt "#34100"
-msgid "Number of channels"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34101"
-msgid "2.0"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34102"
-msgid "2.1"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34103"
-msgid "3.0"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34104"
-msgid "3.1"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34105"
-msgid "4.0"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34106"
-msgid "4.1"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34107"
-msgid "5.0"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34108"
-msgid "5.1"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34109"
-msgid "7.0"
-msgstr ""
-
-#. Indicates the number of audio channels in settings
-#: system/settings/settings.xml
-msgctxt "#34110"
-msgid "7.1"
-msgstr ""
-
-#. Description of setting with label #421 "Keep audio device alive"
-#: system/settings/settings.xml
-msgctxt "#34111"
-msgid "Select the behaviour when no sound is required for either playback or GUI sounds.[CR][Always] Continuous inaudible signal is output, this keeps the receiving audio device alive for any new sounds, however this might also block sound from other applications.[CR][1-10 Minutes] Same as [Always] except that after the selected period of time audio enters a suspended state.[CR][Off] Audio output enters a suspended state. Note: Sounds can be missed if audio enters suspended state."
-msgstr ""
-
-#empty strings from id 34112 to 34119
+#empty strings from id 34006 to 34119
 #34112-34119 reserved for future use
 
 #: system/settings/settings.xml
@@ -12115,12 +11466,6 @@ msgctxt "#34123"
 msgid "Never"
 msgstr ""
 
-#. SPDIF max sampling rate
-#: system/settings/settings.xml
-msgctxt "#34124"
-msgid "44.1"
-msgstr ""
-
 #empty strings from id 34124 to 34119
 #34129-34200 reserved for future use
 
@@ -12142,37 +11487,8 @@ msgctxt "#36041"
 msgid "* Item folder"
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36042"
-msgid "Use limited colour range (16-235)"
-msgstr ""
-
-#empty string with id 36043
-
-#. Name of an action to perform on a specific event, like changing the CEC source away from Kodi
-#: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-#: system/peripherals.xml
-#: addons/skin.estuary/1080i/Variables.xml
-msgctxt "#36044"
-msgid "Stop Playback"
-msgstr ""
-
-#. Name of an action to perform on a specific event, like changing the CEC source away from Kodi
-#: xbmc/peripherals/devices/PeripheralCecAdapter.cpp
-#: system/peripherals.xml
-msgctxt "#36045"
-msgid "Pause Playback"
-msgstr ""
-
-
-#empty strings from id 36046 to 36100
+#empty strings from id 36042 to 36100
 #strings from 36100 to 36999 are reserved for settings descriptions
-
-#. Description of settings section "Appearance"
-#: system/settings/settings.xml
-msgctxt "#36101"
-msgid "Change the look and feel of the user interface."
-msgstr ""
 
 #. Description of settings category "Appearance -> Skin" with label #166
 #: system/settings/settings.xml
@@ -12372,33 +11688,6 @@ msgctxt "#36134"
 msgid "Dim the display when media is paused. Not valid for the \"Dim\" screensaver mode."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36135"
-msgid "No info available yet."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36136"
-msgid "No info available yet."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36137"
-msgid "No info available yet."
-msgstr ""
-
-#. Description of settings section with label #3 "Videos"
-#: system/settings/settings.xml
-msgctxt "#36138"
-msgid "Section that contains settings related to videos and how they are handled."
-msgstr ""
-
-#. Description of settings category with label #14022 "Library"
-#: system/settings/settings.xml
-msgctxt "#36139"
-msgid "This category contains the settings for how the video library is handled."
-msgstr ""
-
 #. Description of setting with label #14105 "Temperature unit"
 #: system/settings/settings.xml
 msgctxt "#36140"
@@ -12483,82 +11772,16 @@ msgctxt "#36153"
 msgid "Adjust the method used to process and display video."
 msgstr ""
 
-#. Description of setting with label #13435 "Enable HQ Scalers for scaling above"
-#: system/settings/settings.xml
-msgctxt "#36154"
-msgid "Use high quality scalers when upscaling a video by at least this percentage."
-msgstr ""
-
-#. Description of setting with label #13425 "Allow hardware acceleration (VDPAU)"
-#: system/settings/settings.xml
-msgctxt "#36155"
-msgid "Enable VDPAU hardware decoding of video files, mainly used for NVIDIA graphics and in some circumstances AMD graphics."
-msgstr ""
-
-#. Description of setting with label #13426 "Allow hardware acceleration (VAAPI)"
-#: system/settings/settings.xml
-msgctxt "#36156"
-msgid "Enable VAAPI hardware decoding of video files, mainly used for Intel graphics and in some circumstances AMD graphics."
-msgstr ""
-
 #. Description of setting with label #20470 "Use movie sets for single movies"
 #: system/settings/settings.xml
 msgctxt "#36157"
 msgid "When enabled, a \"Movie set\" entry is used even if the movie library contains only a single movie from that set. When disabled, a \"Movie set\" entry is used only if the movie library contains more than one movie from that set."
 msgstr ""
 
-#. Description of setting with label #13427 "Allow hardware acceleration (DXVA2)"
-#: system/settings/settings.xml
-msgctxt "#36158"
-msgid "Enable DXVA2 hardware decoding of video files."
-msgstr ""
-
-#. Description of setting with label #13428 "Allow hardware acceleration (CrystalHD)"
-#: system/settings/settings.xml
-msgctxt "#36159"
-msgid "Enable CrystalHD decoding of video files."
-msgstr ""
-
-#. Description of setting with label #13429 "Allow hardware acceleration (VDADecoder)"
-#: system/settings/settings.xml
-msgctxt "#36160"
-msgid "Enable VTB hardware decoding of video files."
-msgstr ""
-
-#. Description of setting with label #13430 "Allow hardware acceleration (OpenMax)"
-#: system/settings/settings.xml
-msgctxt "#36161"
-msgid "Enable OpenMax hardware decoding of video files."
-msgstr ""
-
-#. Description of setting with label #13432 "Allow hardware acceleration (VideoToolbox)"
-#: system/settings/settings.xml
-msgctxt "#36162"
-msgid "Enable VideoToolbox hardware decoding of video files."
-msgstr ""
-
 #. Description of setting with label #20471 "Show empty TV shows"
 #: system/settings/settings.xml
 msgctxt "#36163"
 msgid "Show TV shows with no episodes when browsing the video library."
-msgstr ""
-
-#. Description of setting with label #170 "Adjust display refresh rate"
-#: system/settings/settings.xml
-msgctxt "#36164"
-msgid "Allow the refresh rate of the display to be changed so that it best matches the video frame rate. This may yield smoother video playback."
-msgstr ""
-
-#. Description of setting with label #13550 "Delay after change of refresh rate"
-#: system/settings/settings.xml
-msgctxt "#36165"
-msgid "Delay of reset event after a change of refresh rate"
-msgstr ""
-
-#. Description of setting with label #13510 "Sync playback to display"
-#: system/settings/settings.xml
-msgctxt "#36166"
-msgid "Synchronise video and audio to the refresh rate of the monitor. VideoPlayer won't use passthrough audio in this case because resampling may be required."
 msgstr ""
 
 #. Description of setting with label #14107 "Time format"
@@ -12573,22 +11796,10 @@ msgctxt "#36168"
 msgid "Choose whether to use 12 or 24-hour format for displaying the time in the user interface."
 msgstr ""
 
-#. Description of setting with label #13505 "Resample quality"
-#: system/settings/settings.xml
-msgctxt "#36169"
-msgid "Select the quality of resampling for cases where the audio output needs to be at a different sampling rate from that used by the source.[CR][Low] Is fast and will have minimal impact on system resources such as the use of the CPU.[CR][Medium] & [High] Will use progressively more system resources."
-msgstr ""
-
 #. Description of setting with label #22021 "Minimise black bars"
 #: system/settings/settings.xml
 msgctxt "#36170"
 msgid "Stretch the video up to the set percentage in order to minimise black bars."
-msgstr ""
-
-#. Description of setting with label #173 "Display 4:3 videos as"
-#: system/settings/settings.xml
-msgctxt "#36171"
-msgid "Select the zoom level that 4:3 videos are shown on widescreen displays."
 msgstr ""
 
 #empty string with id 36172
@@ -12597,24 +11808,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36173"
 msgid "Choose which short date format is used for displaying the date in the user interface."
-msgstr ""
-
-#. Description of setting with label #23050 "Activate Teletext"
-#: system/settings/settings.xml
-msgctxt "#36174"
-msgid "Enable teletext when watching a live TV stream."
-msgstr ""
-
-#. Description of setting with label #23055 "Scale Teletext to 4:3"
-#: system/settings/settings.xml
-msgctxt "#36175"
-msgid "Scale teletext to 4:3 ratio."
-msgstr ""
-
-#. Description of settings category with label #14081 "File lists"
-#: system/settings/settings.xml
-msgctxt "#36176"
-msgid "This category contains the settings for how video file lists are handled."
 msgstr ""
 
 #. Description of setting with label #22079 "Default select action"
@@ -12641,11 +11834,6 @@ msgctxt "#36180"
 msgid "Extract thumbnails and information, such as codecs and aspect ratio, to display in library mode."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36181"
-msgid "No info available yet."
-msgstr ""
-
 #. Description of setting with label #20435 "Combine split video items"
 #: system/settings/settings.xml
 msgctxt "#36182"
@@ -12656,12 +11844,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36183"
 msgid "Removes the title, genre, etc. nodes from the library view. Selecting a category takes you straight to the title view."
-msgstr ""
-
-#. Description of settings category with label #287 "Subtitles"
-#: system/settings/settings.xml
-msgctxt "#36184"
-msgid "This category contains the settings for how subtitles are handled."
 msgstr ""
 
 #. Description of setting with label #14089 "Font to use for text subtitles"
@@ -12694,34 +11876,16 @@ msgctxt "#36189"
 msgid "Set the font character set to be used for subtitles."
 msgstr ""
 
-#. Description of setting with label #21368 "Override ASS/SSA subtitles fonts"
-#: system/settings/settings.xml
-msgctxt "#36190"
-msgid "Override ASS / SSA subtitles fonts."
-msgstr ""
-
 #. Description of setting with label #21366 "Custom subtitle folder"
 #: system/settings/settings.xml
 msgctxt "#36191"
 msgid "Set a custom directory for your subtitles. This can be a file share."
 msgstr ""
 
-#. Description of setting with label #21460 "Subtitle location on screen"
-#: system/settings/settings.xml
-msgctxt "#36192"
-msgid "Location of subtitles on the screen."
-msgstr ""
-
 #. Description of settings category with label #14087 "DVDs"
 #: system/settings/settings.xml
 msgctxt "#36193"
 msgid "This category contains the settings for how DVD's, Blu-ray, & CD's are handled."
-msgstr ""
-
-#. Description of setting with label #14088 "Play DVDs automatically"
-#: system/settings/settings.xml
-msgctxt "#36194"
-msgid "Autorun DVD video when inserted in drive."
 msgstr ""
 
 #. Description of setting with label #21372 "Forced DVD player region"
@@ -12756,271 +11920,13 @@ msgctxt "#36200"
 msgid "Select the default music videos information source. See the add-ons manager for options."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36201"
-msgid "Settings for PVR / Live TV."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36202"
-msgid "This category contains the general settings for the PVR / Live TV."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36203"
-msgid "Enables the \"Personal Video Recorder\" (PVR) features. This requires that at least one PVR add-on is installed."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36204"
-msgid "Import channel groups from the PVR backend (if supported). Will delete user created groups if they're not found on the backend."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36205"
-msgid "Sort the channels by channel number from the backend, but use own numbering for channels."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36206"
-msgid "Use the channel numbering from the backend, instead of configuring them manually in the channel manager. Only works with one enabled PVR add-on!"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36207"
-msgid "Open the channel manager, which allows modifying the channel order, channel name, icon, etc."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36208"
-msgid "Instruct the backend to search for channels (if supported)."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36209"
-msgid "Delete the databases for channels and guide and reimport the data from the backend afterwards."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36210"
-msgid "Prevent the \"Connection lost\" notification window from displaying when the PVR backend server is not available."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36211"
-msgid "This category contains the settings for PVR menus and on-screen display (OSD), as well as channel information windows."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36212"
-msgid "Display programming information when changing channels, such as the current TV show."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36213"
-msgid "Open the group manager, which allows modification of groups and their respective channels"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36214"
-msgid "Close the on screen display controls after switching channels."
-msgstr ""
-
 #. Description of setting with label #14110 "Long date format"
 #: system/settings/settings.xml
 msgctxt "#36215"
 msgid "Choose which long date format is used for displaying the date in the user interface."
 msgstr ""
 
-#: system/settings/settings.xml
-msgctxt "#36216"
-msgid "Folder where channel icons are stored."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36217"
-msgid "Scan for missing channel icons."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36218"
-msgid "This category contains the electronic programming guide (EPG) settings."
-msgstr ""
-
 #empty string with id 36219
-
-#: system/settings/settings.xml
-msgctxt "#36220"
-msgid "Number of days to show in the guide and import data for from backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36221"
-msgid "Time between imports of guide data from backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36222"
-msgid "Don't import the guide data while playing TV to minimise CPU usage."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36223"
-msgid "By default, the guide data is cached in a local database to speed up importing on startup."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36224"
-msgid "Hide \"No information available\" labels when no guide data is available for a channel."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36225"
-msgid "Delete the cached guide data and reimport it from the backend."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36226"
-msgid "This category contains the PVR playback and channel switching settings."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36227"
-msgid "Display stream of selected channel in a small box instead of fullscreen."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36228"
-msgid "Continue with the last viewed channel on startup."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36229"
-msgid "Display signal quality information in the codec information window (if supported by the add-on and backend)."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36230"
-msgid "Time to wait for a channel to be received after a channel change. Useful for over-the-air channels that occasionally lose signal strength."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36231"
-msgid "When flipping through channels using channel up/down buttons or when pressing a number button in full screen mode, channel switches must be confirmed using the OK button."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36232"
-msgid "When pressing channel up or down, the actual channel switch is delayed, allowing the user to flip to a channel number without waiting for each channel switch."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36233"
-msgid "This category contains the default recording duration settings."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36234"
-msgid "Duration of instant recordings when pressing the record button."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36235"
-msgid "Priority of the recording. Higher number means higher priority. Not supported by all add-ons and backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36236"
-msgid "Delete recording after this time. Not supported by all add-ons and backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36237"
-msgid "Additional time to record before the scheduled start time to allow for minor broadcasting changes. Not supported by all add-ons and backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36238"
-msgid "Additional time to record after the scheduled end time to allow for minor broadcasting changes. Not supported by all add-ons and backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36239"
-msgid "Display a notification when timers are added, finished or removed by the backend."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36240"
-msgid "This category contains the PVR power management settings, such as when to wakeup the PVR backend server."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36241"
-msgid "Execute the wakeup command below when exiting this application or going into hibernation mode. The timestamp of the next scheduled recording is passed as parameter."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36242"
-msgid "The command will not be executed when a recording will be started within this timeout."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36243"
-msgid "The command to execute (cmd [timestamp])."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36244"
-msgid "Time to subtract from the start time of the next scheduled recording."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36245"
-msgid "Execute the wakeup command every day at the given time."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36246"
-msgid "When to execute the daily wakeup command."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36247"
-msgid "This category contains the parental control settings, if the PVR backend server supports parental controls."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36248"
-msgid "Asks for a pin code to access parental locked channels. Channels can be marked as locked in the channels editor on the general tab. Parental locked channels can't be played or recorded without entering a pin code, and the guide information is hidden for those channels."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36249"
-msgid "Enter a new pin code to unlock parental locked channels."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36250"
-msgid "Ask for the pin code again when trying to access a parental locked channel and the code hasn't been asked for this duration."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36251"
-msgid "This category contains the settings for your PVR backend specifically, if supported by the PVR add-on and backend."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36252"
-msgid "This option will bring you to any specific settings for your PVR backend, if supported by the PVR add-on and backend."
-msgstr ""
-
-#. Description of settings section with label #2 "Music"
-#: system/settings/settings.xml
-msgctxt "#36253"
-msgid "Section that contains settings related to music files and how they are handled."
-msgstr ""
-
-#empty string with id 36254
 
 #. Description of setting with label #13414 "Include artists who appear only on compilations"
 #: system/settings/settings.xml
@@ -13055,12 +11961,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36260"
 msgid "No info available yet."
-msgstr ""
-
-#. Description of setting with label #19108 "Refreshrate"
-#: system/settings/settings.xml
-msgctxt "#36261"
-msgid "If enabled, this framerate is used for streams we were not able to detect fps."
 msgstr ""
 
 #. Description of setting with label #20196 "Export music library"
@@ -13111,12 +12011,6 @@ msgctxt "#36269"
 msgid "Reference volume (PreAmp level) to use for files without encoded ReplayGain information. Default is 89dB as per standard. Change with caution."
 msgstr ""
 
-#. Description of setting with label #643 "Avoid clipping on ReplayGained files"
-#: system/settings/settings.xml
-msgctxt "#36270"
-msgid "Reduce the volume of the file if clipping will occur."
-msgstr ""
-
 #. Description of setting with label #13314 "Crossfade between songs"
 #: system/settings/settings.xml
 msgctxt "#36271"
@@ -13147,22 +12041,10 @@ msgctxt "#36275"
 msgid "Control the way that the names of songs are displayed in the user interface. In order to function properly, tag reading needs to be enabled."
 msgstr ""
 
-#. Description of setting with label #13387 "Track naming template - right"
-#: system/settings/settings.xml
-msgctxt "#36276"
-msgid "Used for formatting the second column in file lists."
-msgstr ""
-
 #. Description of setting with label #13307 "Now Playing - Track naming template"
 #: system/settings/settings.xml
 msgctxt "#36277"
 msgid "Control the way that the names of songs are displayed in the now playing list."
-msgstr ""
-
-#. Description of setting with label #13387 "Now Playing - Track naming template - right"
-#: system/settings/settings.xml
-msgctxt "#36278"
-msgid "Used for formatting the second column in the now playing list."
 msgstr ""
 
 #. Description of setting with label #13307 "Library - Track naming template"
@@ -13171,28 +12053,10 @@ msgctxt "#36279"
 msgid "Control the way that the names of songs are displayed in library lists."
 msgstr ""
 
-#. Description of setting with label #13387 "Library - Track naming template - right"
-#: system/settings/settings.xml
-msgctxt "#36280"
-msgid "Used for formatting the second column in library lists."
-msgstr ""
-
 #. Description of setting with label #14059 "Search for thumbnails on remote shares"
 #: system/settings/settings.xml
 msgctxt "#36281"
 msgid "Search for thumbs on remote shares and optical media. This can often slow down the listing of network folders."
-msgstr ""
-
-#. Description of settings category with label #620 "Audio CDs"
-#: system/settings/settings.xml
-msgctxt "#36282"
-msgid "This category contains the settings for how CDs are handled."
-msgstr ""
-
-#. Description of setting with label #14097 "Audio CD Insert Action"
-#: system/settings/settings.xml
-msgctxt "#36283"
-msgid "Autorun CDs when inserted in drive."
 msgstr ""
 
 #. Description of setting with label #227 "Load audio CD information from online service"
@@ -13219,87 +12083,10 @@ msgctxt "#36287"
 msgid "Select which audio encoder to use when ripping."
 msgstr ""
 
-#. Description of setting with label #622 "Quality"
-#: system/settings/settings.xml
-msgctxt "#36288"
-msgid "Select which quality you want to rip your files."
-msgstr ""
-
-#. Description of setting with label #623 "Bitrate"
-#: system/settings/settings.xml
-msgctxt "#36289"
-msgid "Select which bitrate to use for the specified audio encoder for audio compression."
-msgstr ""
-
-#. Description of setting with label #665 "Compression level"
-#: system/settings/settings.xml
-msgctxt "#36290"
-msgid "For FLAC define compression level, default 5."
-msgstr ""
-
 #. Description of setting with label #14099 "Eject disc when CD ripping is complete"
 #: system/settings/settings.xml
 msgctxt "#36291"
 msgid "Auto eject disc after rip is complete."
-msgstr ""
-
-#. Description of settings category "Music -> Karaoke" with label #13327
-#: system/settings/settings.xml
-msgctxt "#36292"
-msgid "Category containing the settings for how karaoke is handled."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Enable karaoke support" with label #13323
-#: system/settings/settings.xml
-msgctxt "#36293"
-msgid "When playing any music file, XBMC will look for a matching .cdg file and display its graphics."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Show song selector automatically" with label #22037
-#: system/settings/settings.xml
-msgctxt "#36294"
-msgid "Show song selection dialog once the last song in the queue has been played."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Font" with label #22030
-#: system/settings/settings.xml
-msgctxt "#36295"
-msgid "Select the font type used during karaoke."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Size" with label #22031
-#: system/settings/settings.xml
-msgctxt "#36296"
-msgid "Select the size of the font used during karaoke."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Colours" with label #22032
-#: system/settings/settings.xml
-msgctxt "#36297"
-msgid "Select the font colour used during karaoke."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Charset" with label #22033
-#: system/settings/settings.xml
-msgctxt "#36298"
-msgid "Select the character set used during karaoke."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Export karaoke titles..." with label #22038
-#: system/settings/settings.xml
-msgctxt "#36299"
-msgid "Export the karaoke numbered songs to HTML or CSV files."
-msgstr ""
-
-#. Description of setting "Music -> Karaoke -> Import karaoke titles..." with label #22036
-#: system/settings/settings.xml
-msgctxt "#36300"
-msgid "Import the karaoke numbered songs from HTML or CSV files."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36301"
-msgid "No info available yet."
 msgstr ""
 
 #: system/settings/settings.xml
@@ -13310,18 +12097,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36303"
 msgid "No info available yet."
-msgstr ""
-
-#. Description of settings section with label #1 "Pictures"
-#: system/settings/settings.xml
-msgctxt "#36304"
-msgid "Section that contains settings related to pictures and how they are handled."
-msgstr ""
-
-#. Description of settings category with label #14081 "File lists"
-#: system/settings/settings.xml
-msgctxt "#36305"
-msgid "This category contains the settings for how picture file lists are handled."
 msgstr ""
 
 #. Description of setting "Pictures -> Show EXIF picture information" with label #14082
@@ -13354,12 +12129,6 @@ msgctxt "#36310"
 msgid "No info available yet."
 msgstr ""
 
-#. Description of settings category with label #108 "Slideshow"
-#: system/settings/settings.xml
-msgctxt "#36311"
-msgid "This category contains the settings for how the picture slideshow is handled."
-msgstr ""
-
 #. Description of setting with label #12378 "Amount of time to display each image"
 #: system/settings/settings.xml
 msgctxt "#36312"
@@ -13376,12 +12145,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36314"
 msgid "View slideshow images in a random order."
-msgstr ""
-
-#. Description of settings section with label #8 "Weather"
-#: system/settings/settings.xml
-msgctxt "#36315"
-msgid "Section that contains weather related settings."
 msgstr ""
 
 #. Description of settings category with label #16000 "General"
@@ -13432,12 +12195,6 @@ msgctxt "#36323"
 msgid "Enables the UPnP server. This allows you to stream media in your libraries to a UPnP client."
 msgstr ""
 
-#. Description of setting with label #20188 "Announce library updates"
-#: system/settings/settings.xml
-msgctxt "#36324"
-msgid "When a manual or automatic library update occurs, notify UPnP clients."
-msgstr ""
-
 #. Description of setting with label #21881 "Allow playback control via UPnP"
 #: system/settings/settings.xml
 msgctxt "#36325"
@@ -13486,12 +12243,6 @@ msgctxt "#36332"
 msgid "Select between web interfaces installed via the add-on manager."
 msgstr ""
 
-#. Description of settings category with label #790 "Remote Control"
-#: system/settings/settings.xml
-msgctxt "#36333"
-msgid "This category contains the settings for how the remote control service is handled."
-msgstr ""
-
 #. Description of setting with label #791 "Allow remote control from programs on this system"
 #: system/settings/settings.xml
 msgctxt "#36334"
@@ -13534,36 +12285,6 @@ msgctxt "#36340"
 msgid "Continuous repeat delay (ms)."
 msgstr ""
 
-#. Description of settings category with label #1259 "Zeroconf"
-#: system/settings/settings.xml
-msgctxt "#36341"
-msgid "This category contains the settings for how the Zeroconf network discovery service is handled, required for AirPlay."
-msgstr ""
-
-#. Description of setting with label #1260 "Announce services to other systems"
-#: system/settings/settings.xml
-msgctxt "#36342"
-msgid "Allows applications on the network to discover enabled services via Zeroconf."
-msgstr ""
-
-#. Description of setting with label #1270 "Enable AirPlay support"
-#: system/settings/settings.xml
-msgctxt "#36343"
-msgid "If enabled, the content from other AirPlay devices or applications can be received."
-msgstr ""
-
-#. Description of setting with label #1272 "Use password protection"
-#: system/settings/settings.xml
-msgctxt "#36344"
-msgid "Enable AirPlay password protection."
-msgstr ""
-
-#. Description of setting with label #733 "Password"
-#: system/settings/settings.xml
-msgctxt "#36345"
-msgid "Sets the AirPlay password."
-msgstr ""
-
 #. Description of settings category with label #1200 "SMB Client"
 #: system/settings/settings.xml
 msgctxt "#36346"
@@ -13588,43 +12309,13 @@ msgctxt "#36349"
 msgid "Section that contains the system related settings for the device this application is installed on."
 msgstr ""
 
-#. Description of setting with label #13026 "Try to wake remote servers on access"
-#: system/settings/settings.xml
-msgctxt "#36350"
-msgid "Automatically send Wake-on-LAN to server(s) right before trying to access shared files or services."
-msgstr ""
-
-#. Description of setting with label #21373 "Display Mode"
-#: system/settings/settings.xml
-msgctxt "#36351"
-msgid "Changes the way this application is displayed on the selected screen. Either in a window or fullscreen."
-msgstr ""
-
 #. Description of setting with label #169 "Resolution"
 #: system/settings/settings.xml
 msgctxt "#36352"
 msgid "Changes the resolution that the user interface is displayed in."
 msgstr ""
 
-#. Description of setting with label #243 "Refresh Rate"
-#: system/settings/settings.xml
-msgctxt "#36353"
-msgid "Changes the refresh rate that the user interface is displayed in."
-msgstr ""
-
-#. Description of setting with label #14083 "Use fullscreen window"
-#: system/settings/settings.xml
-msgctxt "#36354"
-msgid "If enabled, fullscreen mode will be applied by using a window instead of a real fullscreen mode. The main benefit is for multi-screen configurations, so that other applications can be used in parallel more easily. This uses more resources so playback may be less smooth."
-msgstr ""
-
-#. Description of setting with label #13130 "Blank other displays"
-#: system/settings/settings.xml
-msgctxt "#36355"
-msgid "In a multi-screen configuration, the screens not displaying this application are blacked out."
-msgstr ""
-
-#empty strings from id 36356 to 36356
+#empty strings from id 36353 to 36356
 
 #. Description of setting with label #214 "Video calibration..."
 #: system/settings/settings.xml
@@ -13632,45 +12323,10 @@ msgctxt "#36357"
 msgid "Calibrate the user interface by adjusting the overscan. Use this tool if the image being displayed is too large or small for your display."
 msgstr ""
 
-#. Description of setting with label #226 "Test patterns..."
-#: system/settings/settings.xml
-msgctxt "#36358"
-msgid "Test patterns for display hardware calibration."
-msgstr ""
-
-#. Description of setting with label #36042 "Use limited colour range (16-235)"
-#: system/settings/settings.xml
-msgctxt "#36359"
-msgid "Use limited colour range (16-235) instead of full colour range (0-255). Limited range should be used if your display is a regular HDMI TV and doesn't have a PC or other mode to display full range colour, however if your display is a PC monitor then leave this disabled to get proper blacks."
-msgstr ""
-
 #. Description of settings category with label #772 "Audio"
 #: system/settings/settings.xml
 msgctxt "#36360"
 msgid "This category contains the settings for how audio output is handled."
-msgstr ""
-
-#. Description of setting with label #337 "Output configuration"
-#: system/settings/settings.xml
-msgctxt "#36361"
-msgid "Select how the properties of the audio output are set: [Fixed] Output properties are set to the specified sampling rate & speaker configuration at all times; [Best Match] Output properties are set to always be as close a match to the source properties as possible; [Optimized] Output properties are set at the start of playback and will not change if the properties of the source change."
-msgstr ""
-
-#. Description of setting with label #34100 "Number of channels"
-#: system/settings/settings.xml
-msgctxt "#36362"
-msgid "Select the number of channels supported by the audio connection, or the number of speakers if connected by analogue connections. This setting does not apply to passthrough audio. Note: S/PDIF supports 2.0 channels only but can still output multichannel audio using a format supported by passthrough."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36363"
-msgid "Boost AC3 streams that have been downmixed to 2 channels."
-msgstr ""
-
-#. Description of setting with label #252 "Stereo upmix"
-#: system/settings/settings.xml
-msgctxt "#36364"
-msgid "Select to enable upmixing of 2 channel audio to the number of audio channels specified by the channel configuration."
 msgstr ""
 
 #. Description of setting with label #364 "Dolby Digital (AC3) capable receiver"
@@ -13685,75 +12341,16 @@ msgctxt "#36366"
 msgid "Select this option if your receiver is capable of decoding DTS streams.
 msgstr ""
 
-#: system/settings/darwin_osx.xml
-msgctxt "#36367"
-msgid "Select the maximum number of audio channels / speakers available for decoded audio. If optical / coax digital outputs are used, this must be set to 2.0"
-msgstr ""
-
-#. Description of setting with label #348 "Enable passthrough"
-#: system/settings/settings.xml
-msgctxt "#36368"
-msgid "Select to enable the passthrough audio options for playback of encoded audio such as Dolby Digital (AC3), DTS, etc."
-msgstr ""
-
-#. Description of setting with label #349 "TrueHD capable receiver"
-#: system/settings/settings.xml
-msgctxt "#36369"
-msgid "Select this option if your receiver is capable of decoding TrueHD streams."
-msgstr ""
-
-#. Description of setting with label #347 "DTS-HD capable receiver"
-#: system/settings/settings.xml
-msgctxt "#36370"
-msgid "Select this option if your receiver is capable of decoding DTS-HD streams."
-msgstr ""
-
-#. Description of setting with label #545 "Audio output device"
-#: system/settings/settings.xml
-msgctxt "#36371"
-msgid "Select the device to be used for playback of audio that has been decoded such as mp3."
-msgstr ""
-
-#. Description of setting with label #546 "Passthrough output device"
-#: system/settings/settings.xml
-msgctxt "#36372"
-msgid "Select the device to be used for playback of encoded formats, these are any of the formats below in the capable receiver options."
-msgstr ""
-
-#. Description of setting with label #34120 "Play GUI sounds"
-#: system/settings/settings.xml
-msgctxt "#36373"
-msgid "Configure how interface sounds are handled, such as menu navigation and important notifications."
-msgstr ""
-
 #. Description of settings category with label #14219 "Control"
 #: system/settings/settings.xml
 msgctxt "#36374"
 msgid "This category contains the settings for how input devices are handled."
 msgstr ""
 
-#. Description of setting with label #35000 "Peripherals"
-#: system/settings/settings.xml
-msgctxt "#36375"
-msgid "Configure any attached peripheral devices."
-msgstr ""
-
-#. Description of setting with label #21449 "Remote control sends keyboard presses"
-#: system/settings/settings.xml
-msgctxt "#36376"
-msgid "When activated, your keyboard arrows will move the selection on the virtual keyboard. When deactivated, they will move the cursor from your text."
-msgstr ""
-
 #. Description of setting with label #21369 "Enable mouse and Touch Screen support"
 #: system/settings/settings.xml
 msgctxt "#36377"
 msgid "Use a mouse or touch screen device to control the interface. Note: Disabling will cause you to lose control over this application when no keyboard or remote is present."
-msgstr ""
-
-#. Description of setting with label #35100 "Enable joystick and gamepad support"
-#: system/settings/settings.xml
-msgctxt "#36378"
-msgid "Use a joystick to control the interface."
 msgstr ""
 
 #. Description of settings category with label #798 Internet access
@@ -13808,12 +12405,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#36387"
 msgid "This category contains the settings for power saving."
-msgstr ""
-
-#. Description of setting with label #1450 "Put display to sleep when idle"
-#: system/settings/settings.xml
-msgctxt "#36388"
-msgid "Turn off display when idle. Useful for TVs that turn off when there is no display signal detected."
 msgstr ""
 
 #. Description of setting with label #357 "Shutdown function timer"
@@ -13972,24 +12563,6 @@ msgctxt "#36415"
 msgid "No info available yet."
 msgstr ""
 
-#. Description of setting with label #13600 "Apple remote"
-#: system/settings/settings.xml
-msgctxt "#36416"
-msgid "Specify the type of remote used."
-msgstr ""
-
-#. Description of setting with label #13602 "Allow start of Kodi with remote"
-#: system/settings/settings.xml
-msgctxt "#36417"
-msgid "Always run a Kodi helper so that the remote can be used to start Kodi."
-msgstr ""
-
-#. Description of setting with label #13603 "Sequence delay time"
-#: system/settings/settings.xml
-msgctxt "#36418"
-msgid "Specify the delay between button sequences on a universal remote."
-msgstr ""
-
 #. Description of setting with label #21417 "Settings"
 #: system/settings/settings.xml
 msgctxt "#36419"
@@ -14002,114 +12575,13 @@ msgctxt "#36420"
 msgid "Look for external subtitles for videos provided by the UPnP server. This can cause extensive CPU, filesystem and network load."
 msgstr ""
 
-#. Description of setting with label #13437 "Prefer VDPAU Video Mixer"
-#: system/settings/settings.xml
-msgctxt "#36421"
-msgid "Bypassing VDPAU mixer saves resources on low power systems but slightly reduces picture quality."
-msgstr ""
-
-#. Description of setting with label #13438 "Allow hardware acceleration (amcodec)"
-#: system/settings/settings.xml
-msgctxt "#36422"
-msgid "Enable hardware video decode using Amlogic decoder."
-msgstr ""
-
-#. Description of setting with label #812 "Prevent duplicate episodes"
-#: system/settings/settings.xml
-msgctxt "#36423"
-msgid "Timer rules shall only record new episodes. Not supported by all add-ons and backends."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36424"
-msgid "Select what will happen when an item is selected in the guide: [Show context menu] Will trigger the context menu from where you can choose further actions; [Switch to channel] Will instantly tune to the related channel; [Show information] Will display a detailed information with plot and further options; [Record] Will create a recording timer for the selected item."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36425"
-msgid "Show context menu"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36426"
-msgid "Switch to channel"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36427"
-msgid "Show information"
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#36428"
-msgid "Record"
-msgstr ""
-
-#. Description of setting with label #667 "Enable Dolby Digital transcoding"
-#: system/settings/settings.xml
-msgctxt "#36429"
-msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1 (AC-3), such as a S/PDIF connection. If your system supports PCM multichannel audio via HDMI, leave this disabled."
-msgstr ""
-
-#. Description for setting category #14101: "Video Acceleration"
-#: system/settings/settings.xml
-msgctxt "#36430"
-msgid "Configure how video processing will be accelerated. This includes things like decoding and scaling."
-msgstr ""
-
-#. Description of setting with label #13438 "Show event log"
-#: system/settings/settings.xml
-msgctxt "#36431"
-msgid "Shows all events in the event log for the current profile with options to only show specific levels."
-msgstr ""
-
 #. Description for setting #310: "Keyboard layouts"
 #: system/settings/settings.xml
 msgctxt "#36432"
 msgid "Select virtual keyboard layouts."
 msgstr ""
 
-#. Description for video related setting #13457: "vaapi sw filter"
-#: system/settings/settings.xml
-msgctxt "#36433"
-msgid "When enabled, VAAPI render method is preferred and the CPU has less load. If you experience hangs, disable this option."
-msgstr ""
-
-#. Description of setting "Enable MMAL hardware decoding of video files"
-#: system/settings/settings.xml
-msgctxt "#36434"
-msgid "Allow hardware acceleration - MMAL"
-msgstr ""
-
-#. Description of setting "Enable MMAL hardware decoding of video files"
-#: system/settings/settings.xml
-msgctxt "#36435"
-msgid "Use VideoPlayer for decoding of video files with MMAL acceleration."
-msgstr ""
-
-#empty strings from id 36436 to 36441
-
-#. Description of setting "System -> Audio output -> Volume control steps" with label #1302
-#: system/settings/settings.xml
-msgctxt "#36442"
-msgid "Set the number of volume control steps."
-msgstr ""
-
-#empty strings from id 36443 to 36459
-
-#. Description of settings with label #14112 "Enable event logging"
-#: system/settings/settings.xml
-msgctxt "#36460"
-msgid "Event logging allows to keep track of what has happened."
-msgstr ""
-
-#. Description of settings with label #14113 "Enable notification event logging"
-#: system/settings/settings.xml
-msgctxt "#36461"
-msgid "Notification event describe regular processes and actions performed by the system or the user."
-msgstr ""
-
-#empty strings from id 36462 to 36499
+#empty strings from id 36433 to 36499
 #end reservation
 
 #reserved strings for 3d modes 36462 - 36503
@@ -14117,59 +12589,8 @@ msgstr ""
 #empty strings from id 36462 to 36519
 #end of reserved strings for 3d modes
 
-#empty strings from id 36519 to 36532
-
-#. Description of setting with label #346 "Normalize levels on downmix"
-#: settings/DisplaySettings.cpp
-msgctxt "#36533"
-msgid "Select how audio is downmixed, e.g. from 5.1 to 2.0.[CR][Enabled] Maintains volume level of the original audio source however the dynamic range is compressed.[CR][Disabled] Maintains the dynamic range of the original audio source when downmixed however volume will be lower. Note: Dynamic range is the difference between the quietest and loudest sounds in an audio source. Enable this setting if movie dialogues are barely audible."
-msgstr ""
-
-#. Description of setting with label #668 "Component-specific logging..."
-#: system/settings/settings.xml
-msgctxt "#36534"
-msgid "Specify additional libraries whose verbose messages are to be included in the debug log."
-msgstr ""
-
-#empty strings from id 36535 to 36543
-
-#: system/settings/settings.xml
-msgctxt "#36544"
-msgid "Enable hardware decoding of video files."
-msgstr ""
-
-#empty strings from id 36545 to 36546
-
-#: system/settings/rbp.xml
-msgctxt "#36547"
-msgid "Use higher quality textures for covers and fanart (uses more memory)"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#36548"
-msgid "Limits resolution of GUI to save memory. Does not affect video playback. Requires restart."
-msgstr ""
-
-#empty strings from id 36549 to 36599
+#empty strings from id 36519 to 36599
 #reserved strings 365XX
-
-#. Description of settings category with label #14022 "Library"
-#: system/settings/settings.xml
-msgctxt "#36600"
-msgid "This category contains the settings for how the music library is handled."
-msgstr ""
-
-#. Description of settings category with label #14081 "File lists"
-#: system/settings/settings.xml
-msgctxt "#36601"
-msgid "This category contains the settings for how music file lists are handled."
-msgstr ""
-
-#. Description of settings category with label #1273 "AirPlay"
-#: system/settings/settings.xml
-msgctxt "#36602"
-msgid "This category contains the settings for how the AirPlay service is handled."
-msgstr ""
 
 #. Description of settings category with label #14216 Display
 #: system/settings/settings.xml
@@ -14391,145 +12812,6 @@ msgctxt "#37015"
 msgid "Browse into"
 msgstr ""
 
-#. Description of setting with label #448 "Dolby Digital Plus (E-AC3) capable receiver"
-#: system/settings/settings.xml
-msgctxt "#37016"
-msgid "Select this option if your receiver is capable of decoding Dolby Digital Plus (E-AC3) streams."
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37017"
-msgid "Dual audio output"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37018"
-msgid "Boost centre channel when downmixing"
-msgstr ""
-
-#empty string with id 37019
-
-#: system/settings/rbp.xml
-msgctxt "#37020"
-msgid "Enable higher colour depth artwork"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37021"
-msgid "Set GUI resolution limit"
-msgstr ""
-
-#: xbmc/network/upnp/UPnPPlayer.cpp
-msgctxt "#37022"
-msgid "UPnP player"
-msgstr ""
-
-#: xbmc/network/upnp/UPnPPlayer.cpp
-msgctxt "#37023"
-msgid "Do you wish to stop playback on the remote device?"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37024"
-msgid "Select this if the audio out connection only supports multichannel audio as Dolby Digital 5.1 (AC3), this allows multichannel audio such as AAC 5.1 or FLAC 5.1 to be listened to in 5.1 surround sound. Note: Not recommended on Pi as this requires a lot of CPU."
-msgstr ""
-
-#: system/settings/settings.xml
-msgctxt "#37025"
-msgid "Configure audio encoder settings such as quality and compression level"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37026"
-msgid "Auto"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37027"
-msgid "540"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37028"
-msgid "720"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37029"
-msgid "900"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#37030"
-msgid "Unlimited"
-msgstr ""
-
-#. Description of setting #14102 Blu-ray playback mode
-#: system/settings/settings.xml
-msgctxt "#37031"
-msgid "Specifies how Blu-rays should be opened / played back. Note: Some disc menus are not fully supported and may cause problems."
-msgstr ""
-
-#. Title of category #37032 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37032"
-msgid "Accessibility"
-msgstr ""
-
-#. Description of category #37032 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37033"
-msgid "Video playback related accessibility settings, e.g. \"Prefer subtitles for the hearing impaired\"."
-msgstr ""
-
-#. Setting #37034 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37034"
-msgid "Prefer audio stream for the visually impaired"
-msgstr ""
-
-#. Description of setting #37034 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37035"
-msgid "Prefer the audio stream for the visually impaired to other audio streams of the same language"
-msgstr ""
-
-#. Setting #37036 Settings -> Video -> Accessibility
-#: system/settings/settings.xml
-msgctxt "#37036"
-msgid "Prefer audio stream for the hearing impaired"
-msgstr ""
-
-#. Description of setting #37036 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37037"
-msgid "Prefer the audio stream for the hearing impaired to other audio streams of the same language"
-msgstr ""
-
-#. Setting #37038 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37038"
-msgid "Prefer subtitles for the hearing impaired"
-msgstr ""
-
-#. Description of setting #37038 Accessibility
-#: system/settings/settings.xml
-msgctxt "#37039"
-msgid "Prefer the subtitle stream for the hearing impaired to other subtitle streams of the same language"
-msgstr ""
-
-#. Setting #37040 Playback
-#: system/settings/settings.xml
-msgctxt "#37040"
-msgid "Prefer default audio streams"
-msgstr ""
-
-#. Description of setting #37040 Playback
-#: system/settings/settings.xml
-msgctxt "#37041"
-msgid "If enabled, audio streams that are flagged as default (and match the preferred language) are preferred over audio streams with higher quality (number of channels, codec, ...)."
-msgstr ""
-
 #. Description of setting Skip steps
 #: system/settings/settings.xml
 msgctxt "#37042"
@@ -14556,11 +12838,6 @@ msgstr ""
 
 #empty strings from id 37046 to 38009
 
-#: system/settings/rbp.xml
-msgctxt "#38010"
-msgid "GPU accelerated"
-msgstr ""
-
 #. Setting #38011 "Show All Items entry"
 #: system/settings/settings.xml
 msgctxt "#38011"
@@ -14571,36 +12848,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#38012"
 msgid "Show \"All items\" entry in directory, e.g. \"All albums\" or \"All seasons\"."
-msgstr ""
-
-#. Label of a setting to limit the number of fps used for updating the GUI while playing videos. This is useful for slow systems that have problems rendering GUI and video at the same time in full speed.
-#: system/settings/settings.xml
-msgctxt "#38013"
-msgid "Limit GUI updates during playback"
-msgstr ""
-
-#. Description for the setting with label #38013 "Limit GUI updates when playing video"
-#: system/settings/settings.xml
-msgctxt "#38014"
-msgid "Limits the speed (fps) used to update the GUI while playing videos. This can reduce CPU load and fix playback issues while the GUI is shown."
-msgstr ""
-
-#. Label of a settings value to indicate the "disabled" state of an otherwise limiting setting (like fps limit, bandwidth limit, etc.)
-#: system/settings/settings.xml
-msgctxt "#38015"
-msgid "Unlimited"
-msgstr ""
-
-#. Used to format framerate values. %d will be replaced with the according number/integer, like "24 fps", "50 fps"
-#: system/settings/settings.xml
-msgctxt "#38016"
-msgid "%d fps"
-msgstr ""
-
-#. Description of setting #14111 "Blu-ray region code"
-#: system/settings/settings.xml
-msgctxt "#38017"
-msgid "Region A - Americas, East Asia and Southeast Asia. Region B - Africa, Middle East, Southwest Asia, Europe, Australia, New Zealand. Region C - Central Asia, mainland China, Mongolia, South Asia, Belarus, Russia, Ukraine, Kazakhstan."
 msgstr ""
 
 #. Used for the viewstate selection
@@ -14634,40 +12881,6 @@ msgstr ""
 #: xbmc/view/GUIViewStateVideo.cpp
 msgctxt "#38026"
 msgid "Appearances"
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#38027"
-msgid "Decode the stereo stream from 3D files"
-msgstr ""
-
-#. Description of setting with label #38027 "Decode the stereo stream from 3D files"
-#: system/settings/rbp.xml
-msgctxt "#38028"
-msgid "If enabled, videos created in Multiview Video Coding (MVC) format can also be watched in stereoscopic 3D. MVC format is typically found on 3D Blu-rays.[CR]Note: Processing of this data may reduce playback performance, so only enable if you require stereoscopic 3D support."
-msgstr ""
-
-#: system/settings/rbp.xml
-msgctxt "#38029"
-msgid "Enable Full HD HDMI modes for stereoscopic 3D"
-msgstr ""
-
-#. Description of setting "Enable Full HD HDMI modes for stereoscopic 3D" with label #38029
-#: system/settings/rbp.xml
-msgctxt "#38030"
-msgid "This option uses frame-packing to output full resolution for 3D through HDMI.[CR]Enabling this improves quality of Multiview Video Coding (MVC) videos, but may not be supported by all displays."
-msgstr ""
-
-#. Label for an option to select the video stream to play if current video has more than one video stream
-#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
-msgctxt "#38031"
-msgid "Video stream"
-msgstr ""
-
-#. Label for an option to select the angle to play if current disc has more than one angle
-#: xbmc\video\dialogs\GUIDialogVideoSettings.cpp
-msgctxt "#38032"
-msgid "Angle"
 msgstr ""
 
 #: xbmc/dialogs/GUIDialogSmartPlaylistRule.cpp
@@ -14893,18 +13106,6 @@ msgstr ""
 #: system/settings/settings.xml
 msgctxt "#38109"
 msgid "This category contains the settings for how information for pictures is shown and navigated"
-msgstr ""
-
-#. Description of category #14215 "Databases"
-#: system/settings/settings.xml
-msgctxt "#38110"
-msgid "This category contains the settings for the library databases"
-msgstr ""
-
-#. Description of category #14224 "Other"
-#: system/settings/settings.xml
-msgctxt "#38111"
-msgid "This category contains other settings for the GUI interface"
 msgstr ""
 
 #empty strings from id 38112 to 38206


### PR DESCRIPTION
As stated in title this PR removes locales which were not used. This saves some memory.