### PR TITLE
[Games Library] add abstract program launcher and support for custom configurations

### DIFF
--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -4682,6 +4682,22 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 					<File
 						RelativePath=".\xbmc\programs\launchers\ProgramLauncher.h">
 					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\XBELauncher.cpp">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\XBELauncher.h">
+					</File>
+				</Filter>
+				<Filter
+					Name="dialogs"
+					Filter="">
+					<File
+						RelativePath=".\xbmc\programs\dialogs\GUIDialogProgramSettings.cpp">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\dialogs\GUIDialogProgramSettings.h">
+					</File>
 				</Filter>
 			</Filter>
 		</Filter>

--- a/xbmc.vcproj
+++ b/xbmc.vcproj
@@ -4664,6 +4664,25 @@ bundler xbelogo\saveimage.rdf -o xbelogo\saveimage.xbx
 						RelativePath=".\xbmc\programs\jobs\ProgramLibraryScanningJob.h">
 					</File>
 				</Filter>
+				<Filter
+					Name="launchers"
+					Filter="">
+					<File
+						RelativePath=".\xbmc\programs\launchers\IProgramLauncher.h">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\LauncherFactory.cpp">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\LauncherFactory.h">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\ProgramLauncher.cpp">
+					</File>
+					<File
+						RelativePath=".\xbmc\programs\launchers\ProgramLauncher.h">
+					</File>
+				</Filter>
 			</Filter>
 		</Filter>
 		<Filter

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -36,6 +36,7 @@
 #include "video/Bookmark.h"
 #include "video/VideoLibraryQueue.h"
 #include "music/MusicLibraryQueue.h"
+#include "programs/launchers/ProgramLauncher.h"
 #include "network/NetworkServices.h"
 #include "utils/LangCodeExpander.h"
 #include "GUIInfoManager.h"
@@ -927,7 +928,7 @@ HRESULT CApplication::Create(HWND hWnd)
       char szXBEFileName[1024];
 
       CIoSupport::GetXbePath(szXBEFileName);
-      CUtil::RunXBE(szXBEFileName);
+      LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName, false, false);
     }
     m_pd3dDevice->Release();
   }
@@ -2677,7 +2678,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     char szXBEFileName[1024];
 
     CIoSupport::GetXbePath(szXBEFileName);
-    CUtil::RunXBE(szXBEFileName);
+    LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName, false, false);
   }
 #endif
     break;
@@ -5152,18 +5153,7 @@ bool CApplication::ExecuteXBMCAction(std::string actionStr, const CGUIListItemPt
     }
     else if (item.IsXBE())
     { // an XBE
-      int iRegion;
-      if (CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
-      {
-        CXBE xbe;
-        iRegion = xbe.ExtractGameRegion(item.GetPath());
-        if (iRegion < 1 || iRegion > 7)
-          iRegion = 0;
-        iRegion = xbe.FilterRegion(iRegion);
-      }
-      else
-        iRegion = 0;
-      CUtil::RunXBE(item.GetPath().c_str(),NULL,F_VIDEO(iRegion));
+      LAUNCHERS::CProgramLauncher::LaunchProgram(item.GetPath());
     }
     else if (item.IsAudio() || item.IsVideo())
     { // an audio or video file

--- a/xbmc/Application.cpp
+++ b/xbmc/Application.cpp
@@ -928,7 +928,7 @@ HRESULT CApplication::Create(HWND hWnd)
       char szXBEFileName[1024];
 
       CIoSupport::GetXbePath(szXBEFileName);
-      LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName, false, false);
+      LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName);
     }
     m_pd3dDevice->Release();
   }
@@ -2678,7 +2678,7 @@ void CApplication::OnApplicationMessage(ThreadMessage* pMsg)
     char szXBEFileName[1024];
 
     CIoSupport::GetXbePath(szXBEFileName);
-    LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName, false, false);
+    LAUNCHERS::CProgramLauncher::LaunchProgram(szXBEFileName);
   }
 #endif
     break;

--- a/xbmc/Autorun.cpp
+++ b/xbmc/Autorun.cpp
@@ -42,9 +42,8 @@
 #endif
 #ifdef _XBOX
 #include "interfaces/builtins/Builtins.h"
-#include "utils/Trainer.h"
+#include "programs/launchers/ProgramLauncher.h"
 #include "xbox/xbeheader.h"
-#include "programs/ProgramDatabase.h"
 #endif
 
 #include "defs_from_settings.h"
