### PR TITLE
Fix offline library hang on videodb:// and musicdb:// paths #14860

### DIFF
--- a/xbmc/utils/URIUtils.cpp
+++ b/xbmc/utils/URIUtils.cpp
@@ -590,6 +590,18 @@ bool URIUtils::IsRemote(const CStdString& strFile)
     return false;
   }
 
+  if (IsSourcesPath(strFile))
+    return false;
+
+  if (IsVideoDb(strFile) || IsMusicDb(strFile))
+    return false;
+
+  if (IsLibraryFolder(strFile))
+    return false;
+
+  if (IsPlugin(strFile))
+    return false;
+
   CURL url(strFile);
   if(HasParentInHostname(url))
     return IsRemote(url.GetHostName());


### PR DESCRIPTION
When no network adapter is active, URIUtils::IsRemote() incorrectly treated internal library VFS paths as remote, causing an indefinite Loading directory dialog when opening Movies or TV Shows offline.

Backport IsRemote checks from Kodi PR #14860.