### PR TITLE
added: temporary fix for broken ripping of Audio-CDs

### DIFF
--- a/xbmc/filesystem/CDDAFile.cpp
+++ b/xbmc/filesystem/CDDAFile.cpp
@@ -129,7 +129,7 @@ ssize_t CFileCDDA::Read(void* lpBuf, size_t uiBufSize)
   int iSectorCount = std::min((int)uiBufSize / CDIO_CD_FRAMESIZE_RAW, m_iSectorCount);
 
   if (iSectorCount <= 0)
-    return -1;
+    return 0;
 
   // Are there enough sectors left to read
   if (m_lsnCurrent + iSectorCount > m_lsnEnd)


### PR DESCRIPTION
This problem was introduced after backporting [16b1cba](https://github.com/xbmc/xbmc/commit/16b1cba) from Kodi mainline. There are issues on Kodi github and some of attempts to fix this, but none of them were merged:
https://github.com/xbmc/xbmc/issues/6426
https://github.com/xbmc/xbmc/pull/6461

Check this [comment](https://github.com/xbmc/xbmc/pull/6461#issuecomment-103892308) which goes in more details what's wrong. 

Till this day CDDAFile was not updated so I guess this bug is still presented in Kodi. This PR adds temporary fix which works on Xbox. I've done testing in 4 Audio CDs and all of them ripped without any issue using Lame encoder.