@@ -93,46 +92,7 @@ void CAutorun::ExecuteAutorun( bool bypassSettings, bool ignoreplaying, bool res
 
 void CAutorun::ExecuteXBE(const CStdString &xbeFile)
 {
-  int iRegion;
-  if (CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
-  {
-    CXBE xbe;
-    iRegion = xbe.ExtractGameRegion(xbeFile);
-    if (iRegion < 1 || iRegion > 7)
-      iRegion = 0;
-    iRegion = xbe.FilterRegion(iRegion);
-  }
-  else
-    iRegion = 0;
-
-  CProgramDatabase database;
-  database.Open();
-
-  // Load active trainer
-  DWORD dwTitleId = CUtil::GetXbeID(xbeFile);
-  CFileItemList items;
-  if (database.GetTrainers(items, dwTitleId))
-  {
-   for (int i = 0; i < items.Size(); ++i)
-   {
-     if (items[i]->GetProperty("isactive").asBoolean())
-     {
-       CTrainer* trainer = new CTrainer(items[i]->GetProperty("idtrainer").asInteger32());
-       if (trainer->Load(items[i]->GetPath()))
-       {
-         database.GetTrainerOptions(trainer->GetTrainerId(), dwTitleId, trainer->GetOptions(), trainer->GetNumberOfOptions());
-         CTrainer::InstallTrainer(*trainer);
-       }
-       else
-       {
-         delete trainer;
-       }
-     }
-   }
-  }
-
-  database.Close();
-  CUtil::RunXBE(xbeFile.c_str(), NULL,F_VIDEO(iRegion));
+  LAUNCHERS::CProgramLauncher::LaunchProgram(xbeFile);
 }
 
 void CAutorun::RunCdda()

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -1481,7 +1481,7 @@ void CUtil::PlayDVD(const CStdString& strProtocol, bool restart)
 {
   if (CSettings::GetInstance().GetBool("dvds.useexternaldvdplayer") && !CSettings::GetInstance().GetString("dvds.externaldvdplayer").empty())
   {
-    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("dvds.externaldvdplayer"), false, false);
+    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("dvds.externaldvdplayer"));
   }
   else
   {

--- a/xbmc/Util.cpp
+++ b/xbmc/Util.cpp
@@ -106,6 +106,7 @@
 #include "utils/CharsetConverter.h"
 #include "utils/log.h"
 #include "video/VideoInfoTag.h"
+#include "programs/launchers/ProgramLauncher.h"
 
 #include "defs_from_settings.h"
 
@@ -1480,7 +1481,7 @@ void CUtil::PlayDVD(const CStdString& strProtocol, bool restart)
 {
   if (CSettings::GetInstance().GetBool("dvds.useexternaldvdplayer") && !CSettings::GetInstance().GetString("dvds.externaldvdplayer").empty())
   {
-    RunXBE(CSettings::GetInstance().GetString("dvds.externaldvdplayer").c_str());
+    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("dvds.externaldvdplayer"), false, false);
   }
   else
   {

--- a/xbmc/guilib/GUIWindowManager.cpp
+++ b/xbmc/guilib/GUIWindowManager.cpp
@@ -58,6 +58,7 @@
 #endif
 #include "settings/windows/GUIWindowSettingsScreenCalibration.h"
 #include "programs/GUIWindowPrograms.h"
+#include "programs/dialogs/GUIDialogProgramSettings.h"
 #include "GUIWindowGameSaves.h"
 #include "pictures/GUIWindowPictures.h"
 #include "windows/GUIWindowWeather.h"
@@ -244,6 +245,7 @@ void CGUIWindowManager::CreateWindows()
   Add(new CGUIWindowWeather);
 #ifdef _XBOX
   Add(new CGUIWindowInsignia);
+  Add(new CGUIDialogProgramSettings);
 #endif
   Add(new CGUIWindowStartup);
   Add(new CGUIWindowSplash);

--- a/xbmc/guilib/Key.h
+++ b/xbmc/guilib/Key.h
@@ -337,6 +337,8 @@
 
 #define WINDOW_ADDON_BROWSER              10040
 
+#define WINDOW_DIALOG_PROGRAM_SETTINGS    10063
+
 #define WINDOW_DIALOG_POINTER             10099
 #define WINDOW_DIALOG_YES_NO              10100
 #define WINDOW_DIALOG_PROGRESS            10101

--- a/xbmc/interfaces/builtins/XboxBuiltins.cpp
+++ b/xbmc/interfaces/builtins/XboxBuiltins.cpp
@@ -20,6 +20,7 @@
 
 #include "XboxBuiltins.h"
 
+#include "programs/launchers/ProgramLauncher.h"
 #include "Util.h"
 #include "FileItem.h"
 #include "settings/Settings.h"
@@ -32,7 +33,7 @@
 static int RunDashboard(const std::vector<std::string>& params)
 {
   if (CSettings::GetInstance().GetBool("myprograms.usedashpath"))
-    CUtil::RunXBE(CSettings::GetInstance().GetString("myprograms.dashboard").c_str());
+    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("myprograms.dashboard"), false, false);
   else
     CUtil::BootToDash();
 
@@ -49,22 +50,8 @@ static int RunXBE(const std::vector<std::string>& params)
   item.SetPath(params[0]);
   if (item.IsShortCut())
     CUtil::RunShortcut(params[0].c_str());
-  else if (item.IsXBE())
-  {
-    int iRegion;
-    if (CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
-    {
-      CXBE xbe;
-      iRegion = xbe.ExtractGameRegion(params[0]);
-      if (iRegion < 1 || iRegion > 7)
-        iRegion = 0;
-      iRegion = xbe.FilterRegion(iRegion);
-    }
-    else
-      iRegion = 0;
-
-    CUtil::RunXBE(params[0].c_str(),NULL,F_VIDEO(iRegion));
-  }
+  else
+    LAUNCHERS::CProgramLauncher::LaunchProgram(params[0]);
 
   return 0;
 }

--- a/xbmc/interfaces/builtins/XboxBuiltins.cpp
+++ b/xbmc/interfaces/builtins/XboxBuiltins.cpp
@@ -33,7 +33,7 @@
 static int RunDashboard(const std::vector<std::string>& params)
 {
   if (CSettings::GetInstance().GetBool("myprograms.usedashpath"))
-    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("myprograms.dashboard"), false, false);
+    LAUNCHERS::CProgramLauncher::LaunchProgram(CSettings::GetInstance().GetString("myprograms.dashboard"));
   else
     CUtil::BootToDash();
 

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -16,6 +16,7 @@
 #include "FileItem.h"
 #include "programs/ProgramLibraryQueue.h"
 #include "programs/dialogs/GUIDialogProgramSettings.h"
+#include "programs/launchers/ProgramLauncher.h"
 #include "messaging/ApplicationMessenger.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
@@ -173,35 +174,7 @@ bool CGUIWindowPrograms::OnPlayMedia(int iItem, const std::string& player)
     return true;
   }
 
-  if (!pItem->IsXBE())
-    return false;
-
-  unsigned int idTitle = CUtil::GetXbeID(pItem->GetPath());
-
-  // Load active trainer
-  CFileItemList items;
-  if (m_database.GetTrainers(items, idTitle))
-  {
-    for (int i = 0; i < items.Size(); ++i)
-    {
-      if (items[i]->GetProperty("isactive").asBoolean())
-      {
-        CTrainer* trainer = new CTrainer(items[i]->GetProperty("idtrainer").asInteger32());
-        if (trainer->Load(items[i]->GetPath()))
-        {
-          m_database.GetTrainerOptions(trainer->GetTrainerId(), idTitle, trainer->GetOptions(), trainer->GetNumberOfOptions());
-          CTrainer::InstallTrainer(*trainer);
-        }
-        else
-        {
-          delete trainer;
-        }
-      }
-    }
-  }
-
-  CUtil::RunXBE(pItem->GetPath().c_str());
-  return true;
+  return LAUNCHERS::CProgramLauncher::LaunchProgram(pItem->GetPath());
 }
 
 bool CGUIWindowPrograms::GetDirectory(const std::string &strDirectory, CFileItemList &items)

--- a/xbmc/programs/GUIWindowPrograms.cpp
+++ b/xbmc/programs/GUIWindowPrograms.cpp
@@ -15,6 +15,7 @@
 #include "guilib/LocalizeStrings.h"
 #include "FileItem.h"
 #include "programs/ProgramLibraryQueue.h"
+#include "programs/dialogs/GUIDialogProgramSettings.h"
 #include "messaging/ApplicationMessenger.h"
 #include "Util.h"
 #include "utils/StringUtils.h"
@@ -76,6 +77,7 @@ void CGUIWindowPrograms::GetContextButtons(int itemNumber, CContextButtons &butt
   }
   else if (item->IsXBE())
   {
+    buttons.Add(CONTEXT_BUTTON_LAUNCH_IN, 519);
     buttons.Add(CONTEXT_BUTTON_PLAY_TRAILER, StringUtils::Format("%s %s", g_localizeStrings.Get(208).c_str(), g_localizeStrings.Get(20410).c_str()));
     buttons.Add(CONTEXT_BUTTON_DELETE, 117);
     buttons.Add(CONTEXT_BUTTON_TRAINER_OPTIONS, 38712);
@@ -116,6 +118,11 @@ bool CGUIWindowPrograms::OnContextButton(int itemNumber, CONTEXT_BUTTON button)
         Refresh(true);
         m_viewControl.SetSelectedItem(select);
       }
+      return true;
+    }
+  case CONTEXT_BUTTON_LAUNCH_IN:
+    {
+      CGUIDialogProgramSettings::ShowForTitle(item);
       return true;
     }
   case CONTEXT_BUTTON_PLAY_TRAILER:

