### PR TITLE
[Enhancement] Insignia DNS option in Network Settings menu

### DIFF
--- a/addons/resource.language.en_gb/resources/strings.po
+++ b/addons/resource.language.en_gb/resources/strings.po
@@ -13848,6 +13848,10 @@ msgctxt "#38903"
 msgid "Game is not installed"
 msgstr ""
 
+msgctxt "#38904"
+msgid "Insignia"
+msgstr ""
+
 #empty strings from id 38791 to 38999
 
 msgctxt "#38973"

--- a/system/settings/xbox.xml
+++ b/system/settings/xbox.xml
@@ -330,6 +330,7 @@
             <options>
               <option label="716">1</option> <!-- NETWORK_DHCP -->
               <option label="717">2</option> <!-- NETWORK_STATIC -->
+              <option label="38901">3</option> <!-- NETWORK_INSIGNIA -->
               <option label="38694">0</option> <!-- NETWORK_DASH -->
             </options>
           </constraints>

--- a/system/settings/xbox.xml
+++ b/system/settings/xbox.xml
@@ -330,7 +330,7 @@
             <options>
               <option label="716">1</option> <!-- NETWORK_DHCP -->
               <option label="717">2</option> <!-- NETWORK_STATIC -->
-              <option label="38901">3</option> <!-- NETWORK_INSIGNIA -->
+              <option label="38904">3</option> <!-- NETWORK_INSIGNIA -->
               <option label="38694">0</option> <!-- NETWORK_DASH -->
             </options>
           </constraints>

--- a/xbmc/defs_from_settings.h
+++ b/xbmc/defs_from_settings.h
@@ -71,6 +71,7 @@
 #define NETWORK_DASH   0
 #define NETWORK_DHCP   1
 #define NETWORK_STATIC  2
+#define NETWORK_INSIGNIA  3
 
 #define SETTINGS_TYPE_BOOL   1
 #define SETTINGS_TYPE_FLOAT   2

--- a/xbmc/xbox/Network.cpp
+++ b/xbmc/xbox/Network.cpp
@@ -225,6 +225,20 @@ bool CNetwork::Initialize(int iAssignment, const char* szLocalAddress, const cha
     TranslateConfig(m_networkinfo, params);
     CLog::Log(LOGNOTICE, "Network: Using static IP settings");
   }
+  else if (iAssignment == NETWORK_INSIGNIA)
+  {
+    m_networkinfo.DHCP = false;
+    strcpy(m_networkinfo.ip, szLocalAddress);
+    strcpy(m_networkinfo.subnet, szLocalSubnet);
+    strcpy(m_networkinfo.gateway, szLocalGateway);
+
+    // Insignia DNS
+    strcpy(m_networkinfo.DNS1, "46.101.64.175");
+    strcpy(m_networkinfo.DNS2, "8.8.8.8");
+
+    TranslateConfig(m_networkinfo, params);
+    CLog::Log(LOGNOTICE, "Network: Using Insignia IP settings");
+  }
   else
   {
     dashconfig = true;

--- a/xbmc/xbox/Network.cpp
+++ b/xbmc/xbox/Network.cpp
@@ -234,8 +234,8 @@ bool CNetwork::Initialize(int iAssignment, const char* szLocalAddress, const cha
 
     // Insignia DNS
     strcpy(m_networkinfo.DNS1, "46.101.64.175");
-    strcpy(m_networkinfo.DNS2, "8.8.8.8");
-
+    strcpy(m_networkinfo.DNS2, szNameServerAlt);
+    
     TranslateConfig(m_networkinfo, params);
     CLog::Log(LOGNOTICE, "Network: Using Insignia IP settings");
   }


### PR DESCRIPTION
Just a small patch to include "Insignia" as an option alongside the "Automatic", "Manual", and "Dashboard" options in Network Settings. Automatically grabs IP/subnet/gateway, while forcing DNS1 to 46.101.64.175 (Insignia - Primary). Should help users who regularly switch between dashboards not lose their DNS settings when launching games from X4X.

Could probably use a backup DNS option as well as an option to manually configure IP/subnet/gateway, but this should be good enough for most users. 