--- a/xbmc/programs/ProgramDatabase.h
+++ b/xbmc/programs/ProgramDatabase.h
@@ -63,6 +63,16 @@ public:
   void DeleteProgram(const std::string& strFilenameAndPath);
   void RemoveContentForPath(const std::string& strPath);
 
+  // Program settings
+  bool SetProgramSettings(const std::string& strFileNameAndPath, const std::string& strSettings);
+  bool GetProgramSettings(const std::string& strFileNameAndPath, std::string& strSettings);
+
+  /*! \brief Update the last played time of program
+   Updates the last played date and play count
+   \param strFilenameAndPath program to update the last played time for
+   */
+  void UpdateLastPlayed(const std::string& strFilenameAndPath);
+
   std::string GetXBEPathByTitleId(const std::string& idTitle);
 
 private:

--- a/xbmc/programs/dialogs/GUIDialogProgramSettings.cpp
+++ b/xbmc/programs/dialogs/GUIDialogProgramSettings.cpp
@@ -1,0 +1,412 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "GUIDialogProgramSettings.h"
+
+#include "dialogs/GUIDialogSelect.h"
+#include "FileItem.h"
+#include "filesystem/Directory.h"
+#include "guilib/GUIWindowManager.h"
+#include "guilib/LocalizeStrings.h"
+#include "programs/ProgramDatabase.h"
+#include "programs/launchers/ProgramLauncher.h"
+#include "profiles/ProfilesManager.h"
+#include "settings/lib/Setting.h"
+#include "settings/windows/GUIControlSettings.h"
+#include "Util.h"
+#include "utils/Trainer.h"
+#include "utils/URIUtils.h"
+#include "utils/XMLUtils.h"
+#include "utils/log.h"
+#include "xbox/xbeheader.h"
+
+
+#define SETTING_EXECUTABLE            "programexecutable"
+#define SETTING_FORCEREGION           "programforceregion"
+#define SETTING_TRAINER_LIST          "trainerlist"
+#define SETTING_TRAINER_HACKS         "trainerchoosehacks"
+
+using namespace std;
+
+CGUIDialogProgramSettings::CGUIDialogProgramSettings(void)
+    : CGUIDialogSettingsManualBase(WINDOW_DIALOG_PROGRAM_SETTINGS, "DialogSettings.xml"),
+      m_trainer(nullptr),
+      m_iTitleId(0)
+{
+  m_trainers.clear();
+  m_trainerOptions.clear();
+  m_selectedTrainerOptions.clear();
+  m_strExecutable.clear();
+}
+
+CGUIDialogProgramSettings::~CGUIDialogProgramSettings(void)
+{
+}
+
+bool CGUIDialogProgramSettings::OnMessage(CGUIMessage& message)
+{
+  switch (message.GetMessage())
+  {
+    case GUI_MSG_WINDOW_DEINIT:
+    {
+      Reset();
+      break;
+    }
+
+    case GUI_MSG_CLICKED:
+    {
+      if (message.GetSenderId() == CONTROL_SETTINGS_CUSTOM_BUTTON)
+      {
+        SaveProgramSettings();
+        return true;
+      }
+      break;
+    }
+
+    default:
+      break;
+  }
+
+  return CGUIDialogSettingsManualBase::OnMessage(message);
+}
+
+void CGUIDialogProgramSettings::LoadSettings(const std::string& strExecutable, SProgramSettings& programSettings)
+{
+  CProgramDatabase database;
+  if (database.Open())
+  {
+    bool isXBE = URIUtils::HasExtension(strExecutable, ".xbe");
+
+    std::string strSettings;
+    if (database.GetProgramSettings(strExecutable, strSettings) && !strSettings.empty())
+    {
+      CXBMCTinyXML xmlSettings;
+      if (xmlSettings.Parse(strSettings) &&
+          xmlSettings.RootElement() &&
+          xmlSettings.RootElement()->ValueStr() == "settings")
+      {
+        TiXmlElement *element = xmlSettings.RootElement();
+        XMLUtils::GetString(element, SETTING_EXECUTABLE, programSettings.strExecutable);
+        if (isXBE)
+          XMLUtils::GetInt(element, SETTING_FORCEREGION, programSettings.iForceRegion);
+      }
+    }
+  }
+  // set default values
+  if (programSettings.strExecutable.empty())
+    programSettings.strExecutable = URIUtils::GetFileName(strExecutable);
+}
+
+int CGUIDialogProgramSettings::GetXBERegion(const std::string& strExecutable, bool forceAllRegions /* = false */)
+{
+  CXBE xbe;
+  int iRegion = xbe.ExtractGameRegion(strExecutable);
+  if (iRegion < 1 || iRegion > 7)
+    iRegion = 0;
+  return CXBE::FilterRegion(iRegion, forceAllRegions);
+}
+
+void CGUIDialogProgramSettings::Reset()
+{
+  ResetTrainer(true);
+  m_iTitleId = 0;
+  m_strExecutable.clear();
+  m_settings.Reset();
+}
+
+void CGUIDialogProgramSettings::ResetTrainer(bool bClearTrainers /* = false */)
+{
+  if (bClearTrainers)
+  {
+    for (unsigned int i = 0; i < m_trainers.size(); ++i)
+      delete m_trainers[i];
+    m_trainers.clear();
+  }
+  m_trainer = nullptr;
+  m_trainerOptions.clear();
+  m_selectedTrainerOptions.clear();
+}
+
+void CGUIDialogProgramSettings::LoadProgramSettings()
+{
+  CProgramDatabase database;
+  if (database.Open())
+  {
+    // Load general settings
+    LoadSettings(m_strExecutable, m_settings);
+
+    // Load trainer settings
+    if (URIUtils::HasExtension(m_strExecutable, ".xbe"))
+    {
+      CFileItemList items;
+      database.GetTrainers(items, m_iTitleId);
+      for (int i = 0; i < items.Size(); i++)
+      {
+        CFileItemPtr item = items[i];
+        CTrainer *trainer = new CTrainer(item->GetProperty("idtrainer").asInteger32());
+        if (trainer->Load(item->GetPath()))
+        {
+          database.GetTrainerOptions(trainer->GetTrainerId(), m_iTitleId, trainer->GetOptions(), trainer->GetNumberOfOptions());
+          m_trainers.push_back(trainer);
+          if (item->GetProperty("isactive").asBoolean())
+          {
+            m_trainer = trainer;
+            trainer->GetOptionLabels(m_trainerOptions);
+            for (unsigned int i = 0; i < m_trainerOptions.size(); i++)
+            {
+              if (m_trainer->GetOptions()[i] == 1)
+                m_selectedTrainerOptions.push_back(m_trainerOptions[i]);
+            }
+          }
+        }
+        else
+          delete trainer;
+      }
+    }
+    database.Close();
+  }
+}
+
+void CGUIDialogProgramSettings::SaveSettings(const std::string& strExecutable, const SProgramSettings& settings)
+{
+  CProgramDatabase database;
+  if (database.Open())
+  {
+    bool isXBE = URIUtils::HasExtension(strExecutable, ".xbe");
+
+    // save general settings
+    TiXmlDocument xmlSettings;
+    TiXmlElement xmlRootElement("settings");
+    TiXmlNode *pRoot = xmlSettings.InsertEndChild(xmlRootElement);
+    if (pRoot)
+    {
+      XMLUtils::SetString(pRoot, SETTING_EXECUTABLE, settings.strExecutable);
+      if (isXBE)
+        XMLUtils::SetInt(pRoot, SETTING_FORCEREGION, settings.iForceRegion);
+
+      TiXmlPrinter printer;
+      printer.SetIndent("");
+      xmlSettings.Accept(&printer);
+      database.SetProgramSettings(strExecutable, printer.CStr());
+    }
+  }
+}
+
+void CGUIDialogProgramSettings::SaveProgramSettings()
+{
+  CProgramDatabase database;
+  if (database.Open())
+  {
+    // save general settings
+    SaveSettings(m_strExecutable, m_settings);
+
+    // save trainer settings
+    if (URIUtils::HasExtension(m_strExecutable, ".xbe"))
+      database.SetTrainer(m_iTitleId, m_trainer);
+  }
+}
+
+void CGUIDialogProgramSettings::IntegerOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data)
+{
+  if (setting == NULL || data == NULL)
+    return;
+
+  CGUIDialogProgramSettings *programSettings = static_cast<CGUIDialogProgramSettings*>(data);
+
+  if (setting->GetId() == SETTING_FORCEREGION)
+  {
+    int iRegion = GetXBERegion(programSettings->m_strExecutable, true);
+    list.push_back(make_pair(g_localizeStrings.Get(16316), 0));
+    list.push_back(make_pair(iRegion == VIDEO_NTSCM ? "NTSC-M (default)" : "NTSC-M", VIDEO_NTSCM));
+    list.push_back(make_pair(iRegion == VIDEO_NTSCJ ? "NTSC-J (default)" : "NTSC-J", VIDEO_NTSCJ));
+    list.push_back(make_pair(iRegion == VIDEO_PAL50 ? "PAL (default)" : "PAL", VIDEO_PAL50));
+    list.push_back(make_pair(iRegion == VIDEO_PAL60 ? "PAL60 (default)" : "PAL60", VIDEO_PAL60));
+  }
+  else if (setting->GetId() == SETTING_TRAINER_LIST)
+  {
+    list.push_back(make_pair(g_localizeStrings.Get(231), 0));
+    for (std::vector<CTrainer*>::const_iterator it = programSettings->m_trainers.begin(); it != programSettings->m_trainers.end(); ++it)
+      list.push_back(make_pair((*it)->GetName(), (*it)->GetTrainerId()));
+  }
+}
+
+void CGUIDialogProgramSettings::StringOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data)
+{
+  if (setting == NULL || data == NULL)
+    return;
+
+  CGUIDialogProgramSettings *programSettings = static_cast<CGUIDialogProgramSettings*>(data);
+
+  if (setting->GetId() == SETTING_EXECUTABLE)
+  {
+    CFileItemList items;
+    XFILE::CDirectory::GetDirectory(URIUtils::GetParentPath(programSettings->m_strExecutable), items, URIUtils::GetExtension(programSettings->m_strExecutable), XFILE::DIR_FLAG_DEFAULTS);
+    for (int i = 0; i < items.Size(); ++i)
+    {
+      if (!items[i]->m_bIsFolder)
+      {
+        std::string strLabel = URIUtils::GetFileName(items[i]->GetPath());
+        list.push_back(std::pair<std::string, std::string>(strLabel, strLabel));
+      }
+    }
+  }
+}
+
+void CGUIDialogProgramSettings::OnSettingChanged(const CSetting *setting)
+{
+  if (setting == NULL)
+    return;
+
+  CGUIDialogSettingsManualBase::OnSettingChanged(setting);
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == SETTING_EXECUTABLE)
+  {
+    m_settings.strExecutable = ((CSettingString*)setting)->GetValue();
+  }
+  else if (settingId == SETTING_FORCEREGION)
+  {
+    m_settings.iForceRegion = ((CSettingInt*)setting)->GetValue();
+  }
+  else if (settingId == SETTING_TRAINER_LIST)
+  {
+    ResetTrainer();
+
+    const int idTrainer = ((CSettingInt*)setting)->GetValue();
+    if (idTrainer == 0)
+      return;
+
+    for (std::vector<CTrainer*>::iterator it = m_trainers.begin(); it != m_trainers.end(); ++it)
+    {
+      CTrainer *trainer = *it;
+      if (trainer->GetTrainerId() == idTrainer)
+      {
+        m_trainer = trainer;
+        m_trainer->GetOptionLabels(m_trainerOptions);
+        break;
+      }
+    }
+  }
+}
+
+void CGUIDialogProgramSettings::SetupView()
+{
+  CGUIDialogSettingsManualBase::SetupView();
+  SetHeading(38996);
+
+  SET_CONTROL_HIDDEN(CONTROL_SETTINGS_CANCEL_BUTTON);
+  SET_CONTROL_LABEL(CONTROL_SETTINGS_OKAY_BUTTON, 518);
+  SET_CONTROL_LABEL(CONTROL_SETTINGS_CUSTOM_BUTTON, 190);
+}
+
+void CGUIDialogProgramSettings::OnSettingAction(const CSetting *setting)
+{
+  if (setting == NULL)
+    return;
+
+  CGUIDialogSettingsManualBase::OnSettingChanged(setting);
+
+  const std::string &settingId = setting->GetId();
+  if (settingId == SETTING_TRAINER_HACKS)
+  {
+    CGUIDialogSelect *dialog = static_cast<CGUIDialogSelect *>(g_windowManager.GetWindow(WINDOW_DIALOG_SELECT));
+    if (dialog)
+    {
+      dialog->Reset();
+      dialog->SetMultiSelection(true);
+      dialog->SetHeading(38711);
+      for (std::vector<std::string>::const_iterator it = m_trainerOptions.begin(); it != m_trainerOptions.end(); ++it)
+        dialog->Add((*it));
+      dialog->SetSelected(m_selectedTrainerOptions);
+      dialog->Open();
+
+      if (!dialog->IsConfirmed())
+        return
+
+      // reset to initial state
+      m_selectedTrainerOptions.clear();
+      unsigned char* data = m_trainer->GetOptions();
+      for (int i = 0; i < m_trainer->GetNumberOfOptions(); i++)
+        data[i] = 0;
+
+      // enable selected hacks
+      std::vector<int> selectedItems = dialog->GetSelectedItems();
+      for (unsigned int i = 0; i < selectedItems.size(); i++)
+      {
+        const int index = selectedItems[i];
+        data[index] = 1;
+        m_selectedTrainerOptions.push_back(m_trainerOptions[index]);
+      }
+    }
+  }
+}
+
+void CGUIDialogProgramSettings::Save()
+{
+  if (CProfilesManager::Get().GetMasterProfile().getLockMode() != LOCK_MODE_EVERYONE &&
+      !g_passwordManager.CheckSettingLevelLock(::SettingLevelExpert))
+    return;
+
+  SaveProgramSettings();
+
+  LAUNCHERS::CProgramLauncher::LaunchProgram(m_strExecutable);
+}
+
+void CGUIDialogProgramSettings::InitializeSettings()
+{
+  CGUIDialogSettingsManualBase::InitializeSettings();
+
+  CSettingCategory *category = AddCategory("xbelauncher", -1);
+  if (category == NULL)
+  {
+    CLog::Log(LOGERROR, "CGUIDialogProgramSettings: unable to setup xbelauncher");
+    return;
+  }
+
+  CSettingGroup *group = AddGroup(category);
+  if (group == NULL)
+  {
+    CLog::Log(LOGERROR, "CGUIDialogProgramSettings: unable to setup xbelauncher");
+    return;
+  }
+
+  bool isXBE = URIUtils::HasExtension(m_strExecutable, ".xbe");
+  if (!m_iTitleId)
+    m_iTitleId = isXBE ? CUtil::GetXbeID(m_strExecutable) : 0;
+
+  LoadProgramSettings();
+
+  AddSpinner(group, SETTING_EXECUTABLE, 655, 0, m_settings.strExecutable, StringOptionsFiller, true);
+  if (isXBE)
+  { // Xbox (XBE) executable
+    AddList(group, SETTING_FORCEREGION, 20026, 0, m_settings.iForceRegion, IntegerOptionsFiller, 20026);
+    AddList(group, SETTING_TRAINER_LIST, 38710, 0, m_trainer ? m_trainer->GetTrainerId() : 0, IntegerOptionsFiller, 38710);
+    CSettingAction *btnHacks = AddButton(group, SETTING_TRAINER_HACKS, 38711, 0);
+
+    CSettingDependency dependencyHacks(SettingDependencyTypeEnable, m_settingsManager);
+    dependencyHacks.And()->Add(CSettingDependencyConditionPtr(new CSettingDependencyCondition(SETTING_TRAINER_LIST, "0", SettingDependencyOperatorEquals, true, m_settingsManager)));
+
+    SettingDependencies deps;
+    deps.push_back(dependencyHacks);
+    btnHacks->SetDependencies(deps);
+    deps.clear();
+  }
+}
+
+void CGUIDialogProgramSettings::ShowForTitle(const CFileItemPtr pItem)
+{
+  CGUIDialogProgramSettings *dialog = (CGUIDialogProgramSettings *)g_windowManager.GetWindow(WINDOW_DIALOG_PROGRAM_SETTINGS);
+  if (dialog == nullptr)
+    return;
+
+  // initialize and show the dialog
+  dialog->Initialize();
+  dialog->SetExecutable(pItem->GetPath());
+  dialog->Open();
+}
+

--- a/xbmc/programs/dialogs/GUIDialogProgramSettings.h
+++ b/xbmc/programs/dialogs/GUIDialogProgramSettings.h
@@ -1,0 +1,87 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "settings/dialogs/GUIDialogSettingsManualBase.h"
+
+class CSetting;
+class CTrainer;
+
+typedef struct SProgramSettings
+{
+  SProgramSettings() { Reset(); }
+  std::string strExecutable;  /* which executable to launch */
+  int iForceRegion; /* force game region */
+  void Reset() { strExecutable.clear(); iForceRegion = 0; }
+} SProgramSettings;
+
+class CGUIDialogProgramSettings : public CGUIDialogSettingsManualBase
+{
+public:
+  CGUIDialogProgramSettings();
+  virtual ~CGUIDialogProgramSettings();
+  virtual bool OnMessage(CGUIMessage &message);
+
+  /*! \brief retrieve settings of a given executable
+   \param strExecutable the absolute path to program executable
+   \param programSettings the structure in which settings will be loaded
+   */
+  static void LoadSettings(const std::string& strExecutable, SProgramSettings& programSettings);
+
+  /*! \brief save settings of a given executable
+   \param strExecutable the absolute path to program executable
+   \param settings settings which needs saving
+   */
+  static void SaveSettings(const std::string& strExecutable, const SProgramSettings& settings);
+
+  /*! \brief retrieve region of a given executable
+   \param strExecutable the absolute path to program executable
+   \param forceAllRegions force all regions
+   */
+  static int GetXBERegion(const std::string& strExecutable, bool forceAllRegions = false);
+
+  static void ShowForTitle(const CFileItemPtr pItem);
+
+protected:
+  static void IntegerOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, int> > &list, int &current, void *data);
+  static void StringOptionsFiller(const CSetting *setting, std::vector< std::pair<std::string, std::string> > &list, std::string &current, void *data);
+
+  // implementations of ISettingCallback
+  virtual void OnSettingChanged(const CSetting *setting);
+  virtual void OnSettingAction(const CSetting *setting);
+
+  // specialization of CGUIDialogSettingsManualBase
+  virtual void SetupView();
+
+  // specialization of CGUIDialogSettingsBase
+  virtual bool AllowResettingSettings() const { return false; }
+  virtual void Save();
+
+  // specialization of CGUIDialogSettingsManualBase
+  virtual void InitializeSettings();
+
+  void SetExecutable(const std::string strExecutable) { m_strExecutable = strExecutable; }
+
+private:
+  void Reset();
+  void ResetTrainer(bool bClearTrainers = false);
+
+  void LoadProgramSettings();
+  void SaveProgramSettings();
+
+  std::vector<CTrainer*> m_trainers;
+  std::vector<std::string> m_trainerOptions;
+  std::vector<std::string> m_selectedTrainerOptions;
+
+  CTrainer* m_trainer;
+  unsigned int m_iTitleId;
+  std::string m_strExecutable;
+  SProgramSettings m_settings;
+};
+

--- a/xbmc/programs/launchers/IProgramLauncher.h
+++ b/xbmc/programs/launchers/IProgramLauncher.h
@@ -20,7 +20,7 @@ public:
   \param bAllowRegionSwitching specify if launcher is allowed to force region
   \return Returns true if the program was successfully launched, false otherwise.
   */
-  virtual bool Launch(bool bLoadSettings, bool bAllowRegionSwitching) = 0;
+  virtual bool Launch() = 0;
 
 protected:
   /*!

--- a/xbmc/programs/launchers/IProgramLauncher.h
+++ b/xbmc/programs/launchers/IProgramLauncher.h
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+class IProgramLauncher
+{
+public:
+  virtual ~IProgramLauncher() {}
+
+  /*!
+  \brief Launches the specified program.
+
+  \param bLoadSettings specify if launcher should load custom settings
+  \param bAllowRegionSwitching specify if launcher is allowed to force region
+  \return Returns true if the program was successfully launched, false otherwise.
+  */
+  virtual bool Launch(bool bLoadSettings, bool bAllowRegionSwitching) = 0;
+
+protected:
+  /*!
+  \brief Loads program settings stored in the database.
+
+  Derived classes should implement this method if they support custom settings.
+  */
+  virtual bool LoadSettings() { return false; };
+
+private:
+  /*!
+  \brief Checks if the given executable is supported.
+
+  \return Returns true if the given executable is compatible with the launcher, false otherwise.
+  */
+  virtual bool IsSupported() = 0;
+};

--- a/xbmc/programs/launchers/LauncherFactory.cpp
+++ b/xbmc/programs/launchers/LauncherFactory.cpp
@@ -9,6 +9,7 @@
 #include "LauncherFactory.h"
 
 #include "URL.h"
+#include "XBELauncher.h"
 #include "settings/AdvancedSettings.h"
 #include "utils/URIUtils.h"
 #include "utils/log.h"
@@ -29,6 +30,9 @@ IProgramLauncher* CLauncherFactory::Create(const CURL& url)
     CLog::Log(LOGWARNING, "%s - unsupported protocol: %s", __FUNCTION__, url.GetProtocol().c_str());
     return false;
   }
+
+  if (url.IsFileType("xbe"))
+    return new CXBELauncher(url.Get());
 
   CLog::Log(LOGWARNING, "%s - unsupported executable: %s", __FUNCTION__, url.Get().c_str());
   return NULL;

--- a/xbmc/programs/launchers/LauncherFactory.cpp
+++ b/xbmc/programs/launchers/LauncherFactory.cpp
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "LauncherFactory.h"
+
+#include "URL.h"
+#include "settings/AdvancedSettings.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+using namespace LAUNCHERS;
+
+/*!
+ \brief Create a IProgramLauncher object of the executable specified in \e strPath .
+ \param strPath Specifies the executable to access, can be a share or share with path.
+ \return IProgramLauncher object to allow launching of executable.
+ \sa IProgramLauncher
+ */
+IProgramLauncher* CLauncherFactory::Create(const CURL& url)
+{
+  // We currently only support executables from HDD
+  if (!url.IsProtocol(""))
+  {
+    CLog::Log(LOGWARNING, "%s - unsupported protocol: %s", __FUNCTION__, url.GetProtocol().c_str());
+    return false;
+  }
+
+  CLog::Log(LOGWARNING, "%s - unsupported executable: %s", __FUNCTION__, url.Get().c_str());
+  return NULL;
+}
+

--- a/xbmc/programs/launchers/LauncherFactory.h
+++ b/xbmc/programs/launchers/LauncherFactory.h
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "IProgramLauncher.h"
+
+class CURL;
+
+namespace LAUNCHERS
+{
+/*!
+ \ingroup launchers
+ \brief Get a launcher of given executable.
+ \n
+ Example:
+
+ \verbatim
+ std::string strExecutable="F:\Games\Halo: Combat Evolved\default.xbe";
+
+ IProgramLauncher* pLauncher=CLauncherFactory::Create(strExecutable);
+ \endverbatim
+ The \e pLauncher pointer can be used to launch a program executable.
+ \sa IProgramLauncher
+ */
+class CLauncherFactory
+{
+public:
+  static IProgramLauncher* Create(const CURL& url);
+};
+}

--- a/xbmc/programs/launchers/ProgramLauncher.cpp
+++ b/xbmc/programs/launchers/ProgramLauncher.cpp
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "ProgramLauncher.h"
+
+#include "LauncherFactory.h"
+#include "URL.h"
+#include "utils/URIUtils.h"
+#include "utils/log.h"
+
+using namespace LAUNCHERS;
+
+CProgramLauncher::CProgramLauncher()
+{}
+
+CProgramLauncher::~CProgramLauncher()
+{}
+
+bool CProgramLauncher::LaunchProgram(const std::string& strExecutable, bool bLookForSettings /* = true */, bool bAllowRegionSwitching /* = true */)
+{
+  const CURL url(strExecutable);
+  return LaunchProgram(url);
+}
+
+bool CProgramLauncher::LaunchProgram(const CURL& url, bool bLookForSettings /* = true */, bool bAllowRegionSwitching /* = true */)
+{
+  try
+  {
+    CURL realURL = URIUtils::SubstitutePath(url);
+    boost::shared_ptr<IProgramLauncher> pProgramLauncher(CLauncherFactory::Create(realURL));
+    if (!pProgramLauncher.get())
+      return false;
+
+    if (pProgramLauncher->Launch(bLookForSettings, bAllowRegionSwitching))
+      return true;
+  }
+  catch(...)
+  {
+    CLog::Log(LOGERROR, "%s - Unhandled exception", __FUNCTION__);
+  }
+  CLog::Log(LOGERROR, "%s - Error launching %s", __FUNCTION__, url.GetRedacted().c_str());
+  return false;
+}

--- a/xbmc/programs/launchers/ProgramLauncher.cpp
+++ b/xbmc/programs/launchers/ProgramLauncher.cpp
@@ -21,13 +21,13 @@ CProgramLauncher::CProgramLauncher()
 CProgramLauncher::~CProgramLauncher()
 {}
 
-bool CProgramLauncher::LaunchProgram(const std::string& strExecutable, bool bLookForSettings /* = true */, bool bAllowRegionSwitching /* = true */)
+bool CProgramLauncher::LaunchProgram(const std::string& strExecutable)
 {
   const CURL url(strExecutable);
   return LaunchProgram(url);
 }
 
-bool CProgramLauncher::LaunchProgram(const CURL& url, bool bLookForSettings /* = true */, bool bAllowRegionSwitching /* = true */)
+bool CProgramLauncher::LaunchProgram(const CURL& url)
 {
   try
   {
@@ -36,7 +36,7 @@ bool CProgramLauncher::LaunchProgram(const CURL& url, bool bLookForSettings /* =
     if (!pProgramLauncher.get())
       return false;
 
-    if (pProgramLauncher->Launch(bLookForSettings, bAllowRegionSwitching))
+    if (pProgramLauncher->Launch())
       return true;
   }
   catch(...)

--- a/xbmc/programs/launchers/ProgramLauncher.h
+++ b/xbmc/programs/launchers/ProgramLauncher.h
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "IProgramLauncher.h"
+
+#include <string>
+
+class CURL;
+
+namespace LAUNCHERS
+{
+/*!
+ \ingroup launchers
+ \brief Wrappers for \e IProgramLauncher
+ */
+class CProgramLauncher
+{
+public:
+  CProgramLauncher(void);
+  virtual ~CProgramLauncher(void);
+
+  static bool LaunchProgram(const std::string& strExecutable, bool bLookForSettings = true, bool bAllowRegionSwitching = true);
+  static bool LaunchProgram(const CURL& url, bool bLookForSettings = true, bool bAllowRegionSwitching = true);
+};
+}

--- a/xbmc/programs/launchers/ProgramLauncher.h
+++ b/xbmc/programs/launchers/ProgramLauncher.h
@@ -26,7 +26,7 @@ public:
   CProgramLauncher(void);
   virtual ~CProgramLauncher(void);
 
-  static bool LaunchProgram(const std::string& strExecutable, bool bLookForSettings = true, bool bAllowRegionSwitching = true);
-  static bool LaunchProgram(const CURL& url, bool bLookForSettings = true, bool bAllowRegionSwitching = true);
+  static bool LaunchProgram(const std::string& strExecutable);
+  static bool LaunchProgram(const CURL& url);
 };
 }

--- a/xbmc/programs/launchers/XBELauncher.cpp
+++ b/xbmc/programs/launchers/XBELauncher.cpp
@@ -1,0 +1,166 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#include "XBELauncher.h"
+
+#include "FileItem.h"
+#include "programs/ProgramDatabase.h"
+#include "programs/dialogs/GUIDialogProgramSettings.h"
+#include "settings/DisplaySettings.h"
+#include "settings/Settings.h"
+#include "Util.h"
+#include "utils/FilterFlickerPatch.h"
+#include "utils/log.h"
+#include "utils/Trainer.h"
+#include "utils/URIUtils.h"
+#include "utils/Variant.h"
+#include "xbox/xbeheader.h"
+
+using namespace LAUNCHERS;
+
+CXBELauncher::CXBELauncher(std::string strExecutable)
+{
+  m_strExecutable = strExecutable;
+  m_trainer = nullptr;
+  m_database = new CProgramDatabase();
+  m_settings = new SProgramSettings();
+}
+
+CXBELauncher::~CXBELauncher(void)
+{
+  if (m_trainer)
+    delete m_trainer;
+  delete m_database;
+  delete m_settings;
+}
+
+bool CXBELauncher::LoadSettings()
+{
+  CGUIDialogProgramSettings::LoadSettings(m_strExecutable, *m_settings);
+  return true;
+}
+
+bool CXBELauncher::IsSupported()
+{
+  return URIUtils::HasExtension(m_strExecutable, ".xbe");
+}
+
+bool CXBELauncher::ApplyFFPatch(const std::string& strExecutable, std::string& strPatchedExecutable)
+{
+  RESOLUTION res = CDisplaySettings::Get().GetCurrentResolution();
+  if (res == RES_HDTV_480p_4x3 ||
+      res == RES_HDTV_480p_16x9 ||
+      res == RES_HDTV_720p)
+  {
+    CLog::Log(LOGDEBUG, "%s - Progressive Mode detected: Skipping Filter Flicker Patching!", __FUNCTION__);
+    return false;
+  }
+
+  if (URIUtils::IsOnDVD(strExecutable))
+  {
+    CLog::Log(LOGDEBUG, "%s - Source is DVD-ROM: Skipping Filter Flicker Patching!", __FUNCTION__);
+    return false;
+  }
+
+  CXBE m_xbe;
+  if((int)m_xbe.ExtractGameRegion(strExecutable.c_str()) <= 0) // Reading the GameRegion is enought to detect a Patchable xbe!
+  {
+    CLog::Log(LOGDEBUG, "%s - Not Patchable xbe detected (Homebrew?): Skipping Filter Flicker Patching!", __FUNCTION__);
+    return false;
+  }
+
+  CLog::Log(LOGDEBUG, "%s - Starting Filter Flicker Patching...", __FUNCTION__);
+  CGFFPatch m_ffp;
+  if (!m_ffp.FFPatch(strExecutable, strPatchedExecutable))
+  {
+    CLog::Log(LOGERROR, "%s - Filter Flicker Patching failed!", __FUNCTION__);
+    return false;
+  }
+  CLog::Log(LOGDEBUG, "%s - Filter Flicker Patching done. Saved to %s.", __FUNCTION__, strPatchedExecutable.c_str());
+  return true;
+}
+
+CTrainer* CXBELauncher::LoadTrainer(unsigned int iTitleID)
+{
+  CProgramDatabase database;
+  if (!database.Open())
+    return nullptr;
+
+  CFileItemList items;
+  if (database.GetTrainers(items, iTitleID))
+  {
+    for (int i = 0; i < items.Size(); ++i)
+    {
+      if (items[i]->GetProperty("isactive").asBoolean())
+      {
+        CTrainer* trainer = new CTrainer(items[i]->GetProperty("idtrainer").asInteger32());
+        if (trainer->Load(items[i]->GetPath()) &&
+            database.GetTrainerOptions(trainer->GetTrainerId(), iTitleID, trainer->GetOptions(), trainer->GetNumberOfOptions()))
+          return trainer;
+        else
+        {
+          delete trainer;
+          return nullptr;
+        }
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
+{
+  if (!m_database->Open())
+    return false;
+
+  if (!IsSupported())
+    return false;
+
+  if (bLoadSettings)
+    LoadSettings();
+
+  // install trainer if available
+  m_trainer = LoadTrainer(CUtil::GetXbeID(m_strExecutable));
+  if (m_trainer && !CTrainer::InstallTrainer(*m_trainer))
+  {
+    CLog::Log(LOGERROR, "%s - Trainer could not be installed: %s", __FUNCTION__, m_trainer->GetPath());
+    return false;
+  }
+
+  std::string strExecutable = m_strExecutable;
+
+  // apply flicker filter
+  if (CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
+  {
+    std::string strPatchedExecutable;
+    if (ApplyFFPatch(m_strExecutable, strPatchedExecutable))
+      strExecutable = strPatchedExecutable;
+  }
+
+  int iRegion = 0;
+  // apply video mode switching
+  if (bAllowRegionSwitching)
+  {
+    iRegion = m_settings->iForceRegion;
+    if (!iRegion && CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
+      iRegion = CGUIDialogProgramSettings::GetXBERegion(m_strExecutable);
+  }
+
+  // look for default executable
+  if (!m_settings->strExecutable.empty() && !CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
+  {
+    std::string strParentPath = URIUtils::GetParentPath(m_strExecutable);
+    strExecutable = URIUtils::AddFileToFolder(strParentPath, m_settings->strExecutable);
+  }
+
+  m_database->UpdateLastPlayed(m_strExecutable);
+
+  CUtil::RunXBE(strExecutable.c_str(), NULL, F_VIDEO(iRegion));
+  return true;
+}

--- a/xbmc/programs/launchers/XBELauncher.cpp
+++ b/xbmc/programs/launchers/XBELauncher.cpp
@@ -117,7 +117,7 @@ CTrainer* CXBELauncher::LoadTrainer(unsigned int iTitleID)
   return nullptr;
 }
 
-bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
+bool CXBELauncher::Launch()
 {
   if (!m_database->Open())
     return false;
@@ -125,8 +125,7 @@ bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
   if (!IsSupported())
     return false;
 
-  if (bLoadSettings)
-    LoadSettings();
+  LoadSettings();
 
   // install trainer if available
   m_trainer = LoadTrainer(CUtil::GetXbeID(m_strExecutable));
@@ -146,14 +145,10 @@ bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
       strExecutable = strPatchedExecutable;
   }
 
-  int iRegion = 0;
   // apply video mode switching
-  if (bAllowRegionSwitching)
-  {
-    iRegion = m_settings->iForceRegion;
-    if (!iRegion && CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
-      iRegion = CGUIDialogProgramSettings::GetXBERegion(m_strExecutable);
-  }
+  int iRegion = m_settings->iForceRegion;
+  if (!iRegion && CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
+    iRegion = CGUIDialogProgramSettings::GetXBERegion(m_strExecutable);
 
   // look for default executable
   if (!URIUtils::IsOnDVD(m_strExecutable) && !m_settings->strExecutable.empty() && !CSettings::GetInstance().GetBool("myprograms.autoffpatch"))

--- a/xbmc/programs/launchers/XBELauncher.cpp
+++ b/xbmc/programs/launchers/XBELauncher.cpp
@@ -41,6 +41,9 @@ CXBELauncher::~CXBELauncher(void)
 
 bool CXBELauncher::LoadSettings()
 {
+  if (URIUtils::IsOnDVD(m_strExecutable))
+    return true;
+
   CGUIDialogProgramSettings::LoadSettings(m_strExecutable, *m_settings);
   return true;
 }
@@ -136,7 +139,7 @@ bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
   std::string strExecutable = m_strExecutable;
 
   // apply flicker filter
-  if (CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
+  if (!URIUtils::IsOnDVD(m_strExecutable) && CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
   {
     std::string strPatchedExecutable;
     if (ApplyFFPatch(m_strExecutable, strPatchedExecutable))
@@ -153,13 +156,14 @@ bool CXBELauncher::Launch(bool bLoadSettings, bool bAllowRegionSwitching)
   }
 
   // look for default executable
-  if (!m_settings->strExecutable.empty() && !CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
+  if (!URIUtils::IsOnDVD(m_strExecutable) && !m_settings->strExecutable.empty() && !CSettings::GetInstance().GetBool("myprograms.autoffpatch"))
   {
     std::string strParentPath = URIUtils::GetParentPath(m_strExecutable);
     strExecutable = URIUtils::AddFileToFolder(strParentPath, m_settings->strExecutable);
   }
 
-  m_database->UpdateLastPlayed(m_strExecutable);
+  if (!URIUtils::IsOnDVD(m_strExecutable))
+    m_database->UpdateLastPlayed(m_strExecutable);
 
   CUtil::RunXBE(strExecutable.c_str(), NULL, F_VIDEO(iRegion));
   return true;

--- a/xbmc/programs/launchers/XBELauncher.h
+++ b/xbmc/programs/launchers/XBELauncher.h
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (C) 2023-2025 Team XBMC
+ *  This file is part of XBMC - https://github.com/antonic901/xbmc4xbox-redux
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ *  See LICENSE.md for more information.
+ */
+
+#pragma once
+
+#include "IProgramLauncher.h"
+
+#include <string>
+
+class CTrainer;
+class CProgramDatabase;
+struct SProgramSettings;
+
+namespace LAUNCHERS
+{
+  class CXBELauncher : public IProgramLauncher
+  {
+  public:
+    CXBELauncher(std::string strExecutable);
+    virtual ~CXBELauncher(void);
+
+    static CTrainer* LoadTrainer(unsigned int iTitleID);
+
+    /*! \brief Applies a flicker filter patch to an Xbox Executable (XBE) file.
+     \param strExecutable path to original XBE file that needs patching.
+     \param strPatchedExecutable path to patched XBE
+     */
+    static bool ApplyFFPatch(const std::string& strExecutable, std::string& strPatchedExecutable);
+
+  protected:
+    virtual bool LoadSettings();
+
+  private:
+    virtual bool Launch(bool bLoadSettings, bool bAllowRegionSwitching);
+    virtual bool IsSupported();
+
+    std::string m_strExecutable;
+
+    CTrainer* m_trainer;
+    CProgramDatabase* m_database;
+    SProgramSettings* m_settings;
+  };
+}

--- a/xbmc/programs/launchers/XBELauncher.h
+++ b/xbmc/programs/launchers/XBELauncher.h
@@ -36,7 +36,7 @@ namespace LAUNCHERS
     virtual bool LoadSettings();
 
   private:
-    virtual bool Launch(bool bLoadSettings, bool bAllowRegionSwitching);
+    virtual bool Launch();
     virtual bool IsSupported();
 
     std::string m_strExecutable;

--- a/xbmc/utils/FilterFlickerPatch.h
+++ b/xbmc/utils/FilterFlickerPatch.h
@@ -20,12 +20,13 @@
  *
  */
 
-#include "utils/StdString.h"
+#include <xtl.h>
+#include <string>
 
 class CGFFPatch
 {
   public:
-    bool FFPatch(CStdString m_FFPatchFilePath, CStdString &strNEW_FFPatchFilePath); //
+    bool FFPatch(const std::string& m_FFPatchFilePath, std::string &strNEW_FFPatchFilePath); //
   private:
     BOOL applyPatches(BYTE* pbuffer, int patchCount);
     BOOL Patch1(BYTE* pbuffer, UINT location);

--- a/xbmc/windows/GUIWindowFileManager.cpp
+++ b/xbmc/windows/GUIWindowFileManager.cpp
@@ -64,6 +64,7 @@
 #endif
 #ifdef _XBOX
 #include "xbox/xbeheader.h"
+#include "programs/launchers/ProgramLauncher.h"
 #endif
 
 using namespace XFILE;
@@ -659,20 +660,7 @@ void CGUIWindowFileManager::OnStart(CFileItem *pItem, const std::string &player)
 #endif
 #ifdef _XBOX
   if (pItem->IsXBE())
-  {
-    int iRegion;
-    if (CSettings::GetInstance().GetBool("myprograms.gameautoregion"))
-    {
-      CXBE xbe;
-      iRegion = xbe.ExtractGameRegion(pItem->GetPath());
-      if (iRegion < 1 || iRegion > 7)
-        iRegion = 0;
-      iRegion = xbe.FilterRegion(iRegion);
-    }
-    else
-      iRegion = 0;
-    CUtil::RunXBE(pItem->GetPath().c_str(),NULL,F_VIDEO(iRegion));
-  }
+    LAUNCHERS::CProgramLauncher::LaunchProgram(pItem->GetPath());
   else if (pItem->IsShortCut())
     CUtil::RunShortcut(pItem->GetPath().c_str());
 #endif

--- a/xbmc/windows/GUIWindowInsignia.cpp
+++ b/xbmc/windows/GUIWindowInsignia.cpp
@@ -34,6 +34,7 @@
 #include "utils/StringUtils.h"
 #include "utils/XBMCTinyXML.h"
 #include "programs/ProgramDatabase.h"
+#include "programs/launchers/ProgramLauncher.h"
 
 CGUIWindowInsignia::CGUIWindowInsignia(void)
     : CGUIWindow(WINDOW_INSIGNIA, "Insignia.xml"),
@@ -81,7 +82,7 @@ bool CGUIWindowInsignia::OnAction(const CAction &action)
     if (gamePath.empty())
       CGUIDialogKaiToast::QueueNotification(CGUIDialogKaiToast::Info, "Insignia", g_localizeStrings.Get(38903));
     else
-      CBuiltins::GetInstance().Execute(StringUtils::Format("RunXBE(%s)", gamePath.c_str()));
+      LAUNCHERS::CProgramLauncher::LaunchProgram(gamePath);
 
     return true;
   }


### PR DESCRIPTION
This is backport of `CProgramLauncher` and `CGUIDialogProgramSettings` from Gamers version of XBMC. This allows us to write custom launchers based on file type (XBE, ROM etc.). Currently we have XBE launcher used to launch Xbox executables but in future we could add native emulator ROM launcher. This PR also added option to configure and store custom settings per program. For example you can set trainer, default executable which be be always used when launching a game.